### PR TITLE
[CB-4386] changed ios platform guide to add ios (used to be add android)

### DIFF
--- a/docs/en/edge/guide/platforms/ios/index.md
+++ b/docs/en/edge/guide/platforms/ios/index.md
@@ -76,7 +76,7 @@ Cordova The Command-line Interface. For example, in a source-code directory:
 
         $ cordova create hello com.example.hello "HelloWorld"
         $ cd hello
-        $ cordova platform add android
+        $ cordova platform add ios
         $ cordova prepare              # or "cordova build"
 
 Once created, you can open it from within Xcode. Double-click to open


### PR DESCRIPTION
[CB-4386] changed ios platform guide to add ios (used to be add android)

At [0], ("Open a Project in the SDK" section):

$ cordova platform add android

Should be:

$ cordova platform add ios

[0] http://docs.phonegap.com/en/3.0.0/guide_platforms_ios_index.md.html#iOS%20Platform%20Guide_open_a_project_in_the_sdk
