### PR TITLE
CB-2525: Correct docs for iOS splashscreen sizes

### DIFF
--- a/docs/en/2.2.0/cordova/splashscreen/splashscreen.md
+++ b/docs/en/2.2.0/cordova/splashscreen/splashscreen.md
@@ -74,11 +74,11 @@ Setup
 
    - Default-568h@2x~iphone.png (640x1136 pixels)
    - Default-Landscape@2x~ipad.png (2048x1496 pixels)
-   - Default-Landscape~ipad.png (1024x768 pixels)
+   - Default-Landscape~ipad.png (1024x748 pixels)
    - Default-Portrait@2x~ipad.png (1536x2008 pixels)
-   - Default-Portrait~ipad.png (768x1024 pixels)
+   - Default-Portrait~ipad.png (768x1004 pixels)
    - Default@2x~iphone.png (640x960 pixels)
-   - Default~iphone.png (320x240 pixels)
+   - Default~iphone.png (320x480 pixels)
         
         
 

--- a/docs/en/2.2.0rc2/cordova/splashscreen/splashscreen.md
+++ b/docs/en/2.2.0rc2/cordova/splashscreen/splashscreen.md
@@ -74,11 +74,11 @@ Setup
 
    - Default-568h@2x~iphone.png (640x1136 pixels)
    - Default-Landscape@2x~ipad.png (2048x1496 pixels)
-   - Default-Landscape~ipad.png (1024x768 pixels)
+   - Default-Landscape~ipad.png (1024x748 pixels)
    - Default-Portrait@2x~ipad.png (1536x2008 pixels)
-   - Default-Portrait~ipad.png (768x1024 pixels)
+   - Default-Portrait~ipad.png (768x1004 pixels)
    - Default@2x~iphone.png (640x960 pixels)
-   - Default~iphone.png (320x240 pixels)
+   - Default~iphone.png (320x480 pixels)
         
         
 

--- a/docs/en/2.3.0/cordova/splashscreen/splashscreen.md
+++ b/docs/en/2.3.0/cordova/splashscreen/splashscreen.md
@@ -72,11 +72,11 @@ Setup
 
    - Default-568h@2x~iphone.png (640x1136 pixels)
    - Default-Landscape@2x~ipad.png (2048x1496 pixels)
-   - Default-Landscape~ipad.png (1024x768 pixels)
+   - Default-Landscape~ipad.png (1024x748 pixels)
    - Default-Portrait@2x~ipad.png (1536x2008 pixels)
-   - Default-Portrait~ipad.png (768x1024 pixels)
+   - Default-Portrait~ipad.png (768x1004 pixels)
    - Default@2x~iphone.png (640x960 pixels)
-   - Default~iphone.png (320x240 pixels)
+   - Default~iphone.png (320x480 pixels)
         
         
 

--- a/docs/en/2.3.0rc1/cordova/splashscreen/splashscreen.md
+++ b/docs/en/2.3.0rc1/cordova/splashscreen/splashscreen.md
@@ -74,11 +74,11 @@ Setup
 
    - Default-568h@2x~iphone.png (640x1136 pixels)
    - Default-Landscape@2x~ipad.png (2048x1496 pixels)
-   - Default-Landscape~ipad.png (1024x768 pixels)
+   - Default-Landscape~ipad.png (1024x748 pixels)
    - Default-Portrait@2x~ipad.png (1536x2008 pixels)
-   - Default-Portrait~ipad.png (768x1024 pixels)
+   - Default-Portrait~ipad.png (768x1004 pixels)
    - Default@2x~iphone.png (640x960 pixels)
-   - Default~iphone.png (320x240 pixels)
+   - Default~iphone.png (320x480 pixels)
         
         
 

--- a/docs/en/2.3.0rc2/cordova/splashscreen/splashscreen.md
+++ b/docs/en/2.3.0rc2/cordova/splashscreen/splashscreen.md
@@ -72,11 +72,11 @@ Setup
 
    - Default-568h@2x~iphone.png (640x1136 pixels)
    - Default-Landscape@2x~ipad.png (2048x1496 pixels)
-   - Default-Landscape~ipad.png (1024x768 pixels)
+   - Default-Landscape~ipad.png (1024x748 pixels)
    - Default-Portrait@2x~ipad.png (1536x2008 pixels)
-   - Default-Portrait~ipad.png (768x1024 pixels)
+   - Default-Portrait~ipad.png (768x1004 pixels)
    - Default@2x~iphone.png (640x960 pixels)
-   - Default~iphone.png (320x240 pixels)
+   - Default~iphone.png (320x480 pixels)
         
         
 

--- a/docs/en/2.4.0/cordova/splashscreen/splashscreen.md
+++ b/docs/en/2.4.0/cordova/splashscreen/splashscreen.md
@@ -72,11 +72,11 @@ Setup
 
    - Default-568h@2x~iphone.png (640x1136 pixels)
    - Default-Landscape@2x~ipad.png (2048x1496 pixels)
-   - Default-Landscape~ipad.png (1024x768 pixels)
+   - Default-Landscape~ipad.png (1024x748 pixels)
    - Default-Portrait@2x~ipad.png (1536x2008 pixels)
-   - Default-Portrait~ipad.png (768x1024 pixels)
+   - Default-Portrait~ipad.png (768x1004 pixels)
    - Default@2x~iphone.png (640x960 pixels)
-   - Default~iphone.png (320x240 pixels)
+   - Default~iphone.png (320x480 pixels)
         
         
 

--- a/docs/en/2.4.0rc1/cordova/splashscreen/splashscreen.md
+++ b/docs/en/2.4.0rc1/cordova/splashscreen/splashscreen.md
@@ -72,11 +72,11 @@ Setup
 
    - Default-568h@2x~iphone.png (640x1136 pixels)
    - Default-Landscape@2x~ipad.png (2048x1496 pixels)
-   - Default-Landscape~ipad.png (1024x768 pixels)
+   - Default-Landscape~ipad.png (1024x748 pixels)
    - Default-Portrait@2x~ipad.png (1536x2008 pixels)
-   - Default-Portrait~ipad.png (768x1024 pixels)
+   - Default-Portrait~ipad.png (768x1004 pixels)
    - Default@2x~iphone.png (640x960 pixels)
-   - Default~iphone.png (320x240 pixels)
+   - Default~iphone.png (320x480 pixels)
         
         
 

--- a/docs/en/2.5.0rc1/cordova/splashscreen/splashscreen.md
+++ b/docs/en/2.5.0rc1/cordova/splashscreen/splashscreen.md
@@ -72,11 +72,11 @@ Setup
 
    - Default-568h@2x~iphone.png (640x1136 pixels)
    - Default-Landscape@2x~ipad.png (2048x1496 pixels)
-   - Default-Landscape~ipad.png (1024x768 pixels)
+   - Default-Landscape~ipad.png (1024x748 pixels)
    - Default-Portrait@2x~ipad.png (1536x2008 pixels)
-   - Default-Portrait~ipad.png (768x1024 pixels)
+   - Default-Portrait~ipad.png (768x1004 pixels)
    - Default@2x~iphone.png (640x960 pixels)
-   - Default~iphone.png (320x240 pixels)
+   - Default~iphone.png (320x480 pixels)
         
         
 

--- a/docs/en/edge/cordova/splashscreen/splashscreen.md
+++ b/docs/en/edge/cordova/splashscreen/splashscreen.md
@@ -72,11 +72,11 @@ Setup
 
    - Default-568h@2x~iphone.png (640x1136 pixels)
    - Default-Landscape@2x~ipad.png (2048x1496 pixels)
-   - Default-Landscape~ipad.png (1024x768 pixels)
+   - Default-Landscape~ipad.png (1024x748 pixels)
    - Default-Portrait@2x~ipad.png (1536x2008 pixels)
-   - Default-Portrait~ipad.png (768x1024 pixels)
+   - Default-Portrait~ipad.png (768x1004 pixels)
    - Default@2x~iphone.png (640x960 pixels)
-   - Default~iphone.png (320x240 pixels)
+   - Default~iphone.png (320x480 pixels)
         
         
 

--- a/docs/jp/2.2.0/cordova/splashscreen/splashscreen.md
+++ b/docs/jp/2.2.0/cordova/splashscreen/splashscreen.md
@@ -74,11 +74,11 @@ Setup
 
    - Default-568h@2x~iphone.png (640x1136 pixels)
    - Default-Landscape@2x~ipad.png (2048x1496 pixels)
-   - Default-Landscape~ipad.png (1024x768 pixels)
+   - Default-Landscape~ipad.png (1024x748 pixels)
    - Default-Portrait@2x~ipad.png (1536x2008 pixels)
-   - Default-Portrait~ipad.png (768x1024 pixels)
+   - Default-Portrait~ipad.png (768x1004 pixels)
    - Default@2x~iphone.png (640x960 pixels)
-   - Default~iphone.png (320x240 pixels)
+   - Default~iphone.png (320x480 pixels)
 
 
 


### PR DESCRIPTION
-correct to sizes from http://developer.apple.com/library/ios/#documentation/userexperience/conceptual/mobilehig/IconsImages/IconsImages.html
