### PR TITLE
Add some methods to InAppBrowser's ToC

### DIFF
--- a/docs/en/edge/cordova/inappbrowser/inappbrowser.md
+++ b/docs/en/edge/cordova/inappbrowser/inappbrowser.md
@@ -35,6 +35,8 @@ Methods
 - addEventListener
 - removeEventListener
 - close
+- executeScript
+- insertCSS
 
 Permissions
 -----------


### PR DESCRIPTION
It looks like https://github.com/apache/cordova-docs/commit/40eb8dedd117cc91b692944a5f933b086d770a4f had already added in the documentation for executeScript and insertCSS, but forgot to add it to the table of contents. 
