### PR TITLE
[CB-3961] remove linebreak that suppresses CLI from home page

### DIFF
--- a/docs/en/edge/guide/cli/index.md
+++ b/docs/en/edge/guide/cli/index.md
@@ -18,7 +18,7 @@ license: Licensed to the Apache Software Foundation (ASF) under one
 
 ---
 
-# The Cordova Command-line Interface
+# The Command-line Interface
 
 This guide shows you how to create applications and deploy them to
 various native mobile platforms using the `cordova` command-line

--- a/docs/en/edge/guide/overview/index.md
+++ b/docs/en/edge/guide/overview/index.md
@@ -72,7 +72,7 @@ components to communicate with each other.
 
 The easiest way to set up an application is to run the `cordova`
 command-line utility, also known as the _command-line interface_
-(CLI). (To install the CLI, see The Cordova Command-line Interface.)
+(CLI). (To install the CLI, see The Command-line Interface.)
 Depending on the set of platforms you wish to target, you can rely on
 the CLI for progressively greater shares of the development cycle:
 

--- a/docs/en/edge/guide/platforms/android/index.md
+++ b/docs/en/edge/guide/platforms/android/index.md
@@ -39,7 +39,7 @@ NOTE, doc said:
 -->
 
 Developers should use the the `cordova` utility in conjunction with
-the Android SDK.  See The Cordova Command-line Interface for
+the Android SDK.  See The Command-line Interface for
 information how to install it, add projects, then build and deploy a
 project.
 
@@ -91,7 +91,7 @@ run:
 ## Open a Project in the SDK
 
 Use the `cordova` utility to set up a new project, as described in The
-Cordova Command-line Interface. For example, in a source-code directory:
+Cordova The Command-line Interface. For example, in a source-code directory:
 
         $ cordova create hello com.example.hello "Hello World"
         $ cd hello

--- a/docs/en/edge/guide/platforms/index.md
+++ b/docs/en/edge/guide/platforms/index.md
@@ -22,7 +22,7 @@ Platform Guides
 
 Before developing for any of the platforms listed below, install
 cordova's command-line interface (CLI).
-(For details, see The Cordova Command-line Interface.)
+(For details, see The Command-line Interface.)
 
 To develop Cordova applications, you must install SDKs for each mobile
 platform you are targeting. This installation is necessary regardless

--- a/docs/en/edge/guide/platforms/ios/index.md
+++ b/docs/en/edge/guide/platforms/ios/index.md
@@ -59,7 +59,7 @@ __Command Line Tools__ listing.
 ## Open a Project in the SDK
 
 Use the `cordova` utility to set up a new project, as described in The
-Cordova Command-line Interface. For example, in a source-code directory:
+Cordova The Command-line Interface. For example, in a source-code directory:
 
         $ cordova create hello com.example.hello "Hello World"
         $ cd hello

--- a/docs/en/edge/guide/platforms/tizen/index.md
+++ b/docs/en/edge/guide/platforms/tizen/index.md
@@ -26,7 +26,7 @@ the Tizen SDK requires Linux Ubuntu 10.04/10.10/11.04/11.10 (32-bit),
 or Windows XP SP3/7 (32-bit).
 
 Developers should use the the `cordova` utility in conjunction with
-the Tizen SDK.  See The Cordova Command-line Interface for information
+the Tizen SDK.  See The Command-line Interface for information
 how to install it, add projects, then build and deploy a project.
 
 ## Install the SDK

--- a/docs/en/edge/guide/platforms/wp7/index.md
+++ b/docs/en/edge/guide/platforms/wp7/index.md
@@ -64,7 +64,7 @@ The SDK displays the directory's contents:
 At this point you can modify the app within the SDK, but running the
 `build` or `prepare` commands again wipes out local changes. If Visual
 Studio is open, it alerts you about modified files and offers you the
-option to reload them.  See The Cordova Command-line Interface for
+option to reload them.  See The Command-line Interface for
 more information.
 
 ## Deploy to Emulator

--- a/docs/en/edge/index.md
+++ b/docs/en/edge/index.md
@@ -96,7 +96,7 @@ license: Licensed to the Apache Software Foundation (ASF) under one
             <span>Setup each SDK and create your first Cordova app.</span>
         </li>
         <li>
-            <h2>The Cordova Command-line Interface</h2>
+            <h2>The Command-line Interface</h2>
             <span>Create, build, and deploy from the command-line.</span>
         </li>
         <li>
@@ -120,7 +120,7 @@ license: Licensed to the Apache Software Foundation (ASF) under one
             <span>Grant an application access to external domains.</span>
         </li>
         <li>
-            <h2>Embedding WebView</h2>
+            <h2>Embedding WebViews</h2>
             <span>Implement the Cordova WebView in your project.</span>
         </li>
         <li>


### PR DESCRIPTION
fixes missing home-page topic; will narrow column w/CSS as alternative to make linebreaks look good
