### PR TITLE
Resolve 2278 by removing leftover "incubator" and "incubating" words

### DIFF
--- a/docs/en/2.0.0/guide/plugin-development/bada/index.md
+++ b/docs/en/2.0.0/guide/plugin-development/bada/index.md
@@ -26,7 +26,7 @@ The Bada implementation is a full javascript implementation. Therefore, adding a
 
 1. Clone the CordovaJS repository
 
-        git clone https://git-wip-us.apache.org/repos/asf/incubator-cordova-js.git
+        git clone https://git-wip-us.apache.org/repos/asf/cordova-js.git
 
 2. Create a new javascript file under __lib/bada/plugin/bada/__ and name it _HelloWorld.js_. Add the following content:
 

--- a/docs/en/2.1.0rc1/guide/plugin-development/bada/index.md
+++ b/docs/en/2.1.0rc1/guide/plugin-development/bada/index.md
@@ -26,7 +26,7 @@ The Bada implementation is a full javascript implementation. Therefore, adding a
 
 1. Clone the CordovaJS repository
 
-        git clone https://git-wip-us.apache.org/repos/asf/incubator-cordova-js.git
+        git clone https://git-wip-us.apache.org/repos/asf/cordova-js.git
 
 2. Create a new javascript file under __lib/bada/plugin/bada/__ and name it _HelloWorld.js_. Add the following content:
 

--- a/docs/en/2.1.0rc2/guide/plugin-development/bada/index.md
+++ b/docs/en/2.1.0rc2/guide/plugin-development/bada/index.md
@@ -26,7 +26,7 @@ The Bada implementation is a full javascript implementation. Therefore, adding a
 
 1. Clone the CordovaJS repository
 
-        git clone https://git-wip-us.apache.org/repos/asf/incubator-cordova-js.git
+        git clone https://git-wip-us.apache.org/repos/asf/cordova-js.git
 
 2. Create a new javascript file under __lib/bada/plugin/bada/__ and name it _HelloWorld.js_. Add the following content:
 

--- a/docs/en/2.3.0/guide/getting-started/ios/index.md
+++ b/docs/en/2.3.0/guide/getting-started/ios/index.md
@@ -49,20 +49,20 @@ Apache Cordova is a library used to create native mobile applications using Web 
 
 ### Download Cordova
 
-Download the latest version of [Apache Cordova](http://www.apache.org/dist/cordova/) from http://www.apache.org/dist/incubator/cordova/.  Click on the Download icon and select cordova-X.Y.Z -incubating-src.zip to download to your machine. The X, Y and Z represent the version number of Cordova, for example 2.3.0.  The download includes the code for all of the Apache Cordova supported platforms.   
+Download the latest version of [Apache Cordova](http://www.apache.org/dist/cordova/) from http://www.apache.org/dist/cordova/.  Click on the Download icon and select cordova-X.Y.Z-src.zip to download to your machine. The X, Y and Z represent the version number of Cordova, for example 2.3.0.  The download includes the code for all of the Apache Cordova supported platforms.   
 ### Extract Cordova
 
 To access the code it will need to be extracted from the archive (.zip) file.
 
 
-1. Navigate to the folder where you downloaded the code.  Find the cordova-X.Y.Z-incubating-src.zip file.   
+1. Navigate to the folder where you downloaded the code.  Find the cordova-X.Y.Z-src.zip file.   
     Note: The file names change with each new version of Cordova.  The file name will be different if you are using an updated or newer version of Cordova. 
 
 2. Using the Finder® app, double click the file to extract. This will create a directory named, cordova-X.Y.Z.   
 
-3. Expand this folder and locate the incubator-cordova-ios.zip file and double click to extract it.   
+3. Expand this folder and locate the cordova-ios.zip file and double click to extract it.   
 
-4. The code for iOS is within the incubator-cordova-ios directory structure.
+4. The code for iOS is within the cordova-ios directory structure.
 
 ## Project Creation
 
@@ -81,7 +81,7 @@ Determine where on your system you will locate the Xcode project files for your 
 
 2. Locate the Terminal app and double click to open it.  
 
-3. In Finder, navigate to the incubator-cordova-ios directory from the downloaded and extracted Cordova code and expand it if necessary.   Highlight the bin directory as shown:
+3. In Finder, navigate to the cordova-ios directory from the downloaded and extracted Cordova code and expand it if necessary.   Highlight the bin directory as shown:
 
   ![](img/guide/getting-started/ios/bin_dir_listing.png)
 
@@ -133,7 +133,7 @@ Determine where on your system you will locate the Xcode project files for your 
      The Xcode project is still created in the ~/Documents/CordovaXY/HelloWorld directory, but it references the CordovaLib files from the fixed location of the Cordova distribution rather than a copy of these files within the project directory.  
   - **Additional Scripts**
 
-  Within the incubator-cordova-ios/bin directory there is an additional script that changes the location of the CordovaLib directory to refer to a shared location after the project has been created, 
+  Within the cordova-ios/bin directory there is an additional script that changes the location of the CordovaLib directory to refer to a shared location after the project has been created, 
 
          ./update_cordova_subproject path/to/your/project 
 

--- a/docs/en/2.3.0/guide/plugin-development/bada/index.md
+++ b/docs/en/2.3.0/guide/plugin-development/bada/index.md
@@ -26,7 +26,7 @@ The Bada implementation is a full javascript implementation. Therefore, adding a
 
 1. Clone the CordovaJS repository
 
-        git clone https://git-wip-us.apache.org/repos/asf/incubator-cordova-js.git
+        git clone https://git-wip-us.apache.org/repos/asf/cordova-js.git
 
 2. Create a new javascript file under __lib/bada/plugin/bada/__ and name it _HelloWorld.js_. Add the following content:
 

--- a/docs/en/edge/guide/getting-started/ios/index.md
+++ b/docs/en/edge/guide/getting-started/ios/index.md
@@ -49,20 +49,20 @@ Apache Cordova is a library used to create native mobile applications using Web 
 
 ### Download Cordova
 
-Download the latest version of [Apache Cordova](http://www.apache.org/dist/cordova/) from http://www.apache.org/dist/incubator/cordova/.  Click on the Download icon and select cordova-X.Y.Z -incubating-src.zip to download to your machine. The X, Y and Z represent the version number of Cordova, for example 2.3.0.  The download includes the code for all of the Apache Cordova supported platforms.   
+Download the latest version of [Apache Cordova](http://www.apache.org/dist/cordova/) from http://www.apache.org/dist/cordova/.  Click on the Download icon and select cordova-X.Y.Z-src.zip to download to your machine. The X, Y and Z represent the version number of Cordova, for example 2.3.0.  The download includes the code for all of the Apache Cordova supported platforms.   
 ### Extract Cordova
 
 To access the code it will need to be extracted from the archive (.zip) file.
 
 
-1. Navigate to the folder where you downloaded the code.  Find the cordova-X.Y.Z-incubating-src.zip file.   
+1. Navigate to the folder where you downloaded the code.  Find the cordova-X.Y.Z-src.zip file.   
     Note: The file names change with each new version of Cordova.  The file name will be different if you are using an updated or newer version of Cordova. 
 
 2. Using the Finder® app, double click the file to extract. This will create a directory named, cordova-X.Y.Z.   
 
-3. Expand this folder and locate the incubator-cordova-ios.zip file and double click to extract it.   
+3. Expand this folder and locate the cordova-ios.zip file and double click to extract it.   
 
-4. The code for iOS is within the incubator-cordova-ios directory structure.
+4. The code for iOS is within the cordova-ios directory structure.
 
 ## Project Creation
 
@@ -81,7 +81,7 @@ Determine where on your system you will locate the Xcode project files for your 
 
 2. Locate the Terminal app and double click to open it.  
 
-3. In Finder, navigate to the incubator-cordova-ios directory from the downloaded and extracted Cordova code and expand it if necessary.   Highlight the bin directory as shown:
+3. In Finder, navigate to the cordova-ios directory from the downloaded and extracted Cordova code and expand it if necessary.   Highlight the bin directory as shown:
 
   ![](img/guide/getting-started/ios/bin_dir_listing.png)
 
@@ -133,7 +133,7 @@ Determine where on your system you will locate the Xcode project files for your 
      The Xcode project is still created in the ~/Documents/CordovaXY/HelloWorld directory, but it references the CordovaLib files from the fixed location of the Cordova distribution rather than a copy of these files within the project directory.  
   - **Additional Scripts**
 
-  Within the incubator-cordova-ios/bin directory there is an additional script that changes the location of the CordovaLib directory to refer to a shared location after the project has been created, 
+  Within the cordova-ios/bin directory there is an additional script that changes the location of the CordovaLib directory to refer to a shared location after the project has been created, 
 
          ./update_cordova_subproject path/to/your/project 
 

--- a/docs/en/edge/guide/plugin-development/bada/index.md
+++ b/docs/en/edge/guide/plugin-development/bada/index.md
@@ -26,7 +26,7 @@ The Bada implementation is a full javascript implementation. Therefore, adding a
 
 1. Clone the CordovaJS repository
 
-        git clone https://git-wip-us.apache.org/repos/asf/incubator-cordova-js.git
+        git clone https://git-wip-us.apache.org/repos/asf/cordova-js.git
 
 2. Create a new javascript file under __lib/bada/plugin/bada/__ and name it _HelloWorld.js_. Add the following content:
 

--- a/docs/jp/2.0.0/guide/plugin-development/bada/index.md
+++ b/docs/jp/2.0.0/guide/plugin-development/bada/index.md
@@ -26,7 +26,7 @@ Bada の実装はすべて JavaScript の実装です。そのため、カスタ
 
 1. CordovaJS リポジトリーを clone します
 
-        git clone https://git-wip-us.apache.org/repos/asf/incubator-cordova-js.git
+        git clone https://git-wip-us.apache.org/repos/asf/cordova-js.git
 
 2. __lib/bada/plugin/bada/__ 以下に新しい JavaScript ファイルを作成し、 _HelloWorld.js_ と名前をつけます。以下の内容を追加します:
 

--- a/docs/jp/2.1.0/guide/plugin-development/blackberry/index.md
+++ b/docs/jp/2.1.0/guide/plugin-development/blackberry/index.md
@@ -24,7 +24,7 @@ Developing a Plugin on BlackBerry
 
 このガイドでは、 BlackBerry での Echo プラグインの作り方について説明します。
 もし上位のガイドである JavaScript パートのプラグインについてのガイドを読んでいない場合は、それを最初に読むことをおすすめします。
-加えて、 [Cordova Blackberry repo](https://git-wip-us.apache.org/repos/asf?p=incubator-cordova-blackberry-webworks.git;a=summary) をダウンロードしてください。
+加えて、 [Cordova Blackberry repo](https://git-wip-us.apache.org/repos/asf?p=cordova-blackberry-webworks.git;a=summary) をダウンロードしてください。
 
 Cordova-BlackBerry プロジェクトは Torch, Bold, Playbook といった BlackBerry デバイスへのデプロイを可能にします。
 通常の携帯端末タイプの BlackBerry (例, Torch と Bold) とタブレットタイプの Playbook の間には、デプロイ方法に差があります。

--- a/docs/jp/2.1.0/guide/plugin-development/ios/index.md
+++ b/docs/jp/2.1.0/guide/plugin-development/ios/index.md
@@ -64,8 +64,8 @@ JavaScript の `exec` 関数によってプラグインに割り当てられた�
         [self writeJavascript:javaScript];
     }
 
-1. [CDVInvokedUrlCommand.h](https://github.com/apache/incubator-cordova-ios/blob/master/CordovaLib/Classes/CDVInvokedUrlCommand.h)
-2. [CDVPluginResult.h](https://github.com/apache/incubator-cordova-ios/blob/master/CordovaLib/Classes/CDVPluginResult.h)
+1. [CDVInvokedUrlCommand.h](https://github.com/apache/cordova-ios/blob/master/CordovaLib/Classes/CDVInvokedUrlCommand.h)
+2. [CDVPluginResult.h](https://github.com/apache/cordova-ios/blob/master/CordovaLib/Classes/CDVPluginResult.h)
 
 
 ## プラグインシグネチャ
@@ -145,14 +145,14 @@ JavaScript の `exec` 関数によってプラグインに割り当てられた�
 
 他にも、オーバーライド出来るメソッドについては以下を参照してください:
 
-1. [CDVPlugin.h](https://github.com/apache/incubator-cordova-ios/blob/master/CordovaLib/Classes/CDVPlugin.h)
-2. [CDVPlugin.m](https://github.com/apache/incubator-cordova-ios/blob/master/CordovaLib/Classes/CDVPlugin.m)
+1. [CDVPlugin.h](https://github.com/apache/cordova-ios/blob/master/CordovaLib/Classes/CDVPlugin.h)
+2. [CDVPlugin.m](https://github.com/apache/cordova-ios/blob/master/CordovaLib/Classes/CDVPlugin.m)
 
 例えば、 pausa, resume, app terminate, handleOpenURL events といったような機能を実装できます。
 
 ## プラグインのデバッグ
 
-Objective-C 側でデバッグするには、 Xcode のビルトインのデバッガーを使用します。 JavaScript 側では、 [Apache Cordova Project の Weinre](https://github.com/apache/incubator-cordova-weinre) または [サードパーティ製の iWebInspector](http://www.iwebinspector.com/) を使用できます。
+Objective-C 側でデバッグするには、 Xcode のビルトインのデバッガーを使用します。 JavaScript 側では、 [Apache Cordova Project の Weinre](https://github.com/apache/cordova-weinre) または [サードパーティ製の iWebInspector](http://www.iwebinspector.com/) を使用できます。
 
 iOS 6 では、 Safari 6.0 を使用して簡単に iOS 6 シミュレーター上で動いているアプリをデバッグできます。
 

--- a/docs/jp/2.1.0/guide/plugin-development/windows-phone/index.md
+++ b/docs/jp/2.1.0/guide/plugin-development/windows-phone/index.md
@@ -154,7 +154,7 @@ To pass structured object data back to JS, it should be encoded as a JSON string
 
 オーバーライドできるその他の機能については以下を参照してください:
 
-1. [BaseCommand.cs](https://github.com/apache/incubator-cordova-wp7/blob/master/templates/standalone/cordovalib/Commands/BaseCommand.cs)
+1. [BaseCommand.cs](https://github.com/apache/cordova-wp7/blob/master/templates/standalone/cordovalib/Commands/BaseCommand.cs)
 
 例えば、 'pause' や 'resume' といったアプリケーションイベントもオーバーライドできます。
 

--- a/docs/kr/2.0.0/guide/plugin-development/bada/index.md
+++ b/docs/kr/2.0.0/guide/plugin-development/bada/index.md
@@ -26,7 +26,7 @@ The Bada implementation is a full javascript implementation. Therefore, adding a
 
 1. Clone the CordovaJS repository
 
-        git clone https://git-wip-us.apache.org/repos/asf/incubator-cordova-js.git
+        git clone https://git-wip-us.apache.org/repos/asf/cordova-js.git
 
 2. Create a new javascript file under __lib/bada/plugin/bada/__ and name it _HelloWorld.js_. Add the following content:
 


### PR DESCRIPTION
Hello, we found that there are a few more places in the Docs where the "incubator" words were not removed. I changed this for all of the versions and languages, not just en and edge, is this correct? Thanks. Also was able to build the HTML and verified there are no markup problems or anything like that. 
