### PR TITLE
[CB-3827] Removed "Upgrading Guides" from homepage

### DIFF
--- a/docs/en/3.0.0/index.md
+++ b/docs/en/3.0.0/index.md
@@ -34,10 +34,6 @@ license: Licensed to the Apache Software Foundation (ASF) under one
             <span>Set up each SDK to create your first app.</span>
         </li>
         <li>
-            <h2>Upgrading Guides</h2>
-            <span>Upgrade an application to the latest release.</span>
-        </li>
-        <li>
             <h2>Configuration Reference</h2>
             <span>Customize the features of your app.</span>
         </li>


### PR DESCRIPTION
- Dead link
- The "Upgrading Guides" tree was removed in:
  - 15f11a8e1f37f4823a5218989ca08b3bb9f2c026 on 3.0.x
  - 9982d9a019b1c3d1c4f8480b3b054617860d7ee7 on master
