### PR TITLE
Updated docs for FileTransfer.download headers

### DIFF
--- a/docs/en/edge/cordova/file/filetransfer/filetransfer.md
+++ b/docs/en/edge/cordova/file/filetransfer/filetransfer.md
@@ -199,7 +199,7 @@ __Parameters:__
 - __successCallback__ - A callback that is called with a FileEntry object. _(Function)_
 - __errorCallback__ - A callback that is called if an error occurs retrieving the Metadata. Invoked with a FileTransferError object. _(Function)_
 - __trustAllHosts__ - Optional parameter, defaults to false. If set to true then it will accept all security certificates. This is useful as Android rejects self signed security certificates. Not recommended for production use. Supported on Android and iOS. _(boolean)_
-- __options__ - Optional parameters, currently only supports headers (such as Basic Authentication, etc).
+- __options__ - Optional parameters, currently only supports headers (such as Authorization (Basic Authentication), etc).
 
 __Quick Example__
 


### PR DESCRIPTION
As per issue CB-861, I have updated the docs for FileTransfer to list the optional headers
