### PR TITLE
[CB-4080] fix CSS: remove colons after headings; they're implicit

### DIFF
--- a/template/docs/default/index.css
+++ b/template/docs/default/index.css
@@ -221,11 +221,6 @@ p,blockquote,pre,ul {
   margin:1em 0px;
 }
 
-h2:after,
-h3:after {
-	content: ":";
-}
-
 blockquote {
   color:#767573;
 	font-style:normal;


### PR DESCRIPTION
Colons after headings are unnecessary and distracting 
