### PR TITLE
CB-3356-Clarify the version number used in screen cap

### DIFF
--- a/docs/en/edge/guide/getting-started/windows-phone-8/index.md
+++ b/docs/en/edge/guide/getting-started/windows-phone-8/index.md
@@ -100,6 +100,8 @@ The 'Stand-Alone' template includes ALL the source code for Apache Cordova.  Thi
 
 ![](img/guide/getting-started/windows-phone-8/projectStructure.PNG)
 
+- Note: This screen capture was from the cordova-2.3.0 download, your listing will vary based on the actual Cordova version installed.
+
 
 5. Build and Deploy to Emulator
 -------------------------------


### PR DESCRIPTION
Hello, I received a report that users were getting confused about the cordova version number used in the screen captures in the WP8 Getting Started guide. I added a small disclaimer note like the ones used in the iOS Getting Started guide. 

For CB-3356. I feel like something this small doesn't need a JIRA item but based on the recent discussion on the ML I went ahead and created it anyway. 
