### PR TITLE
fill out getting started splash screen

### DIFF
--- a/docs/en/edge/guide/getting-started/index.md
+++ b/docs/en/edge/guide/getting-started/index.md
@@ -20,14 +20,35 @@ license: Licensed to the Apache Software Foundation (ASF) under one
 Getting Started Guides
 ======================
 
-- Getting Started with Android
-- Getting Started with BlackBerry
-- Getting Started with BlackBerry 10
-- Getting Started with iOS
-- Getting Started with Symbian
-- Getting Started with WebOS
-- Getting Started with Windows Phone 7
-- Getting Started with Windows Phone 8
-- Getting Started with Windows 8
-- Getting Started with Bada
-- Getting Started with Tizen
+To develop Cordova applications, you must install SDKs for each mobile
+platform you are targeting. This installation is necessary even if you
+intend to rely on cordova's command-line interface (CLI) for your build
+cycle rather than individual SDK applications.
+<!-- XREF
+(See The Cordova Command-line Interface for details.)
+XREF -->
+
+This section tells you all you need to know to set up your development
+environment to support each platform: where to obtain the SDK, how to
+set up device emulators, and how to connect devices for direct
+testing.  There is also information on lower-level command-line
+utilities that are appropriate for development that is focused on
+specific platforms' SDKs rather than the cordova CLI.
+
+Common Requirements
+-------------------
+
+To install any of the platforms listed below, download and extract the
+latest version of [Apache Cordova](http://www.apache.org/dist/cordova/).
+
+- Getting Started with Android (Windows, Mac, Linux)
+- Getting Started with BlackBerry (Windows, Mac)
+- Getting Started with BlackBerry 10 (Windows, Mac)
+- Getting Started with iOS (Mac)
+- Getting Started with Symbian (Windows, Mac, Linux)
+- Getting Started with WebOS (Windows, Mac, Linux)
+- Getting Started with Windows Phone 7 (Windows 7 or 8)
+- Getting Started with Windows Phone 8 (Windows 8)
+- Getting Started with Windows 8 (Windows 8)
+- Getting Started with Bada (Windows)
+- Getting Started with Tizen (Windows, Linux)


### PR DESCRIPTION
move info about cordova installation onto top-level "Getting Started"; will remove redundant info from each platform as separate commit
