### PR TITLE
mark headings inline to make it easier to grep & such

### DIFF
--- a/docs/en/edge/cordova/accelerometer/acceleration/acceleration.md
+++ b/docs/en/edge/cordova/accelerometer/acceleration/acceleration.md
@@ -17,29 +17,25 @@
          under the License.
 ---
 
-Acceleration
-============
+# Acceleration
 
 Contains `Accelerometer` data captured at a specific point in time.
 
-Properties
-----------
+## Properties
 
 - __x__:  Amount of acceleration on the x-axis. (in m/s^2) _(Number)_
 - __y__:  Amount of acceleration on the y-axis. (in m/s^2) _(Number)_
 - __z__:  Amount of acceleration on the z-axis. (in m/s^2) _(Number)_
 - __timestamp__: Creation timestamp in milliseconds. _(DOMTimeStamp)_
 
-Description
------------
+## Description
 
 An `Acceleration` object is populated and returned by any of the API's
 `Accelerometer` methods. Acceleration values include the effect of
 gravity (9.81 m/s^2), so that when a device lies flat and facing up,
 _x_, _y_, and _z_ values returned should be `0`, `0`, and `9.81`.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
@@ -48,8 +44,7 @@ Supported Platforms
 - Windows Phone 7 and 8
 - Windows 8
 
-Quick Example
--------------
+## Quick Example
 
     function onSuccess(acceleration) {
         alert('Acceleration X: ' + acceleration.x + '\n' +
@@ -64,8 +59,7 @@ Quick Example
 
     navigator.accelerometer.getCurrentAcceleration(onSuccess, onError);
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>

--- a/docs/en/edge/cordova/accelerometer/accelerometer.clearWatch.md
+++ b/docs/en/edge/cordova/accelerometer/accelerometer.clearWatch.md
@@ -17,8 +17,7 @@
          under the License.
 ---
 
-accelerometer.clearWatch
-========================
+# accelerometer.clearWatch
 
 Stop watching the `Acceleration` referenced by the `watchID` parameter.
 
@@ -26,8 +25,7 @@ Stop watching the `Acceleration` referenced by the `watchID` parameter.
 
 - __watchID__: The ID returned by `accelerometer.watchAcceleration`.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
@@ -36,8 +34,7 @@ Supported Platforms
 - Windows Phone 7 and 8
 - Windows 8
 
-Quick Example
--------------
+## Quick Example
 
     var watchID = navigator.accelerometer.watchAcceleration(onSuccess, onError, options);
 
@@ -45,8 +42,7 @@ Quick Example
 
     navigator.accelerometer.clearWatch(watchID);
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>

--- a/docs/en/edge/cordova/accelerometer/accelerometer.getCurrentAcceleration.md
+++ b/docs/en/edge/cordova/accelerometer/accelerometer.getCurrentAcceleration.md
@@ -17,15 +17,13 @@
          under the License.
 ---
 
-accelerometer.getCurrentAcceleration
-====================================
+# accelerometer.getCurrentAcceleration
 
 Get the current acceleration along the _x_, _y_, and _z_ axes.
 
     navigator.accelerometer.getCurrentAcceleration(accelerometerSuccess, accelerometerError);
 
-Description
------------
+## Description
 
 The accelerometer is a motion sensor that detects the change (_delta_)
 in movement relative to the current device orientation, in three
@@ -34,8 +32,7 @@ dimensions along the _x_, _y_, and _z_ axis.
 These acceleration values are returned to the `accelerometerSuccess`
 callback function.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
@@ -44,8 +41,7 @@ Supported Platforms
 - Windows Phone 7 and 8
 - Windows 8
 
-Quick Example
--------------
+## Quick Example
 
     function onSuccess(acceleration) {
         alert('Acceleration X: ' + acceleration.x + '\n' +
@@ -60,8 +56,7 @@ Quick Example
 
     navigator.accelerometer.getCurrentAcceleration(onSuccess, onError);
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>
@@ -104,8 +99,7 @@ Full Example
       </body>
     </html>
 
-iOS Quirks
--------------
+## iOS Quirks
 
 - iOS doesn't recognize the concept of getting the current acceleration at any given point.
 

--- a/docs/en/edge/cordova/accelerometer/accelerometer.md
+++ b/docs/en/edge/cordova/accelerometer/accelerometer.md
@@ -17,27 +17,23 @@
          under the License.
 ---
 
-Accelerometer
-=============
+# Accelerometer
 
 > Captures device motion in the _x_, _y_, and _z_ direction.
 
-Methods
--------
+## Methods
 
 - accelerometer.getCurrentAcceleration
 - accelerometer.watchAcceleration
 - accelerometer.clearWatch
 
-Arguments
----------
+## Arguments
 
 - accelerometerSuccess
 - accelerometerError
 - accelerometerOptions
 
-Objects (Read-Only)
--------------------
+## Objects (Read-Only)
 
 - Acceleration
 

--- a/docs/en/edge/cordova/accelerometer/accelerometer.watchAcceleration.md
+++ b/docs/en/edge/cordova/accelerometer/accelerometer.watchAcceleration.md
@@ -17,8 +17,7 @@
          under the License.
 ---
 
-accelerometer.watchAcceleration
-===============================
+# accelerometer.watchAcceleration
 
 At a regular interval, get the acceleration along the _x_, _y_, and _z_ axis.
 
@@ -26,8 +25,7 @@ At a regular interval, get the acceleration along the _x_, _y_, and _z_ axis.
                                                            accelerometerError,
                                                            [accelerometerOptions]);
 
-Description
------------
+## Description
 
 The accelerometer is a motion sensor that detects the change (delta)
 in movement relative to the current position. The accelerometer can
@@ -43,8 +41,7 @@ The returned watch ID references the accelerometer's watch interval,
 and can be used with `accelerometer.clearWatch` to stop watching the
 accelerometer.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
@@ -53,8 +50,7 @@ Supported Platforms
 - Windows Phone 7 and 8
 - Windows 8
 
-Quick Example
--------------
+## Quick Example
 
     function onSuccess(acceleration) {
         alert('Acceleration X: ' + acceleration.x + '\n' +
@@ -71,8 +67,7 @@ Quick Example
 
     var watchID = navigator.accelerometer.watchAcceleration(onSuccess, onError, options);
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>
@@ -137,8 +132,7 @@ Full Example
       </body>
     </html>
 
-iOS Quirks
--------------
+## iOS Quirks
 
 The API calls the success callback function at the interval requested,
 but restricts the range of requests to the device between 40ms and

--- a/docs/en/edge/cordova/accelerometer/parameters/accelerometerError.md
+++ b/docs/en/edge/cordova/accelerometer/parameters/accelerometerError.md
@@ -17,8 +17,7 @@
          under the License.
 ---
 
-accelerometerError
-==================
+# accelerometerError
 
 onError callback function for acceleration functions.
 

--- a/docs/en/edge/cordova/accelerometer/parameters/accelerometerOptions.md
+++ b/docs/en/edge/cordova/accelerometer/parameters/accelerometerOptions.md
@@ -17,12 +17,10 @@
          under the License.
 ---
 
-accelerometerOptions
-====================
+# accelerometerOptions
 
 An optional parameter to customize the retrieval of accelerometer values.
 
-Options
--------
+## Options
 
 - __frequency__: How often to retrieve the `Acceleration` in milliseconds. _(Number)_ (Default: 10000)

--- a/docs/en/edge/cordova/accelerometer/parameters/accelerometerSuccess.md
+++ b/docs/en/edge/cordova/accelerometer/parameters/accelerometerSuccess.md
@@ -17,8 +17,7 @@
          under the License.
 ---
 
-accelerometerSuccess
-====================
+# accelerometerSuccess
 
 onSuccess callback function that provides the `Acceleration` information.
 
@@ -26,13 +25,11 @@ onSuccess callback function that provides the `Acceleration` information.
         // Do something
     }
 
-Parameters
-----------
+## Parameters
 
 - __acceleration__: The acceleration at a single moment in time. (Acceleration)
 
-Example
--------
+## Example
 
     function onSuccess(acceleration) {
         alert('Acceleration X: ' + acceleration.x + '\n' +

--- a/docs/en/edge/cordova/camera/camera.cleanup.md
+++ b/docs/en/edge/cordova/camera/camera.cleanup.md
@@ -17,29 +17,25 @@
          under the License.
 ---
 
-camera.cleanup
-=================
+# camera.cleanup
 
 Removes intermediate photos taken by the camera from temporary
 storage.
 
     navigator.camera.cleanup( cameraSuccess, cameraError );
 
-Description
------------
+## Description
 
 Removes intermediate image files that are kept in temporary storage
 after calling `camera.getPicture`. Applies only when the value of
 `Camera.sourceType` equals `Camera.PictureSourceType.CAMERA` and the
 `Camera.destinationType` equals `Camera.DestinationType.FILE_URI`.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - iOS
 
-Example
--------------
+## Example
 
     navigator.camera.cleanup(onSuccess, onFail);
 

--- a/docs/en/edge/cordova/camera/camera.getPicture.md
+++ b/docs/en/edge/cordova/camera/camera.getPicture.md
@@ -17,8 +17,7 @@
          under the License.
 ---
 
-camera.getPicture
-=================
+# camera.getPicture
 
 Takes a photo using the camera, or retrieves a photo from the device's
 image gallery.  The image is passed to the success callback as a
@@ -28,8 +27,7 @@ reposition the file selection popover.
 
     navigator.camera.getPicture( cameraSuccess, cameraError, [ cameraOptions ] );
 
-Description
------------
+## Description
 
 The `camera.getPicture` function opens the device's default camera
 application that allows users to snap pictures. This behavior occurs
@@ -67,8 +65,7 @@ quality, even if a `quality` parameter is specified.  To avoid common
 memory problems, set `Camera.destinationType` to `FILE_URI` rather
 than `DATA_URL`.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
@@ -77,14 +74,13 @@ Supported Platforms
 - Windows Phone 7 and 8
 - Windows 8
 
-Android Quirks
------------------
+## Android Quirks
+
 Android uses intents to launch the camera activity on the device to capture
 images, and on phones with low memory, the Cordova activity may be killed.  In this
 scenario, the image may not appear when the cordova activity is restored.
 
-iOS Quirks
-----------
+## iOS Quirks
 
 Including a JavaScript `alert()` in either of the callback functions
 can cause problems.  Wrap the alert within a `setTimeout()` to allow
@@ -95,21 +91,18 @@ displays:
         // do your thing here!
     }, 0);
 
-Windows Phone 7 Quirks
-----------------------
+## Windows Phone 7 Quirks
 
 Invoking the native camera application while your device is connected
 via Zune does not work, and triggers an error callback.
 
-Tizen Quirks
-----------------------
+## Tizen Quirks
 
 Tizen only supports a `destinationType` of
 `Camera.DestinationType.FILE_URI` and a `sourceType` of
 `Camera.PictureSourceType.PHOTOLIBRARY`.
 
-Quick Example
--------------
+## Quick Example
 
 Take a photo and retrieve it as a base64-encoded image:
 
@@ -140,8 +133,7 @@ Take a photo and retrieve the image's file location:
         alert('Failed because: ' + message);
     }
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>

--- a/docs/en/edge/cordova/camera/camera.md
+++ b/docs/en/edge/cordova/camera/camera.md
@@ -17,15 +17,13 @@
          under the License.
 ---
 
-Camera
-======
+# Camera
 
 > The `camera` object provides access to the device's default camera application.
 
 **Important privacy note:** Collection and use of images from a device's camera raises important privacy issues.  Your app's privacy policy should discuss how the app uses the camera and whether the images recorded are shared with any other parties.  In addition, if the app's use of the camera is not apparent in the user interface, you should provide a just-in-time notice prior to your app accessing the camera (if the device operating system doesn't do so already).  That notice should provide the same information noted above, as well as obtaining the user's permission (e.g., by presenting choices for "OK" and "No Thanks").  For more information, please see the Privacy Guide.
 
-Methods
--------
+## Methods
 
 - camera.getPicture
 - camera.cleanup

--- a/docs/en/edge/cordova/camera/parameter/CameraPopoverHandle.md
+++ b/docs/en/edge/cordova/camera/parameter/CameraPopoverHandle.md
@@ -17,23 +17,19 @@
          under the License.
 ---
 
-CameraPopoverHandle
-===================
+# CameraPopoverHandle
 
 A handle to the popover dialog created by `camera.getPicture`.
 
-Methods
--------
+## Methods
 
 - __setPosition__: Set the position of the popover.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - iOS
 
-setPosition
------------
+## setPosition
 
 Set the position of the popover.
 
@@ -41,14 +37,12 @@ __Parameters:__
 
 - `cameraPopoverOptions`: the `CameraPopoverOptions` that specify the new position
 
-Quick Example
--------------
+## Quick Example
 
      var cameraPopoverOptions = new CameraPopoverOptions(300, 300, 100, 100, Camera.PopoverArrowDirection.ARROW_ANY);
      cameraPopoverHandle.setPosition(cameraPopoverOptions);
 
-Full Example
-------------
+## Full Example
 
      function onSuccess(imageData) {
           // Do stuff with the image!

--- a/docs/en/edge/cordova/camera/parameter/CameraPopoverOptions.md
+++ b/docs/en/edge/cordova/camera/parameter/CameraPopoverOptions.md
@@ -17,8 +17,7 @@
          under the License.
 ---
 
-CameraPopoverOptions
-====================
+# CameraPopoverOptions
 
 iOS-only parameters that specify the anchor element location and arrow
 direction of the popover when selecting images from an iPad's library
@@ -31,8 +30,7 @@ or album.
       arrowDir : Camera.PopoverArrowDirection.ARROW_ANY
     };
 
-CameraPopoverOptions
---------------------
+## CameraPopoverOptions
 
 - __x__: x pixel coordinate of screen element onto which to anchor the popover. _(Number)_
 
@@ -57,8 +55,7 @@ direction of the arrow and orientation of the screen.  Make sure to
 account for orientation changes when specifying the anchor element
 location.
 
-Quick Example
--------------
+## Quick Example
 
      var popover = new CameraPopoverOptions(300, 300, 100, 100, Camera.PopoverArrowDirection.ARROW_ANY);
      var options = {

--- a/docs/en/edge/cordova/camera/parameter/cameraError.md
+++ b/docs/en/edge/cordova/camera/parameter/cameraError.md
@@ -17,8 +17,7 @@
          under the License.
 ---
 
-cameraError
-===========
+# cameraError
 
 onError callback function that provides an error message.
 
@@ -26,7 +25,6 @@ onError callback function that provides an error message.
         // Show a helpful message
     }
 
-Parameters
-----------
+## Parameters
 
 - __message__: The message is provided by the device's native code. _(String)_

--- a/docs/en/edge/cordova/camera/parameter/cameraOptions.md
+++ b/docs/en/edge/cordova/camera/parameter/cameraOptions.md
@@ -17,8 +17,7 @@
          under the License.
 ---
 
-cameraOptions
-=============
+# cameraOptions
 
 Optional parameters to customize the camera settings.
 
@@ -32,8 +31,7 @@ Optional parameters to customize the camera settings.
       popoverOptions: CameraPopoverOptions,
       saveToPhotoAlbum: false };
 
-Options
--------
+## Options
 
 - __quality__: Quality of the saved image, expressed as a range of 0-100, where 100 is typically full resolution with no loss from file compression. _(Number)_ (Note that information about the camera's resolution is unavailable.)
 
@@ -87,15 +85,13 @@ Options
             FRONT : 1      // Use the front-facing camera
         };
 
-Android Quirks
---------------
+## Android Quirks
 
 - Ignores the `allowEdit` parameter.
 
 - `Camera.PictureSourceType.PHOTOLIBRARY` and `Camera.PictureSourceType.SAVEDPHOTOALBUM` both display the same photo album.
 
-BlackBerry Quirks
------------------
+## BlackBerry Quirks
 
 - Ignores the `quality` parameter.
 
@@ -113,22 +109,19 @@ BlackBerry Quirks
 
 - Ignores the `cameraDirection` parameter.
 
-iOS Quirks
---------------
+## iOS Quirks
 
 - Set `quality` below 50 to avoid memory errors on some devices.
 
 - When using `destinationType.FILE_URI`, photos are saved in the application's temporary directory.  You may delete the contents of this directory using the `navigator.fileMgr` APIs if storage space is a concern.
 
-Tizen Quirks
---------------
+## Tizen Quirks
 
 - options not supported
 
 - always returns a FILE URI
 
-Windows Phone 7 and 8 Quirks
---------------
+## Windows Phone 7 and 8 Quirks
 
 - Ignores the `allowEdit` parameter.
 

--- a/docs/en/edge/cordova/camera/parameter/cameraSuccess.md
+++ b/docs/en/edge/cordova/camera/parameter/cameraSuccess.md
@@ -17,8 +17,7 @@
          under the License.
 ---
 
-cameraSuccess
-=============
+# cameraSuccess
 
 onSuccess callback function that provides the image data.
 
@@ -26,13 +25,11 @@ onSuccess callback function that provides the image data.
         // Do something with the image
     }
 
-Parameters
-----------
+## Parameters
 
 - __imageData__: Base64 encoding of the image data, _or_ the image file URI, depending on `cameraOptions` in effect. _(String)_
 
-Example
--------
+## Example
 
     // Show image
     //

--- a/docs/en/edge/cordova/compass/compass.clearWatch.md
+++ b/docs/en/edge/cordova/compass/compass.clearWatch.md
@@ -17,8 +17,7 @@
          under the License.
 ---
 
-compass.clearWatch
-========================
+# compass.clearWatch
 
 Stop watching the compass referenced by the watch ID parameter.
 
@@ -26,8 +25,7 @@ Stop watching the compass referenced by the watch ID parameter.
 
 - __watchID__: The ID returned by `compass.watchHeading`.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry 10
@@ -36,8 +34,7 @@ Supported Platforms
 - Windows Phone 7 and 8 (if available in hardware)
 - Windows 8
 
-Quick Example
--------------
+## Quick Example
 
     var watchID = navigator.compass.watchHeading(onSuccess, onError, options);
 
@@ -45,8 +42,7 @@ Quick Example
 
     navigator.compass.clearWatch(watchID);
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>

--- a/docs/en/edge/cordova/compass/compass.clearWatchFilter.md
+++ b/docs/en/edge/cordova/compass/compass.clearWatchFilter.md
@@ -17,7 +17,6 @@
          under the License.
 ---
 
-compass.clearWatchFilter
-========================
+# compass.clearWatchFilter
 
 No longer supported as of 1.6.  See `compass.clearWatch`.

--- a/docs/en/edge/cordova/compass/compass.getCurrentHeading.md
+++ b/docs/en/edge/cordova/compass/compass.getCurrentHeading.md
@@ -17,15 +17,13 @@
          under the License.
 ---
 
-compass.getCurrentHeading
-=========================
+# compass.getCurrentHeading
 
 Get the current compass heading.
 
     navigator.compass.getCurrentHeading(compassSuccess, compassError, compassOptions);
 
-Description
------------
+## Description
 
 The compass is a sensor that detects the direction or heading that the
 device is pointed, typically from the top of the device.  It measures
@@ -34,8 +32,7 @@ the heading in degrees from 0 to 359.99, where 0 is north.
 The compass heading information is returned via a `CompassHeading`
 object using the `compassSuccess` callback function.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry 10
@@ -44,8 +41,7 @@ Supported Platforms
 - Windows Phone 7 and 8 (if available in hardware)
 - Windows 8
 
-Quick Example
--------------
+## Quick Example
 
     function onSuccess(heading) {
         alert('Heading: ' + heading.magneticHeading);
@@ -57,8 +53,7 @@ Quick Example
 
     navigator.compass.getCurrentHeading(onSuccess, onError);
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>

--- a/docs/en/edge/cordova/compass/compass.md
+++ b/docs/en/edge/cordova/compass/compass.md
@@ -17,13 +17,11 @@
          under the License.
 ---
 
-Compass
-=======
+# Compass
 
 > Obtains the direction that the device is pointing.
 
-Methods
--------
+## Methods
 
 - compass.getCurrentHeading
 - compass.watchHeading
@@ -31,8 +29,7 @@ Methods
 - compass.watchHeadingFilter (obsolete)
 - compass.clearWatchFilter   (obsolete)
 
-Arguments
----------
+## Arguments
 
 - compassSuccess
 - compassError

--- a/docs/en/edge/cordova/compass/compass.watchHeading.md
+++ b/docs/en/edge/cordova/compass/compass.watchHeading.md
@@ -17,15 +17,13 @@
          under the License.
 ---
 
-compass.watchHeading
-====================
+# compass.watchHeading
 
 At a regular interval, get the compass heading in degrees.
 
     var watchID = navigator.compass.watchHeading(compassSuccess, compassError, [compassOptions]);
 
-Description
------------
+## Description
 
 The compass is a sensor that detects the direction or heading that the
 device is pointed.  It measures the heading in degrees from 0 to
@@ -40,8 +38,7 @@ object.
 The returned watch ID references the compass watch interval. The watch
 ID can be used with `compass.clearWatch` to stop watching the compass.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry 10
@@ -50,8 +47,7 @@ Supported Platforms
 - Windows Phone 7 and 8 (if available in hardware)
 - Windows 8
 
-Quick Example
--------------
+## Quick Example
 
     function onSuccess(heading) {
         var element = document.getElementById('heading');
@@ -68,8 +64,7 @@ Quick Example
 
     var watchID = navigator.compass.watchHeading(onSuccess, onError, options);
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>
@@ -133,8 +128,7 @@ Full Example
       </body>
     </html>
 
-iOS Quirks
---------------
+## iOS Quirks
 
 In iOS `compass.watchHeading` can also get the device's current
 heading when it changes by a specified number of degrees. Each time

--- a/docs/en/edge/cordova/compass/compass.watchHeadingFilter.md
+++ b/docs/en/edge/cordova/compass/compass.watchHeadingFilter.md
@@ -17,7 +17,6 @@
          under the License.
 ---
 
-compass.watchHeadingFilter
-==========================
+# compass.watchHeadingFilter
 
 No longer supported as of 1.6, see `compass.watchHeading` for equivalent functionality.

--- a/docs/en/edge/cordova/compass/compassError/compassError.md
+++ b/docs/en/edge/cordova/compass/compassError/compassError.md
@@ -17,23 +17,20 @@
          under the License.
 ---
 
-CompassError
-==========
+# CompassError
 
 A `CompassError` object is returned to the `compassError` callback function when an error occurs.
 
-Properties
-----------
+## Properties
 
 - __code__: One of the predefined error codes listed below.
 
-Constants
----------
+## Constants
+
 - `CompassError.COMPASS_INTERNAL_ERR`
 - `CompassError.COMPASS_NOT_SUPPORTED`
 
-Description
------------
+## Description
 
 When an error occurs, the `CompassError` object is passed as a
 parameter to a `compassError` callback function.

--- a/docs/en/edge/cordova/compass/parameters/compassError.md
+++ b/docs/en/edge/cordova/compass/parameters/compassError.md
@@ -17,13 +17,11 @@
          under the License.
 ---
 
-compassError
-==========
+# compassError
 
 onError callback function for compass functions.
 
-Example
--------
+## Example
 
     function(CompassError) {
         // Handle the error

--- a/docs/en/edge/cordova/compass/parameters/compassHeading.md
+++ b/docs/en/edge/cordova/compass/parameters/compassHeading.md
@@ -17,13 +17,11 @@
          under the License.
 ---
 
-compassHeading
-==========
+# compassHeading
 
 A `CompassHeading` object is returned to the `compassSuccess` callback function.
 
-Properties
-----------
+## Properties
 
 - __magneticHeading__: The heading in degrees from 0-359.99 at a single moment in time. _(Number)_
 
@@ -33,20 +31,17 @@ Properties
 
 - __timestamp__: The time at which this heading was determined.  _(milliseconds)_
 
-Description
------------
+## Description
 
 The `CompassHeading` object is returned to the `compassSuccess` callback function.
 
-Android Quirks
---------------
+## Android Quirks
 
 - `trueHeading` is not supported, but reports the same value as `magneticHeading`
 
 - `headingAccuracy` is always 0 because there is no difference between the `magneticHeading` and `trueHeading`.
 
-iOS Quirks
-----------
+## iOS Quirks
 
 - `trueHeading` is only returned when location services are enabled via `navigator.geolocation.watchLocation()`
 

--- a/docs/en/edge/cordova/compass/parameters/compassOptions.md
+++ b/docs/en/edge/cordova/compass/parameters/compassOptions.md
@@ -17,13 +17,11 @@
          under the License.
 ---
 
-compassOptions
-==============
+# compassOptions
 
 An optional parameter to customize the retrieval of the compass.
 
-Options
--------
+## Options
 
 - __frequency__: How often to retrieve the compass heading in milliseconds. _(Number)_ (Default: 100)
 
@@ -34,12 +32,10 @@ ______________
 
 - `filter` is not supported.
 
-Tizen Quirks
------------
+## Tizen Quirks
 
 - `filter` is not supported.
 
-Windows Phone 7 and 8 Quirks
---------------
+## Windows Phone 7 and 8 Quirks
 
 - `filter` is not supported.

--- a/docs/en/edge/cordova/compass/parameters/compassSuccess.md
+++ b/docs/en/edge/cordova/compass/parameters/compassSuccess.md
@@ -17,8 +17,7 @@
          under the License.
 ---
 
-compassSuccess
-==============
+# compassSuccess
 
 onSuccess callback function that provides the compass heading information via a `compassHeading` object.
 
@@ -26,13 +25,11 @@ onSuccess callback function that provides the compass heading information via a 
         // Do something
     }
 
-Parameters
-----------
+## Parameters
 
 - __heading__: The heading information. _(compassHeading)_
 
-Example
--------
+## Example
 
     function onSuccess(heading) {
         alert('Heading: ' + heading.magneticHeading);

--- a/docs/en/edge/cordova/connection/connection.md
+++ b/docs/en/edge/cordova/connection/connection.md
@@ -17,18 +17,15 @@
          under the License.
 ---
 
-Connection
-==========
+# Connection
 
 > The `connection` object, exposed via `navigator.connection`,  provides information about the device's cellular and wifi connection.
 
-Properties
-----------
+## Properties
 
 - connection.type
 
-Constants
----------
+## Constants
 
 - Connection.UNKNOWN
 - Connection.ETHERNET

--- a/docs/en/edge/cordova/connection/connection.type.md
+++ b/docs/en/edge/cordova/connection/connection.type.md
@@ -17,19 +17,16 @@
          under the License.
 ---
 
-connection.type
-===================
+# connection.type
 
 Checks the currently active network connection.
 
-Description
------------
+## Description
 
 This property offers a fast way to determine the device's network
 connection state, and type of connection.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - iOS
 - Android
@@ -38,8 +35,7 @@ Supported Platforms
 - Windows Phone 7 and 8
 - Windows 8
 
-Quick Example
--------------
+## Quick Example
 
     function checkConnection() {
         var networkState = navigator.connection.type;
@@ -59,8 +55,7 @@ Quick Example
 
     checkConnection();
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>
@@ -103,8 +98,7 @@ Full Example
       </body>
     </html>
 
-API Change
-----------
+## API Change
 
 Until Cordova 2.3.0, the `Connection` object was accessed via
 `navigator.network.connection`, after which it was changed to
@@ -112,22 +106,19 @@ Until Cordova 2.3.0, the `Connection` object was accessed via
 available at its original location, but is deprecated and will
 eventually be removed.
 
-iOS Quirks
-----------
+## iOS Quirks
 
 - iOS cannot detect the type of cellular network connection.
     - `navigator.connection.type` is set to `Connection.CELL` for all cellular data.
 
-Windows Phone Quirks
---------------------
+## Windows Phone Quirks
 
 - When running in the emulator, always detects `navigator.connection.type` as `Connection.UNKNOWN`.
 
 - Windows Phone cannot detect the type of cellular network connection.
     - `navigator.connection.type` is set to `Connection.CELL` for all cellular data.
 
-Tizen Quirks
---------------------
+## Tizen Quirks
 
 - Tizen can only detect a WiFi or cellular connection.
     - `navigator.connection.type` is set to `Connection.CELL_2G` for all cellular data.

--- a/docs/en/edge/cordova/contacts/Contact/contact.md
+++ b/docs/en/edge/cordova/contacts/Contact/contact.md
@@ -17,13 +17,11 @@
          under the License.
 ---
 
-Contact
-=======
+# Contact
 
 Contains properties that describe a contact, such as a user's personal or business contact.
 
-Properties
-----------
+## Properties
 
 - __id__: A globally unique identifier. _(DOMString)_
 
@@ -53,8 +51,7 @@ Properties
 
 - __urls__:  An array of web pages associated with the contact. _(ContactField[])_
 
-Methods
--------
+## Methods
 
 - __clone__: Returns a new `Contact` object that is a deep copy of the calling object, with the `id` property set to `null`.
 
@@ -62,8 +59,7 @@ Methods
 
 - __save__: Saves a new contact to the device contacts database, or updates an existing contact if a contact with the same __id__ already exists.
 
-Details
--------
+## Details
 
 The `Contact` object represents a user's contact.  Contacts can be
 created, stored, or removed from the device contacts database.
@@ -74,8 +70,7 @@ __NOTE:__ Not all of the contact fields listed above are supported on
 every device platform.  Please check each platform's _Quirks_ section
 for details.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
@@ -83,8 +78,7 @@ Supported Platforms
 - Windows Phone 7 and 8
 - Windows 8
 
-Save Quick Example
-------------------
+## Save Quick Example
 
     function onSuccess(contact) {
         alert("Save Success");
@@ -108,8 +102,7 @@ Save Quick Example
     // save to device
     contact.save(onSuccess,onError);
 
-Clone Quick Example
--------------------
+## Clone Quick Example
 
         // clone the contact object
         var clone = contact.clone();
@@ -117,8 +110,7 @@ Clone Quick Example
         console.log("Original contact name = " + contact.name.givenName);
         console.log("Cloned contact name = " + clone.name.givenName);
 
-Remove Quick Example
---------------------
+## Remove Quick Example
 
     function onSuccess() {
         alert("Removal Success");
@@ -131,8 +123,7 @@ Remove Quick Example
         // remove the contact from the device
         contact.remove(onSuccess,onError);
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>
@@ -203,13 +194,11 @@ Full Example
       </body>
     </html>
 
-Android 2.X Quirks
-------------------
+## Android 2.X Quirks
 
 - __categories__:  Not supported on Android 2.X devices, returning `null`.
 
-BlackBerry WebWorks (OS 5.0 and higher) Quirks
----------------------------------------------
+## BlackBerry WebWorks (OS 5.0 and higher) Quirks
 
 - __id__: Supported.  Assigned by the device when saving the contact.
 
@@ -233,8 +222,7 @@ BlackBerry WebWorks (OS 5.0 and higher) Quirks
 
 - __urls__:  Partially supported. The first URL is stored in BlackBerry __webpage__ field.
 
-iOS Quirks
-----------
+## iOS Quirks
 
 - __displayName__: Not supported on iOS, returning `null` unless there is no `ContactName` specified, in which case it returns the composite name, __nickname__ or `""`, respectively.
 
@@ -244,8 +232,7 @@ iOS Quirks
 
 - __categories__:  This property is currently not supported, returning `null`.
 
-Windows Phone 7 and 8 Quirks
------------
+## Windows Phone 7 and 8 Quirks
 
 - __displayName__: When creating a contact, the value provided for the display name parameter differs from the display name retrieved when finding the contact.
 

--- a/docs/en/edge/cordova/contacts/ContactAddress/contactaddress.md
+++ b/docs/en/edge/cordova/contacts/ContactAddress/contactaddress.md
@@ -17,13 +17,11 @@
          under the License.
 ---
 
-ContactAddress
-==============
+# ContactAddress
 
 Contains address properties for a `Contact` object.
 
-Properties
-----------
+## Properties
 
 - __pref__: Set to `true` if this `ContactAddress` contains the user's preferred value. _(boolean)_
 
@@ -41,15 +39,13 @@ Properties
 
 - __country__: The country name. _(DOMString)_
 
-Details
--------
+## Details
 
 The `ContactAddress` object stores the properties of a single address
 of a contact.  A `Contact` object may include more than one address in
 a `ContactAddress[]` array.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
@@ -57,8 +53,7 @@ Supported Platforms
 - Windows Phone 7 and 8
 - Windows 8
 
-Quick Example
--------------
+## Quick Example
 
     // display the address information for all contacts
 
@@ -87,8 +82,7 @@ Quick Example
     var filter = ["displayName", "addresses"];
     navigator.contacts.find(filter, onSuccess, onError, options);
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>
@@ -144,13 +138,11 @@ Full Example
       </body>
     </html>
 
-Android 2.X Quirks
-------------------
+## Android 2.X Quirks
 
 - __pref__: Not supported, returning `false` on Android 2.X devices.
 
-BlackBerry WebWorks (OS 5.0 and higher) Quirks
---------------------------------------------
+## BlackBerry WebWorks (OS 5.0 and higher) Quirks
 
 - __pref__: Not supported on BlackBerry devices, returning `false`.
 
@@ -168,8 +160,7 @@ BlackBerry WebWorks (OS 5.0 and higher) Quirks
 
 - __country__: Supported.
 
-iOS Quirks
-----------
+## iOS Quirks
 
 - __pref__: Not supported on iOS devices, returning `false`.
 

--- a/docs/en/edge/cordova/contacts/ContactError/contactError.md
+++ b/docs/en/edge/cordova/contacts/ContactError/contactError.md
@@ -17,18 +17,15 @@
          under the License.
 ---
 
-ContactError
-========
+# ContactError
 
 A `ContactError` object is passed to the `contactError` callback when an error occurs.
 
-Properties
-----------
+## Properties
 
 - __code__: One of the predefined error codes listed below.
 
-Constants
----------
+## Constants
 
 - `ContactError.UNKNOWN_ERROR`
 - `ContactError.INVALID_ARGUMENT_ERROR`
@@ -38,8 +35,7 @@ Constants
 - `ContactError.NOT_SUPPORTED_ERROR`
 - `ContactError.PERMISSION_DENIED_ERROR`
 
-Description
------------
+## Description
 
 The `ContactError` object is returned to the user through the
 `contactError` callback function when an error occurs.

--- a/docs/en/edge/cordova/contacts/ContactField/contactfield.md
+++ b/docs/en/edge/cordova/contacts/ContactField/contactfield.md
@@ -17,15 +17,13 @@
          under the License.
 ---
 
-ContactField
-============
+# ContactField
 
 Supports generic fields in a `Contact` object.  Some properties stored
 as `ContactField` objects include email addresses, phone numbers, and
 URLs.
 
-Properties
-----------
+## Properties
 
 - __type__: A string that indicates what type of field this is, _home_ for example. _(DOMString)_
 
@@ -33,8 +31,7 @@ Properties
 
 - __pref__: Set to `true` if this `ContactField` contains the user's preferred value. _(boolean)_
 
-Details
--------
+## Details
 
 The `ContactField` object is a reusable component that represents
 contact fields generically.  Each `ContactField` object contains a
@@ -52,8 +49,7 @@ __url__ when the __value__ attribute contains a URL to the photo
 image, or _base64_ when the __value__ contains a base64-encoded image
 string.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
@@ -61,8 +57,7 @@ Supported Platforms
 - Windows Phone 7 and 8
 - Windows 8
 
-Quick Example
--------------
+## Quick Example
 
         // create a new contact
         var contact = navigator.contacts.create();
@@ -77,8 +72,7 @@ Quick Example
         // save the contact
         contact.save();
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>
@@ -143,13 +137,11 @@ Full Example
       </body>
     </html>
 
-Android Quirks
---------------
+## Android Quirks
 
 - __pref__: Not supported, returning `false`.
 
-BlackBerry WebWorks (OS 5.0 and higher) Quirks
---------------------------------------------
+## BlackBerry WebWorks (OS 5.0 and higher) Quirks
 
 - __type__: Partially supported.  Used for phone numbers.
 
@@ -157,8 +149,7 @@ BlackBerry WebWorks (OS 5.0 and higher) Quirks
 
 - __pref__: Not supported, returning `false`.
 
-iOS Quirks
------------
+## iOS Quirks
 
 - __pref__: Not supported, returning `false`.
 

--- a/docs/en/edge/cordova/contacts/ContactFindOptions/contactfindoptions.md
+++ b/docs/en/edge/cordova/contacts/ContactFindOptions/contactfindoptions.md
@@ -17,20 +17,17 @@
          under the License.
 ---
 
-ContactFindOptions
-==================
+# ContactFindOptions
 
 Contains properties that can be used to filter the results of a `contacts.find` operation.
 
-Properties
-----------
+## Properties
 
 - __filter__: The search string used to find contacts. _(DOMString)_ (Default: `""`)
 
 - __multiple__: Determines if the find operation returns multiple contacts. _(Boolean)_ (Default: false)
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
@@ -38,8 +35,7 @@ Supported Platforms
 - Windows Phone 7 and 8
 - Windows 8
 
-Quick Example
--------------
+## Quick Example
 
     // success callback
     function onSuccess(contacts) {
@@ -62,8 +58,7 @@ Quick Example
         // find contacts
     navigator.contacts.find(filter, onSuccess, onError, options);
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>

--- a/docs/en/edge/cordova/contacts/ContactName/contactname.md
+++ b/docs/en/edge/cordova/contacts/ContactName/contactname.md
@@ -17,13 +17,11 @@
          under the License.
 ---
 
-ContactName
-===========
+# ContactName
 
 Contains different kinds of information about a `Contact` object's name.
 
-Properties
-----------
+## Properties
 
 - __formatted__: The complete name of the contact. _(DOMString)_
 
@@ -37,13 +35,11 @@ Properties
 
 - __honorificSuffix__: The contact's suffix (example _Esq._). _(DOMString)_
 
-Details
--------
+## Details
 
 The `ContactName` object stores a contact's name properties.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android 2.X
 - BlackBerry WebWorks (OS 5.0 and higher)
@@ -51,8 +47,7 @@ Supported Platforms
 - Windows Phone 7 and 8
 - Windows 8
 
-Quick Example
--------------
+## Quick Example
 
     function onSuccess(contacts) {
         for (var i = 0; i < contacts.length; i++) {
@@ -74,8 +69,7 @@ Quick Example
     filter = ["displayName", "name"];
     navigator.contacts.find(filter, onSuccess, onError, options);
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>
@@ -125,13 +119,11 @@ Full Example
       </body>
     </html>
 
-Android Quirks
-------------
+## Android Quirks
 
 - __formatted__: Partially supported, and read-only.  Returns a concatenation of `honorificPrefix`, `givenName`, `middleName`, `familyName`, and `honorificSuffix`.
 
-BlackBerry WebWorks (OS 5.0 and higher) Quirks
----------------------------------------------
+## BlackBerry WebWorks (OS 5.0 and higher) Quirks
 
 - __formatted__: Partially supported.  Returns a concatenation of BlackBerry __firstName__ and __lastName__ fields.
 
@@ -145,8 +137,7 @@ BlackBerry WebWorks (OS 5.0 and higher) Quirks
 
 - __honorificSuffix__: Not supported, returning `null`.
 
-iOS Quirks
-------------
+## iOS Quirks
 
 - __formatted__: Partially supported.  Returns iOS Composite Name, but is read-only.
 

--- a/docs/en/edge/cordova/contacts/ContactOrganization/contactorganization.md
+++ b/docs/en/edge/cordova/contacts/ContactOrganization/contactorganization.md
@@ -17,13 +17,11 @@
          under the License.
 ---
 
-ContactOrganization
-===================
+# ContactOrganization
 
 Contains a `Contact` object's organization properties.
 
-Properties
-----------
+## Properties
 
 - __pref__: Set to `true` if this `ContactOrganization` contains the user's preferred value. _(boolean)_
 
@@ -35,15 +33,13 @@ Properties
 
 - __title__: The contact's title at the organization. _(DOMString)_
 
-Details
--------
+## Details
 
 The `ContactOrganization` object stores a contact's organization
 properties.  A `Contact` object stores one or more
 `ContactOrganization` objects in an array.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
@@ -51,8 +47,7 @@ Supported Platforms
 - Windows Phone 7 and 8
 - Windows 8
 
-Quick Example
--------------
+## Quick Example
 
     function onSuccess(contacts) {
         for (var i = 0; i < contacts.length; i++) {
@@ -75,8 +70,7 @@ Quick Example
     filter = ["displayName", "organizations"];
     navigator.contacts.find(filter, onSuccess, onError, options);
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>
@@ -127,13 +121,11 @@ Full Example
       </body>
     </html>
 
-Android 2.X Quirks
-------------------
+## Android 2.X Quirks
 
 - __pref__: Not supported by Android 2.X devices, returning `false`.
 
-BlackBerry WebWorks (OS 5.0 and higher) Quirks
---------------------------------------------
+## BlackBerry WebWorks (OS 5.0 and higher) Quirks
 
 - __pref__: Not supported by BlackBerry devices, returning `false`.
 
@@ -145,8 +137,7 @@ BlackBerry WebWorks (OS 5.0 and higher) Quirks
 
 - __title__: Partially supported.  The first organization title is stored in the BlackBerry __jobTitle__ field.
 
-iOS Quirks
------------
+## iOS Quirks
 
 - __pref__: Not supported on iOS devices, returning `false`.
 

--- a/docs/en/edge/cordova/contacts/contacts.create.md
+++ b/docs/en/edge/cordova/contacts/contacts.create.md
@@ -17,36 +17,31 @@
          under the License.
 ---
 
-contacts.create
-===============
+# contacts.create
 
 Returns a new Contact object.
 
     var contact = navigator.contacts.create(properties);
 
-Description
------------
+## Description
 
 The `contacts.create` method is synchronous, and returns a new `Contact` object.
 
 This method does not retain the Contact object in the device contacts
 database, for which you need to invoke the `Contact.save` method.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
 - iOS
 - Windows Phone 7 and 8
 
-Quick Example
--------------
+## Quick Example
 
     var myContact = navigator.contacts.create({"displayName": "Test User"});
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>

--- a/docs/en/edge/cordova/contacts/contacts.find.md
+++ b/docs/en/edge/cordova/contacts/contacts.find.md
@@ -17,16 +17,14 @@
          under the License.
 ---
 
-contacts.find
-=============
+# contacts.find
 
 Queries the device contacts database and returns one or more `Contact`
 objects, each containing the fields specified.
 
     navigator.contacts.find(contactFields, contactSuccess, contactError, contactFindOptions);
 
-Description
------------
+## Description
 
 The `contacts.find` method executes asynchronously, querying the
 device contacts database and returning an array of `Contact` objects.
@@ -46,8 +44,7 @@ case-insensitive, partial value match is applied to each field
 specified in the __contactFields__ parameter.  If there's a match for
 _any_ of the specified fields, the contact is returned.
 
-Parameters
-----------
+## Parameters
 
 - __contactFields__: Contact fields to use as a search qualifier. The resulting `Contact` object only features values for these fields. _(DOMString[])_ [Required]
 
@@ -57,8 +54,7 @@ Parameters
 
 - __contactFindOptions__: Search options to filter contacts. [Optional]
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
@@ -66,8 +62,7 @@ Supported Platforms
 - Windows Phone 7 and 8
 - Windows 8
 
-Quick Example
--------------
+## Quick Example
 
     function onSuccess(contacts) {
         alert('Found ' + contacts.length + ' contacts.');
@@ -84,8 +79,7 @@ Quick Example
     var fields       = ["displayName", "name"];
     navigator.contacts.find(fields, onSuccess, onError, options);
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>

--- a/docs/en/edge/cordova/contacts/contacts.md
+++ b/docs/en/edge/cordova/contacts/contacts.md
@@ -17,29 +17,25 @@
          under the License.
 ---
 
-Contacts
-========
+# Contacts
 
 > The `contacts` object provides access to the device contacts database.
 
 **Important privacy note:** Collection and use of contact data raises important privacy issues.  Your app's privacy policy should discuss how the app uses contact data and whether it is shared with any other parties.  Contact information is considered sensitive because it reveals the people with whom a person communicates.  Therefore, in addition to your app's privacy policy, you should strongly consider providing a just-in-time notice prior to your app accessing or using contact data (if the device operating system doesn't do so already). That notice should provide the same information noted above, as well as obtaining the user's permission (e.g., by presenting choices for "OK" and "No Thanks").  Note that some app marketplaces may require your app to provide just-in-time notice and obtain permission from the user prior to accessing contact data.  A clear and easy to understand user experience surrounding the use of contact data will help avoid user confusion and perceived misuse of contact data.  For more information, please see the Privacy Guide.
 
-Methods
--------
+## Methods
 
 - contacts.create
 - contacts.find
 
-Arguments
----------
+## Arguments
 
 - contactFields
 - contactSuccess
 - contactError
 - contactFindOptions
 
-Objects
--------
+## Objects
 
 - Contact
 - ContactName

--- a/docs/en/edge/cordova/contacts/parameters/contactError.md
+++ b/docs/en/edge/cordova/contacts/parameters/contactError.md
@@ -17,8 +17,7 @@
          under the License.
 ---
 
-contactError
-============
+# contactError
 
 Error callback function for contact functions.
 

--- a/docs/en/edge/cordova/contacts/parameters/contactFields.md
+++ b/docs/en/edge/cordova/contacts/parameters/contactFields.md
@@ -17,8 +17,7 @@
          under the License.
 ---
 
-contactFields
-=============
+# contactFields
 
 Required parameter for the `contacts.find` method, used to specify which fields should be included in the `Contact` objects resulting from a find operation.
 

--- a/docs/en/edge/cordova/contacts/parameters/contactFindOptions.md
+++ b/docs/en/edge/cordova/contacts/parameters/contactFindOptions.md
@@ -17,8 +17,7 @@
          under the License.
 ---
 
-contactFindOptions
-==================
+# contactFindOptions
 
 Optional parameter of the `contacts.find` method, used to filter the
 contacts returned from the contacts database.
@@ -28,8 +27,7 @@ contacts returned from the contacts database.
       multiple: true,
     };
 
-Options
--------
+## Options
 
 - __filter__: The search string used to filter contacts. _(DOMString)_ (Default: `""`)
 

--- a/docs/en/edge/cordova/contacts/parameters/contactSuccess.md
+++ b/docs/en/edge/cordova/contacts/parameters/contactSuccess.md
@@ -17,8 +17,7 @@
          under the License.
 ---
 
-contactSuccess
-==============
+# contactSuccess
 
 Success callback function that provides the `Contact` array resulting from a `contacts.find` operation.
 
@@ -26,13 +25,11 @@ Success callback function that provides the `Contact` array resulting from a `co
         // Do something
     }
 
-Parameters
-----------
+## Parameters
 
 - __contacts__: The contact array resulting from a find operation. _(Contact)_
 
-Example
--------
+## Example
 
     function contactSuccess(contacts) {
         for (var i=0; i<contacts.length; i++) {

--- a/docs/en/edge/cordova/device/device.cordova.md
+++ b/docs/en/edge/cordova/device/device.cordova.md
@@ -17,20 +17,17 @@
          under the License.
 ---
 
-device.cordova
-===============
+# device.cordova
 
 Get the version of Cordova running on the device.
 
     var string = device.cordova;
 
-Description
------------
+## Description
 
 `device.cordova` returns the version of Cordova running on the device.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
@@ -39,13 +36,11 @@ Supported Platforms
 - Windows Phone 7 and 8
 - Windows 8
 
-Quick Example
--------------
+## Quick Example
 
     var name = device.cordova;
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>

--- a/docs/en/edge/cordova/device/device.md
+++ b/docs/en/edge/cordova/device/device.md
@@ -17,13 +17,11 @@
          under the License.
 ---
 
-Device
-======
+# Device
 
 > The `device` object describes the device's hardware and software.
 
-Properties
-----------
+## Properties
 
 - device.name
 - device.cordova
@@ -32,8 +30,7 @@ Properties
 - device.version
 - device.model
 
-Variable Scope
---------------
+## Variable Scope
 
 Since `device` is assigned to the `window` object, it is implicitly in the global scope.
 

--- a/docs/en/edge/cordova/device/device.model.md
+++ b/docs/en/edge/cordova/device/device.model.md
@@ -17,22 +17,19 @@
          under the License.
 ---
 
-device.model
-===========
+# device.model
 
 Get the device's model name.
 
     var string = device.model;
 
-Description
------------
+## Description
 
 The `device.model` returns the name of the device's model or
 product. The value is set by the device manufacturer and may be
 different across versions of the same product.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
@@ -41,8 +38,7 @@ Supported Platforms
 - Windows Phone 7 and 8
 - Windows 8
 
-Quick Example
--------------
+## Quick Example
 
     // Android:    Nexus One       returns "Passion" (Nexus One code name)
     //             Motorola Droid  returns "voles"
@@ -51,8 +47,7 @@ Quick Example
     //
     var model = device.model;
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>
@@ -85,17 +80,14 @@ Full Example
       </body>
     </html>
 
-Android Quirks
---------------
+## Android Quirks
 
 - Gets the [product name](http://developer.android.com/reference/android/os/Build.html#PRODUCT) instead of the [model name](http://developer.android.com/reference/android/os/Build.html#MODEL), which is often the production code name. For example, the Nexus One returns `Passion`, and Motorola Droid returns `voles`.
 
-Tizen Quirks
------------
+## Tizen Quirks
 
 - Returns the device model assigned by the vendor, for example, `TIZEN`
 
-Windows Phone 7 and 8 Quirks
--------------
+## Windows Phone 7 and 8 Quirks
 
 - Returns the device model specified by the manufacturer. For example, the Samsung Focus returns `SGH-i917`.

--- a/docs/en/edge/cordova/device/device.name.md
+++ b/docs/en/edge/cordova/device/device.name.md
@@ -17,8 +17,7 @@
          under the License.
 ---
 
-device.name
-===========
+# device.name
 
 __WARNING:__ `device.name` is deprecated as of version 2.3.0. Use `device.model` instead.
 
@@ -26,15 +25,13 @@ Get the device's model name.
 
     var string = device.name;
 
-Description
------------
+## Description
 
 `device.name` returns the name of the device's model or product. This
 value is set by the device manufacturer and may be different across
 versions of the same product.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
@@ -43,8 +40,7 @@ Supported Platforms
 - Windows Phone 7 and 8
 - Windows 8
 
-Quick Example
--------------
+## Quick Example
 
     // Android:    Nexus One       returns "Passion" (Nexus One code name)
     //             Motorola Droid  returns "voles"
@@ -53,8 +49,7 @@ Quick Example
     //
     var name = device.name;
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>
@@ -87,17 +82,14 @@ Full Example
       </body>
     </html>
 
-Android Quirks
---------------
+## Android Quirks
 
 - Gets the [product name](http://developer.android.com/reference/android/os/Build.html#PRODUCT) instead of the [model name](http://developer.android.com/reference/android/os/Build.html#MODEL), which is often the production code name. For example, the Nexus One returns `Passion`, and Motorola Droid returns `voles`.
 
-Windows Phone 7 and 8 Quirks
--------------
+## Windows Phone 7 and 8 Quirks
 
 - Returns the device model specified by the manufacturer. For example, the Samsung Focus returns `SGH-i917`.
 
-Tizen Quirks
------------
+## Tizen Quirks
 
 - Returns the device model assigned by the vendor, for example, `TIZEN`

--- a/docs/en/edge/cordova/device/device.platform.md
+++ b/docs/en/edge/cordova/device/device.platform.md
@@ -17,15 +17,13 @@
          under the License.
 ---
 
-device.platform
-===============
+# device.platform
 
 Get the device's operating system name.
 
     var string = device.platform;
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
@@ -34,8 +32,7 @@ Supported Platforms
 - Windows Phone 7 and 8
 - Windows 8
 
-Quick Example
--------------
+## Quick Example
 
     // Depending on the device, a few examples are:
     //   - "Android"
@@ -45,8 +42,7 @@ Quick Example
     //   - "Tizen"
     var devicePlatform = device.platform;
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>
@@ -78,19 +74,16 @@ Full Example
       </body>
     </html>
 
-BlackBerry Quirks
------------------
+## BlackBerry Quirks
 
 Devices may return the device platform version number instead of the
 platform name.  For example, the Storm2 9550 returns a value such as
 `2.13.0.95`.
 
-Windows Phone 7 Quirks
------------------
+## Windows Phone 7 Quirks
 
 Windows Phone 7 devices report the platform as `WinCE`.
 
-Windows Phone 8 Quirks
------------------
+## Windows Phone 8 Quirks
 
 Windows Phone 8 devices report the platform as `Win32NT`.

--- a/docs/en/edge/cordova/device/device.uuid.md
+++ b/docs/en/edge/cordova/device/device.uuid.md
@@ -17,20 +17,17 @@
          under the License.
 ---
 
-device.uuid
-===========
+# device.uuid
 
 Get the device's Universally Unique Identifier ([UUID](http://en.wikipedia.org/wiki/Universally_Unique_Identifier)).
 
     var string = device.uuid;
 
-Description
------------
+## Description
 
 The details of how a UUID is generated are determined by the device manufacturer and are specific to the device's platform or model.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
@@ -39,8 +36,7 @@ Supported Platforms
 - Windows Phone 7 and 8
 - Windows 8
 
-Quick Example
--------------
+## Quick Example
 
     // Android: Returns a random 64-bit integer (as a string, again!)
     //          The integer is generated on the device's first boot
@@ -58,8 +54,7 @@ Quick Example
     // unique to every GSM and UMTS mobile phone.
     var deviceID = device.uuid;
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>
@@ -91,8 +86,7 @@ Full Example
       </body>
     </html>
 
-iOS Quirk
--------------
+## iOS Quirk
 
 The `uuid` on iOS is not unique to a device, but varies for each
 application, for each installation.  It changes if you delete and
@@ -100,8 +94,7 @@ re-install the app, and possibly also when you upgrade iOS, or even
 upgrade your app per version (apparent in iOS 5.1). The `uuid` is not
 a reliable value.
 
-Windows Phone 7 and 8 Quirks
--------------
+## Windows Phone 7 and 8 Quirks
 
 The `uuid` for Windows Phone 7 requires the permission
 `ID_CAP_IDENTITY_DEVICE`.  Microsoft will likely deprecate this

--- a/docs/en/edge/cordova/device/device.version.md
+++ b/docs/en/edge/cordova/device/device.version.md
@@ -17,15 +17,13 @@
          under the License.
 ---
 
-device.version
-==============
+# device.version
 
 Get the operating system version.
 
     var string = device.version;
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android 2.1+
 - BlackBerry WebWorks (OS 5.0 and higher)
@@ -34,8 +32,7 @@ Supported Platforms
 - Windows Phone 7 and 8
 - Windows 8
 
-Quick Example
--------------
+## Quick Example
 
     // Android:    Froyo OS would return "2.2"
     //             Eclair OS would return "2.1", "2.0.1", or "2.0"
@@ -49,8 +46,7 @@ Quick Example
     // Tizen: returns "TIZEN_20120425_2"
     var deviceVersion = device.version;
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>

--- a/docs/en/edge/cordova/events/events.backbutton.md
+++ b/docs/en/edge/cordova/events/events.backbutton.md
@@ -17,15 +17,13 @@
          under the License.
 ---
 
-backbutton
-===========
+# backbutton
 
 The event fires when the user presses the back button.
 
     document.addEventListener("backbutton", yourCallbackFunction, false);
 
-Details
--------
+## Details
 
 To override the default back-button behavior, register an event
 listener for the `backbutton` event, typically by calling
@@ -33,15 +31,13 @@ listener for the `backbutton` event, typically by calling
 It is no longer necessary to call any other method to override the
 back-button behavior.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
 - Windows Phone 7 and 8
 
-Quick Example
--------------
+## Quick Example
 
     document.addEventListener("backbutton", onBackKeyDown, false);
 
@@ -49,8 +45,7 @@ Quick Example
         // Handle the back button
     }
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>

--- a/docs/en/edge/cordova/events/events.batterycritical.md
+++ b/docs/en/edge/cordova/events/events.batterycritical.md
@@ -17,16 +17,14 @@
          under the License.
 ---
 
-batterycritical
-===========
+# batterycritical
 
 The event fires when the battery has reached the critical level
 threshold.
 
     window.addEventListener("batterycritical", yourCallbackFunction, false);
 
-Details
--------
+## Details
 
 The event fires when the percentage of battery charge has reached the
 critical battery threshold. The value is device-specific.
@@ -41,16 +39,14 @@ properties:
 Applications typically should use `window.addEventListener` to attach
 an event listener once the `deviceready` event fires.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - iOS
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
 - Tizen
 
-Quick Example
--------------
+## Quick Example
 
     window.addEventListener("batterycritical", onBatteryCritical, false);
 
@@ -59,8 +55,7 @@ Quick Example
         alert("Battery Level Critical " + info.level + "%\nRecharge Soon!");
     }
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>

--- a/docs/en/edge/cordova/events/events.batterylow.md
+++ b/docs/en/edge/cordova/events/events.batterylow.md
@@ -17,15 +17,13 @@
          under the License.
 ---
 
-batterylow
-===========
+# batterylow
 
 The event fires when the battery has reached the low level threshold.
 
     window.addEventListener("batterylow", yourCallbackFunction, false);
 
-Details
--------
+## Details
 
 The event fires when the percentage of battery charge has reached the
 low battery threshold, device-specific value.
@@ -40,16 +38,14 @@ properties:
 Applications typically should use `document.addEventListener` to
 attach an event listener once the `deviceready` event fires.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - iOS
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
 - Tizen
 
-Quick Example
--------------
+## Quick Example
 
     window.addEventListener("batterylow", onBatteryLow, false);
 
@@ -58,8 +54,7 @@ Quick Example
         alert("Battery Level Low " + info.level + "%");
     }
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>

--- a/docs/en/edge/cordova/events/events.batterystatus.md
+++ b/docs/en/edge/cordova/events/events.batterystatus.md
@@ -17,15 +17,13 @@
          under the License.
 ---
 
-batterystatus
-===========
+# batterystatus
 
 The event fires when there is a change in the battery status.
 
     window.addEventListener("batterystatus", yourCallbackFunction, false);
 
-Details
--------
+## Details
 
 This event fires when the percentage of battery charge changes by at
 least 1 percent, or if the device is plugged in or unplugged.
@@ -40,8 +38,7 @@ properties:
 Applications typically should use `window.addEventListener` to
 attach an event listener once the `deviceready` event fires.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - iOS
 - Android
@@ -49,15 +46,13 @@ Supported Platforms
 - Windows Phone 7 and 8
 - Tizen
 
-Windows Phone 7 and 8 Quirks
-----------------------
+## Windows Phone 7 and 8 Quirks
 
 Windows Phone 7 does not provide native APIs to determine battery
 level, so the `level` property is unavailable.  The `isPlugged`
 parameter _is_ supported.
 
-Quick Example
--------------
+## Quick Example
 
     window.addEventListener("batterystatus", onBatteryStatus, false);
 
@@ -66,8 +61,7 @@ Quick Example
         console.log("Level: " + info.level + " isPlugged: " + info.isPlugged);
     }
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>

--- a/docs/en/edge/cordova/events/events.deviceready.md
+++ b/docs/en/edge/cordova/events/events.deviceready.md
@@ -17,15 +17,13 @@
          under the License.
 ---
 
-deviceready
-===========
+# deviceready
 
 The event fires when Cordova is fully loaded.
 
     document.addEventListener("deviceready", yourCallbackFunction, false);
 
-Details
--------
+## Details
 
 This event is essential to any application. It signals that Cordova's
 device APIs have loaded and are ready to access.
@@ -45,8 +43,7 @@ The `deviceready` event behaves somewhat differently from others.  Any
 event handler registered after the `deviceready` event fires has its
 callback function called immediately.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
@@ -55,8 +52,7 @@ Supported Platforms
 - Windows Phone 7 and 8
 - Windows 8
 
-Quick Example
--------------
+## Quick Example
 
     document.addEventListener("deviceready", onDeviceReady, false);
 
@@ -64,8 +60,7 @@ Quick Example
         // Now safe to use device APIs
     }
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>

--- a/docs/en/edge/cordova/events/events.endcallbutton.md
+++ b/docs/en/edge/cordova/events/events.endcallbutton.md
@@ -17,28 +17,24 @@
          under the License.
 ---
 
-endcallbutton
-===========
+# endcallbutton
 
 This event fires when the user presses the end call button.
 
     document.addEventListener("endcallbutton", yourCallbackFunction, false);
 
-Details
--------
+## Details
 
 The event overrides the default end call behavior.
 
 Applications typically should use `document.addEventListener` to
 attach an event listener once the `deviceready` event fires.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - BlackBerry WebWorks (OS 5.0 and higher)
 
-Quick Example
--------------
+## Quick Example
 
     document.addEventListener("endcallbutton", onEndCallKeyDown, false);
 
@@ -46,8 +42,7 @@ Quick Example
         // Handle the end call button
     }
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
                           "http://www.w3.org/TR/html4/strict.dtd">

--- a/docs/en/edge/cordova/events/events.md
+++ b/docs/en/edge/cordova/events/events.md
@@ -17,13 +17,11 @@
          under the License.
 ---
 
-Events
-======
+# Events
 
 > Cordova lifecycle events.
 
-Event Types
------------
+## Event Types
 
 - deviceready
 - pause

--- a/docs/en/edge/cordova/events/events.menubutton.md
+++ b/docs/en/edge/cordova/events/events.menubutton.md
@@ -17,29 +17,25 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-menubutton
-===========
+# menubutton
 
 The event fires when the user presses the menu button.
 
     document.addEventListener("menubutton", yourCallbackFunction, false);
 
-Details
--------
+## Details
 
 Applying an event handler overrides the default menu button behavior.
 
 Applications typically should use `document.addEventListener` to
 attach an event listener once the `deviceready` event fires.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
 
-Quick Example
--------------
+## Quick Example
 
     document.addEventListener("menubutton", onMenuKeyDown, false);
 
@@ -47,8 +43,7 @@ Quick Example
         // Handle the back button
     }
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
                           "http://www.w3.org/TR/html4/strict.dtd">

--- a/docs/en/edge/cordova/events/events.offline.md
+++ b/docs/en/edge/cordova/events/events.offline.md
@@ -17,16 +17,14 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-offline
-===========
+# offline
 
 The event fires when an application goes offline, and the device is
 not connected to the Internet.
 
     document.addEventListener("offline", yourCallbackFunction, false);
 
-Details
--------
+## Details
 
 The `offline` event fires when a previously connected device loses a
 network connection so that an application can no longer access the
@@ -37,8 +35,7 @@ value.
 Applications typically should use `document.addEventListener` to
 attach an event listener once the `deviceready` event fires.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
@@ -47,8 +44,7 @@ Supported Platforms
 - Tizen
 - Windows 8
 
-Quick Example
--------------
+## Quick Example
 
     document.addEventListener("offline", onOffline, false);
 
@@ -56,8 +52,7 @@ Quick Example
         // Handle the offline event
     }
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>
@@ -90,14 +85,14 @@ Full Example
       </body>
     </html>
 
-iOS Quirks
---------------------------
+## iOS Quirks
+
 During initial startup, the first offline event (if applicable) takes at least a second to fire.
 
-Windows Phone 7 Quirks
---------------------------
+## Windows Phone 7 Quirks
+
 When running in the Emulator, the `connection.status` is always unknown, so this event does _not_ fire.
 
-Windows Phone 8 Quirks
---------------------------
+## Windows Phone 8 Quirks
+
 The Emulator reports the connection type as `Cellular`, which does not change, so the event does _not_ fire.

--- a/docs/en/edge/cordova/events/events.online.md
+++ b/docs/en/edge/cordova/events/events.online.md
@@ -17,16 +17,14 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-online
-===========
+# online
 
 This event fires when an application goes online, and the device
 becomes connected to the Internet.
 
     document.addEventListener("online", yourCallbackFunction, false);
 
-Details
--------
+## Details
 
 The `online` event fires when a previously unconnected device receives
 a network connection to allow an application access to the Internet.
@@ -36,8 +34,7 @@ when the value of `connection.type` becomes `NONE`.
 Applications typically should use `document.addEventListener` to
 attach an event listener once the `deviceready` event fires.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
@@ -46,8 +43,7 @@ Supported Platforms
 - Tizen
 - Windows 8
 
-Quick Example
--------------
+## Quick Example
 
     document.addEventListener("online", onOnline, false);
 
@@ -55,8 +51,7 @@ Quick Example
         // Handle the online event
     }
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>
@@ -89,17 +84,16 @@ Full Example
       </body>
     </html>
 
-iOS Quirks
---------------------------
+## iOS Quirks
 
 During initial startup, the first `online` event (if applicable) takes
 at least a second to fire, prior to which `connection.type` is
 `UNKNOWN`.
 
-Windows Phone 7 Quirks
---------------------------
+## Windows Phone 7 Quirks
+
 When running in the Emulator, the `connection.status` is always unknown, so this event will _not_ fire.
 
-Windows Phone 8 Quirks
---------------------------
+## Windows Phone 8 Quirks
+
 The Emulator reports the connection type as `Cellular`, which does not change, so events will _not_ fire.

--- a/docs/en/edge/cordova/events/events.pause.md
+++ b/docs/en/edge/cordova/events/events.pause.md
@@ -17,15 +17,13 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-pause
-===========
+# pause
 
 The event fires when an application is put into the background.
 
     document.addEventListener("pause", yourCallbackFunction, false);
 
-Details
--------
+## Details
 
 The `pause` event fires when the native platform puts the application
 into the background, typically when the user switches to a different
@@ -34,8 +32,7 @@ application.
 Applications typically should use `document.addEventListener` to
 attach an event listener once the `deviceready` event fires.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
@@ -43,8 +40,7 @@ Supported Platforms
 - Windows Phone 7 and 8
 - Windows 8
 
-Quick Example
--------------
+## Quick Example
 
     document.addEventListener("pause", onPause, false);
 
@@ -52,8 +48,7 @@ Quick Example
         // Handle the pause event
     }
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>
@@ -86,8 +81,7 @@ Full Example
       </body>
     </html>
 
-iOS Quirks
---------------------------
+## iOS Quirks
 
 In the `pause` handler, any calls to the Cordova API or to native
 plugins that go through Objective-C do not work, along with any

--- a/docs/en/edge/cordova/events/events.resume.md
+++ b/docs/en/edge/cordova/events/events.resume.md
@@ -17,15 +17,13 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-resume
-===========
+# resume
 
 The event fires when an application is retrieved from the background.
 
     document.addEventListener("resume", yourCallbackFunction, false);
 
-Details
--------
+## Details
 
 The `resume` event fires when the native platform pulls the
 application out from the background.
@@ -33,8 +31,7 @@ application out from the background.
 Applications typically should use `document.addEventListener` to
 attach an event listener once the `deviceready` event fires.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
@@ -42,8 +39,7 @@ Supported Platforms
 - Windows Phone 7 and 8
 - Windows 8
 
-Quick Example
--------------
+## Quick Example
 
     document.addEventListener("resume", onResume, false);
 
@@ -51,8 +47,7 @@ Quick Example
         // Handle the resume event
     }
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>
@@ -85,8 +80,7 @@ Full Example
       </body>
     </html>
 
-iOS Quirks
---------------------------
+## iOS Quirks
 
 Any interactive functions called from a `pause` event handler execute
 later when the app resumes, as signaled by the `resume` event. These

--- a/docs/en/edge/cordova/events/events.searchbutton.md
+++ b/docs/en/edge/cordova/events/events.searchbutton.md
@@ -17,15 +17,13 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-searchbutton
-===========
+# searchbutton
 
 The event fires when the user presses the search button on Android.
 
     document.addEventListener("searchbutton", yourCallbackFunction, false);
 
-Details
--------
+## Details
 
 If you need to override the default search button behavior on Android
 you can register an event listener for the 'searchbutton' event.
@@ -33,13 +31,11 @@ you can register an event listener for the 'searchbutton' event.
 Applications typically should use `document.addEventListener` to
 attach an event listener once the `deviceready` event fires.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 
-Quick Example
--------------
+## Quick Example
 
     document.addEventListener("searchbutton", onSearchKeyDown, false);
 
@@ -47,8 +43,7 @@ Quick Example
         // Handle the search button
     }
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
                           "http://www.w3.org/TR/html4/strict.dtd">

--- a/docs/en/edge/cordova/events/events.startcallbutton.md
+++ b/docs/en/edge/cordova/events/events.startcallbutton.md
@@ -17,15 +17,13 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-startcallbutton
-===========
+# startcallbutton
 
 The event fires when the user presses the start call button.
 
     document.addEventListener("startcallbutton", yourCallbackFunction, false);
 
-Details
--------
+## Details
 
 If you need to override the default start call behavior you can
 register an event listener for the `startcallbutton` event.
@@ -33,13 +31,11 @@ register an event listener for the `startcallbutton` event.
 Applications typically should use `document.addEventListener` to
 attach an event listener once the `deviceready` event fires.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - BlackBerry WebWorks (OS 5.0 and higher)
 
-Quick Example
--------------
+## Quick Example
 
     document.addEventListener("startcallbutton", onStartCallKeyDown, false);
 
@@ -47,8 +43,7 @@ Quick Example
         // Handle the start call button
     }
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
                           "http://www.w3.org/TR/html4/strict.dtd">

--- a/docs/en/edge/cordova/events/events.volumedownbutton.md
+++ b/docs/en/edge/cordova/events/events.volumedownbutton.md
@@ -17,15 +17,13 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-volumedownbutton
-===========
+# volumedownbutton
 
 The event fires when the user presses the volume down button.
 
     document.addEventListener("volumedownbutton", yourCallbackFunction, false);
 
-Details
--------
+## Details
 
 If you need to override the default volume down behavior you can
 register an event listener for the `volumedownbutton` event.
@@ -33,13 +31,11 @@ register an event listener for the `volumedownbutton` event.
 Applications typically should use `document.addEventListener` to
 attach an event listener once the `deviceready` event fires.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - BlackBerry WebWorks (OS 5.0 and higher)
 
-Quick Example
--------------
+## Quick Example
 
     document.addEventListener("volumedownbutton", onVolumeDownKeyDown, false);
 
@@ -47,8 +43,7 @@ Quick Example
         // Handle the volume down button
     }
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
                           "http://www.w3.org/TR/html4/strict.dtd">

--- a/docs/en/edge/cordova/events/events.volumeupbutton.md
+++ b/docs/en/edge/cordova/events/events.volumeupbutton.md
@@ -17,15 +17,13 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-volumeupbutton
-===========
+# volumeupbutton
 
 The event fires when the user presses the volume up button.
 
     document.addEventListener("volumeupbutton", yourCallbackFunction, false);
 
-Details
--------
+## Details
 
 If you need to override the default volume up behavior you can
 register an event listener for the `volumeupbutton` event.
@@ -33,13 +31,11 @@ register an event listener for the `volumeupbutton` event.
 Applications typically should use `document.addEventListener` to
 attach an event listener once the `deviceready` event fires.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - BlackBerry WebWorks (OS 5.0 and higher)
 
-Quick Example
--------------
+## Quick Example
 
     document.addEventListener("volumeupbutton", onVolumeUpKeyDown, false);
 
@@ -47,8 +43,7 @@ Quick Example
         // Handle the volume up button
     }
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
                           "http://www.w3.org/TR/html4/strict.dtd">

--- a/docs/en/edge/cordova/file/directoryentry/directoryentry.md
+++ b/docs/en/edge/cordova/file/directoryentry/directoryentry.md
@@ -17,15 +17,13 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-DirectoryEntry
-==============
+# DirectoryEntry
 
 This object represents a directory on a file system, as defined by the
 [W3C Directories and Systems](http://www.w3.org/TR/file-system-api/)
 specification.
 
-Properties
-----------
+## Properties
 
 - __isFile__: Always false. _(boolean)_
 
@@ -40,8 +38,7 @@ but is _not_ supported:
 
 - __filesystem__: The file system on which the `DirectoryEntry` resides. _(FileSystem)_
 
-Methods
--------
+## Methods
 
 The following methods can be invoked on a `DirectoryEntry` object:
 
@@ -67,8 +64,7 @@ The following methods can be invoked on a `DirectoryEntry` object:
 
 - __removeRecursively__: Delete a directory and all of its contents.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
@@ -76,8 +72,7 @@ Supported Platforms
 - Windows Phone 7 and 8
 - Windows 8
 
-getMetadata
------------
+## getMetadata
 
 Look up metadata about a directory.
 
@@ -100,8 +95,7 @@ __Quick Example__
     // Request the metadata object for this entry
     entry.getMetadata(success, fail);
 
-setMetadata
-----------------
+## setMetadata
 
 Sets a directory's extended attributes, or metadata. _Currently works
 only on iOS._
@@ -164,8 +158,7 @@ __Quick Example__
 
         setFolderMetadata(LocalFileSystem.PERSISTENT, "Backups", "com.apple.MobileBackup", 1);
 
-moveTo
-------
+## moveTo
 
 Move a directory to a different location on the file system. An error results if the app attempts to:
 
@@ -210,8 +203,7 @@ __Quick Example__
         entry.moveTo(parentEntry, newName, success, fail);
     }
 
-copyTo
-------
+## copyTo
 
 Copy a directory to a different location on the file system.  An error results if the app attempts to:
 
@@ -251,8 +243,7 @@ __Quick Example__
         entry.copyTo(parentEntry, newName, success, fail);
     }
 
-toURL
------
+## toURL
 
 Returns a URL that can be used to locate the directory.
 
@@ -262,8 +253,7 @@ __Quick Example__
     var dirURL = entry.toURL();
     console.log(dirURL);
 
-remove
-------
+## remove
 
 Deletes a directory. An error results if the app attempts to:
 
@@ -290,8 +280,7 @@ __Quick Example__
     // remove this directory
     entry.remove(success, fail);
 
-getParent
----------
+## getParent
 
 Look up the parent `DirectoryEntry` containing the directory.
 
@@ -314,8 +303,7 @@ __Quick Example__
     // Get the parent DirectoryEntry
     entry.getParent(success, fail);
 
-createReader
-------------
+## createReader
 
 Creates a new DirectoryReader to read entries in a directory.
 
@@ -324,8 +312,7 @@ __Quick Example__
     // create a directory reader
     var directoryReader = entry.createReader();
 
-getDirectory
-------------
+## getDirectory
 
 Creates or looks up an existing directory.  An error results if the app attempts to:
 
@@ -354,8 +341,7 @@ __Quick Example__
     // Retrieve an existing directory, or create it if it does not already exist
     entry.getDirectory("newDir", {create: true, exclusive: false}, success, fail);
 
-getFile
--------
+## getFile
 
 Creates or looks up a file.  An error results if the app attempts to:
 
@@ -384,8 +370,7 @@ __Quick Example__
     // Retrieve an existing file, or create it if it does not exist
     entry.getFile("newFile.txt", {create: true, exclusive: false}, success, fail);
 
-removeRecursively
------------------
+## removeRecursively
 
 Deletes a directory and all of its contents.  In the event of an error (such as trying to delete
 a directory containing a file that cannot be removed), some of the contents of the directory may
@@ -412,8 +397,7 @@ __Quick Example__
     // remove the directory and all it's contents
     entry.removeRecursively(success, fail);
 
-BlackBerry Quirks
------------------
+## BlackBerry Quirks
 
 May fail with a `ControlledAccessException` in the following cases:
 

--- a/docs/en/edge/cordova/file/directoryreader/directoryreader.md
+++ b/docs/en/edge/cordova/file/directoryreader/directoryreader.md
@@ -17,21 +17,18 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-DirectoryReader
-===============
+# DirectoryReader
 
 An object that lists files and directories within a directory, as
 defined in the
 [W3C Directories and Systems](http://www.w3.org/TR/file-system-api/)
 specification.
 
-Methods
--------
+## Methods
 
 - __readEntries__: Read the entries in a directory.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
@@ -39,8 +36,7 @@ Supported Platforms
 - Windows Phone 7 and 8
 - Windows 8
 
-readEntries
------------
+## readEntries
 
 Read the entries in this directory.
 

--- a/docs/en/edge/cordova/file/file.md
+++ b/docs/en/edge/cordova/file/file.md
@@ -17,13 +17,11 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-File
-==========
+# File
 
 > An API to read, write and navigate file system hierarchies, based on the [W3C File API](http://www.w3.org/TR/FileAPI).
 
-Objects
--------
+## Objects
 
 - DirectoryEntry
 - DirectoryReader

--- a/docs/en/edge/cordova/file/fileentry/fileentry.md
+++ b/docs/en/edge/cordova/file/fileentry/fileentry.md
@@ -17,15 +17,13 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-FileEntry
-==========
+# FileEntry
 
 Represents a file on a file system, as defined in the
 [W3C Directories and Systems](http://www.w3.org/TR/file-system-api/)
 specification.
 
-Properties
-----------
+## Properties
 
 - __isFile__: Always true. _(boolean)_
 
@@ -40,8 +38,7 @@ but is _not_ supported:
 
 - __filesystem__: The file system on which the `FileEntry` resides. _(FileSystem)_
 
-Methods
--------
+## Methods
 
 - __getMetadata__: Look up metadata about a file.
 
@@ -61,8 +58,7 @@ Methods
 
 - __file__: Creates a `File` object containing file properties.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
@@ -70,8 +66,7 @@ Supported Platforms
 - Windows Phone 7 and 8
 - Windows 8
 
-getMetadata
-----------------
+## getMetadata
 
 Look up metadata about a file.
 
@@ -94,8 +89,7 @@ __Quick Example__
     // Request the metadata object for this entry
     entry.getMetadata(success, fail);
 
-setMetadata
-----------------
+## setMetadata
 
 Set metadata on a file.
 
@@ -161,8 +155,7 @@ __Quick Example__
 
         setFileMetadata(LocalFileSystem.PERSISTENT, "Backups/sqlite.db", "com.apple.MobileBackup", 1);
 
-moveTo
-------
+## moveTo
 
 Move a file to a different location on the file system. An error
 results if the app attempts to:
@@ -203,8 +196,7 @@ __Quick Example__
         entry.moveTo(parentEntry, "newFile.txt", success, fail);
     }
 
-copyTo
-------
+## copyTo
 
 Copy a file to a new location on the file system.  An error results if
 the app attempts to:
@@ -240,8 +232,7 @@ __Quick Example__
         entry.copyTo(parentEntry, "file.copy", success, fail);
     }
 
-toURL
------
+## toURL
 
 Returns a URL that can be used to locate the file.
 
@@ -251,8 +242,7 @@ __Quick Example__
     var fileURL = entry.toURL();
     console.log(fileURL);
 
-remove
-------
+## remove
 
 Deletes a file.
 
@@ -275,8 +265,7 @@ __Quick Example__
     // remove the file
     entry.remove(success, fail);
 
-getParent
----------
+## getParent
 
 Look up the parent `DirectoryEntry` containing the file.
 
@@ -299,8 +288,7 @@ __Quick Example__
     // Get the parent DirectoryEntry
     entry.getParent(success, fail);
 
-createWriter
-------------
+## createWriter
 
 Create a `FileWriter` object associated with the file represented by the `FileEntry`.
 
@@ -323,8 +311,7 @@ __Quick Example__
     // create a FileWriter to write to the file
     entry.createWriter(success, fail);
 
-file
-----
+## file
 
 Return a `File` object that represents the current state of the file
 that this `FileEntry` represents.

--- a/docs/en/edge/cordova/file/fileerror/fileerror.md
+++ b/docs/en/edge/cordova/file/fileerror/fileerror.md
@@ -17,18 +17,15 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-FileError
-========
+# FileError
 
 A `FileError` object is set when an error occurs in any of the File API methods.
 
-Properties
-----------
+## Properties
 
 - __code__: One of the predefined error codes listed below.
 
-Constants
----------
+## Constants
 
 - `FileError.NOT_FOUND_ERR`
 - `FileError.SECURITY_ERR`
@@ -43,8 +40,7 @@ Constants
 - `FileError.TYPE_MISMATCH_ERR`
 - `FileError.PATH_EXISTS_ERR`
 
-Description
------------
+## Description
 
 The `FileError` object is the only parameter provided to any of the
 File API's error callbacks.  To determine the type of error, compare

--- a/docs/en/edge/cordova/file/fileobj/fileobj.md
+++ b/docs/en/edge/cordova/file/fileobj/fileobj.md
@@ -17,13 +17,11 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-File
-====
+# File
 
 This object contains attributes of a single file.
 
-Properties
-----------
+## Properties
 
 - __name__: The name of the file. _(DOMString)_
 
@@ -35,20 +33,17 @@ Properties
 
 - __size__: The size of the file in bytes. _(long)_
 
-Methods
--------
+## Methods
 
 - __slice__: Select only a portion of the file to be read.
 
-Details
--------
+## Details
 
 The `File` object contains attributes of a single file.  You can get
 an instance of a `File` object by calling a `FileEntry` object's
 `file()` method.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
@@ -56,8 +51,7 @@ Supported Platforms
 - Windows Phone 7 and 8
 - Windows 8
 
-slice
---------------
+## slice
 
 Return a new `File` object, for which `FileReader` returns only the
 specified portion of the file.  Negative values for `start` or `end`

--- a/docs/en/edge/cordova/file/filereader/filereader.md
+++ b/docs/en/edge/cordova/file/filereader/filereader.md
@@ -17,13 +17,11 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-FileReader
-==========
+# FileReader
 
 The `FileReader` allows basic access to a file.
 
-Properties
-----------
+## Properties
 
 - __readyState__: One of the reader's three possible states, either `EMPTY`, `LOADING` or `DONE`.
 
@@ -45,8 +43,7 @@ __NOTE:__ The following porperty is not supported:
 
 - __onprogress__: Called while reading the file, reporting progress in terms of `progress.loaded`/`progress.total`. _(Function)_
 
-Methods
--------
+## Methods
 
 - __abort__: Aborts reading file.
 
@@ -58,16 +55,14 @@ Methods
 
 - __readAsArrayBuffer__: Reads file as an `ArrayBuffer`.
 
-Details
--------
+## Details
 
 The `FileReader` object offers a way to read files from the device's
 file system.  Files can be read as text or as a base64 data-encoded
 string.  Event listeners receive the `loadstart`, `progress`, `load`,
 `loadend`, `error`, and `abort` events.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
@@ -75,15 +70,13 @@ Supported Platforms
 - Windows Phone 7 and 8
 - Windows 8
 
-Read As Data URL
-----------------
+## Read As Data URL
 
 __Parameters:__
 
 - __file__: the file object to read.
 
-Quick Example
--------------
+## Quick Example
 
     function win(file) {
         var reader = new FileReader();
@@ -100,8 +93,7 @@ Quick Example
 
     entry.file(win, fail);
 
-Read As Text
-------------
+## Read As Text
 
 __Parameters:__
 
@@ -109,8 +101,7 @@ __Parameters:__
 
 - __encoding__: the encoding to use to encode the file's content. Default is UTF8.
 
-Quick Example
--------------
+## Quick Example
 
     function win(file) {
         var reader = new FileReader();
@@ -127,8 +118,7 @@ Quick Example
 
     entry.file(win, fail);
 
-Abort Quick Example
--------------------
+## Abort Quick Example
 
     function win(file) {
         var reader = new FileReader();
@@ -146,8 +136,7 @@ Abort Quick Example
 
     entry.file(win, fail);
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>
@@ -210,13 +199,11 @@ Full Example
       </body>
     </html>
 
-iOS Quirks
-----------
+## iOS Quirks
 
 - The __encoding__ parameter is not supported, and UTF8 encoding is always in effect.
 
-Read As Binary String
----------------------
+## Read As Binary String
 
 Currently supported on iOS and Android only.
 
@@ -224,8 +211,7 @@ __Parameters:__
 
 - __file__: the file object to read.
 
-Quick Example
--------------
+## Quick Example
 
     function win(file) {
         var reader = new FileReader();
@@ -242,8 +228,7 @@ Quick Example
 
     entry.file(win, fail);
 
-Read As Array Buffer
---------------------
+## Read As Array Buffer
 
 Currently supported on iOS and Android only.
 
@@ -251,8 +236,7 @@ __Parameters:__
 
 - __file__:  the file object to read.
 
-Quick Example
--------------
+## Quick Example
 
     function win(file) {
         var reader = new FileReader();

--- a/docs/en/edge/cordova/file/filesystem/filesystem.md
+++ b/docs/en/edge/cordova/file/filesystem/filesystem.md
@@ -17,28 +17,24 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-FileSystem
-==========
+# FileSystem
 
 This object represents a file system.
 
-Properties
-----------
+## Properties
 
 - __name__: The name of the file system. _(DOMString)_
 
 - __root__: The root directory of the file system. _(DirectoryEntry)_
 
-Details
--------
+## Details
 
 The `FileSystem` object represents information about the file system.
 The name of the file system is unique across the list of exposed
 file systems.  The root property contains a `DirectoryEntry` object
 that represents the file system's root directory.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
@@ -46,8 +42,7 @@ Supported Platforms
 - Windows Phone 7 and 8
 - Windows 8
 
-File System Quick Example
--------------------------
+## File System Quick Example
 
     function onSuccess(fileSystem) {
         console.log(fileSystem.name);
@@ -57,8 +52,7 @@ File System Quick Example
     // request the persistent file system
     window.requestFileSystem(LocalFileSystem.PERSISTENT, 0, onSuccess, null);
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>

--- a/docs/en/edge/cordova/file/filetransfer/filetransfer.md
+++ b/docs/en/edge/cordova/file/filetransfer/filetransfer.md
@@ -17,19 +17,16 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-FileTransfer
-==========
+# FileTransfer
 
 The `FileTransfer` object allows you to upload or download files to
 and from a server.
 
-Properties
-----------
+## Properties
 
 - __onprogress__: Called with a `ProgressEvent` whenever a new chunk of data is transferred. _(Function)_
 
-Methods
--------
+## Methods
 
 - __upload__: sends a file to a server.
 
@@ -37,8 +34,7 @@ Methods
 
 - __abort__: Aborts an in-progress transfer.
 
-Details
--------
+## Details
 
 The `FileTransfer` object provides a way to upload files to a remote
 server using an HTTP multi-part POST request.  Both HTTP and HTTPS
@@ -50,8 +46,7 @@ passed to the error callback.  It is also possible (only on iOS and
 Android) to download a file from a remote server and save it on the
 device.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
@@ -59,8 +54,7 @@ Supported Platforms
 - Windows Phone 7 and 8
 - Windows 8
 
-upload
---------------
+## upload
 
 __Parameters:__
 
@@ -206,8 +200,7 @@ __Android Quirks__
 Set the `chunkedMode` option to `false` to prevent problems uploading
 to a Nginx server.
 
-download
---------------
+## download
 
 __Parameters:__
 
@@ -249,8 +242,7 @@ __Quick Example__
         }
     );
 
-abort
---------------
+## abort
 
 Aborts an in-progress transfer. The onerror callback is passed a FileTransferError object which has an error code of FileTransferError.ABORT_ERR.
 
@@ -283,8 +275,7 @@ __Quick Example__
     ft.upload(fileURI, encodeURI("http://some.server.com/upload.php"), win, fail, options);
     ft.abort();
 
-onprogress
---------------
+## onprogress
 
 Called with a ProgressEvent whenever a new chunk of data is transferred.
 

--- a/docs/en/edge/cordova/file/filetransfererror/filetransfererror.md
+++ b/docs/en/edge/cordova/file/filetransfererror/filetransfererror.md
@@ -17,13 +17,11 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-FileTransferError
-========
+# FileTransferError
 
 A `FileTransferError` object is passed to an error callback when an error occurs.
 
-Properties
-----------
+## Properties
 
 - __code__: One of the predefined error codes listed below. (Number)
 
@@ -33,16 +31,14 @@ Properties
 
 - __http_status__: HTTP status code.  This attribute is only available when a response code is received from the HTTP connection. (Number)
 
-Constants
----------
+## Constants
 
 - `FileTransferError.FILE_NOT_FOUND_ERR`
 - `FileTransferError.INVALID_URL_ERR`
 - `FileTransferError.CONNECTION_ERR`
 - `FileTransferError.ABORT_ERR`
 
-Description
------------
+## Description
 
 The `FileTransferError` object is passed to the error callback when an
 error occurs when uploading or downloading a file.

--- a/docs/en/edge/cordova/file/fileuploadoptions/fileuploadoptions.md
+++ b/docs/en/edge/cordova/file/fileuploadoptions/fileuploadoptions.md
@@ -17,15 +17,13 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-FileUploadOptions
-========
+# FileUploadOptions
 
 A `FileUploadOptions` object can be passed to the `FileTransfer`
 object's `upload()` method to specify additional parameters to the
 upload script.
 
-Properties
-----------
+## Properties
 
 - __fileKey__: The name of the form element.  Defaults to `file`. (DOMString)
 
@@ -39,14 +37,12 @@ Properties
 
 - __headers__: A map of header name/header values. Use an array to specify more than one value. (Object)
 
-Description
------------
+## Description
 
 A `FileUploadOptions` object can be passed to the `FileTransfer`
 object's `upload()` method to specify additional parameters to the
 upload script.
 
-WP7 Quirk
----------
+## WP7 Quirk
 
 - __chunkedMode:__: Ignored on WP7.

--- a/docs/en/edge/cordova/file/fileuploadresult/fileuploadresult.md
+++ b/docs/en/edge/cordova/file/fileuploadresult/fileuploadresult.md
@@ -17,14 +17,12 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-FileUploadResult
-========
+# FileUploadResult
 
 A `FileUploadResult` object is passed to the success callback of the
 `FileTransfer` object's `upload()` method.
 
-Properties
-----------
+## Properties
 
 - __bytesSent__: The number of bytes sent to the server as part of the upload. (long)
 
@@ -32,13 +30,11 @@ Properties
 
 - __response__: The HTTP response returned by the server. (DOMString)
 
-Description
------------
+## Description
 
 The `FileUploadResult` object is returned via the success callback of
 the `FileTransfer` object's `upload()` method.
 
-iOS Quirks
-----------
+## iOS Quirks
 
 - Does not support `responseCode` or `bytesSent`.

--- a/docs/en/edge/cordova/file/filewriter/filewriter.md
+++ b/docs/en/edge/cordova/file/filewriter/filewriter.md
@@ -17,13 +17,11 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-FileWriter
-==========
+# FileWriter
 
 As object that allows you to create and write data to a file.
 
-Properties
-----------
+## Properties
 
 - __readyState__: One of the three possible states, either `INIT`, `WRITING`, or `DONE`.
 
@@ -48,8 +46,7 @@ Properties
 The following property is _not_ supported:
 
 - __onprogress__: Called while writing the file, reporting progress in terms of `progress.loaded`/`progress.total`. _(Function)_
-Methods
--------
+## Methods
 
 - __abort__: Aborts writing the file.
 
@@ -59,8 +56,7 @@ Methods
 
 - __write__: Writes data to the file.
 
-Details
--------
+## Details
 
 The `FileWriter` object offers a way to write UTF-8 encoded files to
 the device file system.  Applications respond to `writestart`,
@@ -76,8 +72,7 @@ write to the end of the file.
 
 Text data is supported by all platforms listed below. Text is encoded as UTF-8 before being written to the filesystem. Some platforms also support binary data, which can be passed in as either an ArrayBuffer or a Blob.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 Text and Binary Support:
 
@@ -90,8 +85,7 @@ Text-only Support:
 - Windows Phone 7 and 8
 - Windows 8
 
-Seek Quick Example
-------------------------------
+## Seek Quick Example
 
     function win(writer) {
         // fast forwards file pointer to end of file
@@ -104,8 +98,7 @@ Seek Quick Example
 
     entry.createWriter(win, fail);
 
-Truncate Quick Example
---------------------------
+## Truncate Quick Example
 
     function win(writer) {
         writer.truncate(10);
@@ -117,8 +110,7 @@ Truncate Quick Example
 
     entry.createWriter(win, fail);
 
-Write Quick Example
--------------------
+## Write Quick Example
 
     function win(writer) {
         writer.onwrite = function(evt) {
@@ -133,8 +125,7 @@ Write Quick Example
 
     entry.createWriter(win, fail);
 
-Binary Write Quick Example
---------------------------
+## Binary Write Quick Example
 
     function win(writer) {
         var data = new ArrayBuffer(5),
@@ -154,8 +145,7 @@ Binary Write Quick Example
 
     entry.createWriter(win, fail);
 
-Append Quick Example
---------------------
+## Append Quick Example
 
     function win(writer) {
         writer.onwrite = function(evt) {
@@ -171,8 +161,7 @@ Append Quick Example
 
     entry.createWriter(win, fail);
 
-Abort Quick Example
--------------------
+## Abort Quick Example
 
     function win(writer) {
         writer.onwrite = function(evt) {
@@ -188,8 +177,8 @@ Abort Quick Example
 
     entry.createWriter(win, fail);
 
-Full Example
-------------
+## Full Example
+
     <!DOCTYPE html>
     <html>
       <head>

--- a/docs/en/edge/cordova/file/flags/flags.md
+++ b/docs/en/edge/cordova/file/flags/flags.md
@@ -17,22 +17,19 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-Flags
-=====
+# Flags
 
 Supplies arguments to the `DirectoryEntry` object's `getFile()` and
 `getDirectory()` methods, which look up or create files and
 directories, respectively.
 
-Properties
-----------
+## Properties
 
 - __create__: Indicates that the file or directory should be created if it does not already exist. _(boolean)_
 
 - __exclusive__: Has has no effect by itself, but when used with `create` causes the file or directory creation to fail if the target path already exists. _(boolean)_
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
@@ -40,8 +37,7 @@ Supported Platforms
 - Windows Phone 7 and 8
 - Windows 8
 
-Quick Example
--------------
+## Quick Example
 
     // Get the data directory, creating it if it doesn't exist.
     dataDir = fileSystem.root.getDirectory("data", {create: true});

--- a/docs/en/edge/cordova/file/localfilesystem/localfilesystem.md
+++ b/docs/en/edge/cordova/file/localfilesystem/localfilesystem.md
@@ -17,32 +17,27 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-LocalFileSystem
-===============
+# LocalFileSystem
 
 This object provides a way to obtain root file systems.
 
-Methods
-----------
+## Methods
 
 - __requestFileSystem__: Requests a filesystem. _(Function)_
 
 - __resolveLocalFileSystemURI__: Retrieve a `DirectoryEntry` or `FileEntry` using local URI. _(Function)_
 
-Constants
----------
+## Constants
 
 - `LocalFileSystem.PERSISTENT`: Used for storage that should not be removed by the user agent without application or user permission.
 
 - `LocalFileSystem.TEMPORARY`: Used for storage with no guarantee of persistence.
 
-Details
--------
+## Details
 
 The `LocalFileSystem` object methods are defined on the `window` object.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
@@ -50,8 +45,7 @@ Supported Platforms
 - Windows Phone 7 and 8
 - Windows 8
 
-Request File System Quick Example
----------------------------------
+## Request File System Quick Example
 
     function onSuccess(fileSystem) {
         console.log(fileSystem.name);
@@ -60,8 +54,7 @@ Request File System Quick Example
     // request the persistent file system
     window.requestFileSystem(LocalFileSystem.PERSISTENT, 0, onSuccess, onError);
 
-Resolve Local File System URI Quick Example
--------------------------------------------
+## Resolve Local File System URI Quick Example
 
     function onSuccess(fileEntry) {
         console.log(fileEntry.name);
@@ -69,8 +62,7 @@ Resolve Local File System URI Quick Example
 
     window.resolveLocalFileSystemURI("file:///example.txt", onSuccess, onError);
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>

--- a/docs/en/edge/cordova/file/metadata/metadata.md
+++ b/docs/en/edge/cordova/file/metadata/metadata.md
@@ -17,25 +17,21 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-Metadata
-==========
+# Metadata
 
 An interface that supplies information about the state of a file or directory.
 
-Properties
-----------
+## Properties
 
 - __modificationTime__: The time when the file or directory was last modified. _(Date)_
 
-Details
--------
+## Details
 
 The `Metadata` object represents information about the state of a file
 or directory.  Calling a `DirectoryEntry` or `FileEntry` object's
 `getMetadata()` method results in a `Metadata` instance.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
@@ -43,8 +39,7 @@ Supported Platforms
 - Windows Phone 7 and 8
 - Windows 8
 
-Quick Example
--------------
+## Quick Example
 
     function win(metadata) {
         console.log("Last Modified: " + metadata.modificationTime);

--- a/docs/en/edge/cordova/geolocation/Coordinates/coordinates.md
+++ b/docs/en/edge/cordova/geolocation/Coordinates/coordinates.md
@@ -17,13 +17,11 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-Coordinates
-===========
+# Coordinates
 
 A set of properties that describe the geographic coordinates of a position.
 
-Properties
-----------
+## Properties
 
 * __latitude__: Latitude in decimal degrees. _(Number)_
 
@@ -39,14 +37,12 @@ Properties
 
 * __speed__: Current ground speed of the device, specified in meters per second. _(Number)_
 
-Description
------------
+## Description
 
 The `Coordinates` object is attached to the `Position` object that is
 available to callback functions in requests for the current position.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
@@ -55,8 +51,7 @@ Supported Platforms
 - Windows Phone 7 and 8
 - Windows 8
 
-Quick Example
--------------
+## Quick Example
 
     // onSuccess Callback
     //
@@ -79,8 +74,7 @@ Quick Example
 
     navigator.geolocation.getCurrentPosition(onSuccess, onError);
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>
@@ -126,7 +120,6 @@ Full Example
       </body>
     </html>
 
-Android Quirks
--------------
+## Android Quirks
 
 __altitudeAccuracy__: Not supported by Android devices, returning `null`.

--- a/docs/en/edge/cordova/geolocation/Position/position.md
+++ b/docs/en/edge/cordova/geolocation/Position/position.md
@@ -17,25 +17,21 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-Position
-========
+# Position
 
 Contains `Position` coordinates and timestamp, created by the geolocation API.
 
-Properties
-----------
+## Properties
 
 - __coords__: A set of geographic coordinates. _(Coordinates)_
 
 - __timestamp__: Creation timestamp for `coords`. _(Date)_
 
-Description
------------
+## Description
 
 The `Position` object is created and populated by Cordova, and returned to the user through a callback function.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
@@ -44,8 +40,7 @@ Supported Platforms
 - Windows Phone 7 and 8
 - Windows 8
 
-Quick Example
--------------
+## Quick Example
 
     // onSuccess Callback
     //
@@ -69,8 +64,7 @@ Quick Example
 
     navigator.geolocation.getCurrentPosition(onSuccess, onError);
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>

--- a/docs/en/edge/cordova/geolocation/PositionError/positionError.md
+++ b/docs/en/edge/cordova/geolocation/PositionError/positionError.md
@@ -17,27 +17,23 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-PositionError
-========
+# PositionError
 
 A `PositionError` object is passed to the `geolocationError` callback when an error occurs.
 
-Properties
-----------
+## Properties
 
 - __code__: One of the predefined error codes listed below.
 
 - __message__: Error message describing the details of the error encountered.
 
-Constants
----------
+## Constants
 
 - `PositionError.PERMISSION_DENIED`
 - `PositionError.POSITION_UNAVAILABLE`
 - `PositionError.TIMEOUT`
 
-Description
------------
+## Description
 
 The `PositionError` object is passed to the `geolocationError`
 callback function when an error occurs with geolocation.

--- a/docs/en/edge/cordova/geolocation/geolocation.clearWatch.md
+++ b/docs/en/edge/cordova/geolocation/geolocation.clearWatch.md
@@ -17,28 +17,24 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-geolocation.clearWatch
-======================
+# geolocation.clearWatch
 
 Stop watching for changes to the device's location referenced by the
 `watchID` parameter.
 
     navigator.geolocation.clearWatch(watchID);
 
-Parameters
-----------
+## Parameters
 
 - __watchID__: The id of the `watchPosition` interval to clear. (String)
 
-Description
------------
+## Description
 
 The `geolocation.clearWatch` stops watching changes to the device's
 location by clearing the `geolocation.watchPosition` referenced by
 `watchID`.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
@@ -47,8 +43,7 @@ Supported Platforms
 - Windows Phone 7 and 8
 - Windows 8
 
-Quick Example
--------------
+## Quick Example
 
     // Options: watch for changes in position, and use the most
     // accurate position acquisition method available.
@@ -59,8 +54,7 @@ Quick Example
 
     navigator.geolocation.clearWatch(watchID);
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>

--- a/docs/en/edge/cordova/geolocation/geolocation.getCurrentPosition.md
+++ b/docs/en/edge/cordova/geolocation/geolocation.getCurrentPosition.md
@@ -17,8 +17,7 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-geolocation.getCurrentPosition
-==============================
+# geolocation.getCurrentPosition
 
 Returns the device's current position as a `Position` object.
 
@@ -26,8 +25,7 @@ Returns the device's current position as a `Position` object.
                                              [geolocationError],
                                              [geolocationOptions]);
 
-Parameters
-----------
+## Parameters
 
 - __geolocationSuccess__: The callback that is passed the current position.
 
@@ -35,8 +33,7 @@ Parameters
 
 - __geolocationOptions__: _(Optional)_ The geolocation options.
 
-Description
------------
+## Description
 
 `geolocation.getCurrentPosition` is an asynchronous function. It
 returns the device's current position to the `geolocationSuccess`
@@ -44,8 +41,7 @@ callback with a `Position` object as the parameter.  If there is an
 error, the `geolocationError` callback is passed a
 `PositionError` object.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
@@ -54,8 +50,7 @@ Supported Platforms
 - Windows Phone 7 and 8
 - Windows 8
 
-Quick Example
--------------
+## Quick Example
 
     // onSuccess Callback
     // This method accepts a Position object, which contains the
@@ -81,8 +76,7 @@ Quick Example
 
     navigator.geolocation.getCurrentPosition(onSuccess, onError);
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>

--- a/docs/en/edge/cordova/geolocation/geolocation.md
+++ b/docs/en/edge/cordova/geolocation/geolocation.md
@@ -17,8 +17,7 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-Geolocation
-===========
+# Geolocation
 
 > The `geolocation` object provides access to location data based on the device's GPS sensor or inferred from network signals.
 
@@ -35,22 +34,19 @@ and only executes on devices that don't already provide an implementation.
 
 **Important privacy note:** Collection and use of geolocation data raises important privacy issues.  Your app's privacy policy should discuss how the app uses geolocation data, whether it is shared with any other parties, and the level of precision of the data (for example, coarse, fine, ZIP code level, etc.).  Geolocation data is generally considered sensitive because it can reveal a person's whereabouts and, if stored, the history of his or her travels.  Therefore, in addition to your app's privacy policy, you should strongly consider providing a just-in-time notice prior to your app accessing geolocation data (if the device operating system doesn't do so already).  That notice should provide the same information noted above, as well as obtaining the user's permission (e.g., by presenting choices for "OK" and "No Thanks").  For more information, please see the Privacy Guide.
 
-Methods
--------
+## Methods
 
 - geolocation.getCurrentPosition
 - geolocation.watchPosition
 - geolocation.clearWatch
 
-Arguments
----------
+## Arguments
 
 - geolocationSuccess
 - geolocationError
 - geolocationOptions
 
-Objects (Read-Only)
--------------------
+## Objects (Read-Only)
 
 - Position
 - PositionError

--- a/docs/en/edge/cordova/geolocation/geolocation.watchPosition.md
+++ b/docs/en/edge/cordova/geolocation/geolocation.watchPosition.md
@@ -17,8 +17,7 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-geolocation.watchPosition
-=========================
+# geolocation.watchPosition
 
 Watches for changes to the device's current position.
 
@@ -26,8 +25,7 @@ Watches for changes to the device's current position.
                                                       [geolocationError],
                                                       [geolocationOptions]);
 
-Parameters
-----------
+## Parameters
 
 - __geolocationSuccess__: The callback that is passed the current position.
 
@@ -35,13 +33,11 @@ Parameters
 
 - __geolocationOptions__: (Optional) The geolocation options.
 
-Returns
--------
+## Returns
 
 - __String__: returns a watch id that references the watch position interval. The watch id should be used with `geolocation.clearWatch` to stop watching for changes in position.
 
-Description
------------
+## Description
 
 `geolocation.watchPosition` is an asynchronous function. It returns
 the device's current position when a change in position is detected.
@@ -50,8 +46,7 @@ callback executes with a `Position` object as the parameter.  If
 there is an error, the `geolocationError` callback executes with a
 `PositionError` object as the parameter.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
@@ -60,8 +55,7 @@ Supported Platforms
 - Windows Phone 7 and 8
 - Windows 8
 
-Quick Example
--------------
+## Quick Example
 
     // onSuccess Callback
     //   This method accepts a `Position` object, which contains
@@ -85,8 +79,7 @@ Quick Example
     //
     var watchID = navigator.geolocation.watchPosition(onSuccess, onError, { timeout: 30000 });
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>

--- a/docs/en/edge/cordova/geolocation/parameters/geolocation.options.md
+++ b/docs/en/edge/cordova/geolocation/parameters/geolocation.options.md
@@ -17,16 +17,14 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-geolocationOptions
-==================
+# geolocationOptions
 
 Optional parameters to customize the retrieval of the geolocation
 `Position`.
 
     { maximumAge: 3000, timeout: 5000, enableHighAccuracy: true };
 
-Options
--------
+## Options
 
 - __enableHighAccuracy__: Provides a hint that the application needs the best possible results. By default, the device attempts to retrieve a `Position` using network-based methods. Setting this property to `true` tells the framework to use more accurate methods, such as satellite positioning. _(Boolean)_
 
@@ -34,8 +32,7 @@ Options
 
 - __maximumAge__: Accept a cached position whose age is no greater than the specified time in milliseconds. _(Number)_
 
-Android Quirks
---------------
+## Android Quirks
 
 Android 2.x emulators do not return a geolocation result unless the `enableHighAccuracy` option is set to `true`.
 

--- a/docs/en/edge/cordova/geolocation/parameters/geolocationError.md
+++ b/docs/en/edge/cordova/geolocation/parameters/geolocationError.md
@@ -17,8 +17,7 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-geolocationError
-================
+# geolocationError
 
 The user's callback function that executes when there is an error for
 geolocation functions.
@@ -27,7 +26,6 @@ geolocation functions.
         // Handle the error
     }
 
-Parameters
-----------
+## Parameters
 
 - __error__: The error returned by the device. _(PositionError)_

--- a/docs/en/edge/cordova/geolocation/parameters/geolocationSuccess.md
+++ b/docs/en/edge/cordova/geolocation/parameters/geolocationSuccess.md
@@ -17,8 +17,7 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-geolocationSuccess
-==================
+# geolocationSuccess
 
 The user's callback function that executes when a geolocation position
 becomes available (when called from `geolocation.getCurrentPosition`),
@@ -29,13 +28,11 @@ or when the position changes (when called from
         // Do something
     }
 
-Parameters
-----------
+## Parameters
 
 - __position__: The geolocation position returned by the device. _(Position)_
 
-Example
--------
+## Example
 
     function geolocationSuccess(position) {
         alert('Latitude: '          + position.coords.latitude          + '\n' +

--- a/docs/en/edge/cordova/globalization/GlobalizationError/globalizationerror.md
+++ b/docs/en/edge/cordova/globalization/GlobalizationError/globalizationerror.md
@@ -17,13 +17,11 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-GlobalizationError
-============
+# GlobalizationError
 
 An object representing a error from the Globalization API.
 
-Properties
-----------
+## Properties
 
 - __code__:  One of the following codes representing the error type _(Number)_
   - GlobalizationError.UNKNOWN\_ERROR: 0
@@ -32,20 +30,17 @@ Properties
   - GlobalizationError.PATTERN\_ERROR: 3
 - __message__:  A text message that includes the error's explanation and/or details _(String)_
 
-Description
------------
+## Description
 
 This object is created and populated by Cordova, and returned to a callback in the case of an error.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
 - iOS
 
-Quick Example
--------------
+## Quick Example
 
 When the following error callback executes, it displays a
 popup dialog with the text similar to `code: 3` and `message:`
@@ -55,8 +50,7 @@ popup dialog with the text similar to `code: 3` and `message:`
               'message: ' + error.message + '\n');
     };
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE HTML>
     <html>

--- a/docs/en/edge/cordova/globalization/globalization.dateToString.md
+++ b/docs/en/edge/cordova/globalization/globalization.dateToString.md
@@ -17,15 +17,13 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-globalization.dateToString
-===========
+# globalization.dateToString
 
 Returns a date formatted as a string according to the client's locale and timezone.
 
     navigator.globalization.dateToString(date, successCallback, errorCallback, options);
 
-Description
------------
+## Description
 
 Returns the formatted date `String` via a `value` property accessible
 from the object passed as a parameter to the `successCallback`.
@@ -44,16 +42,14 @@ The `options.formatLength` can be `short`, `medium`, `long`, or `full`.
 
 The `options.selector` can be `date`, `time` or `date and time`.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
 - iOS
 - Windows Phone 8
 
-Quick Example
--------------
+## Quick Example
 
 If the browser is set to the `en\_US` locale, this displays a popup
 dialog with text similar to `date: 9/25/2012 4:21PM` using the default
@@ -66,8 +62,7 @@ options:
         { formatLength: 'short', selector: 'date and time' }
     );
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE HTML>
     <html>
@@ -91,7 +86,6 @@ Full Example
       </body>
     </html>
 
-Windows Phone 8 Quirks
---------------
+## Windows Phone 8 Quirks
 
 - The `formatLength` option supports only `short` and `full` values.

--- a/docs/en/edge/cordova/globalization/globalization.getCurrencyPattern.md
+++ b/docs/en/edge/cordova/globalization/globalization.getCurrencyPattern.md
@@ -17,16 +17,14 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-globalization.getCurrencyPattern
-===========
+# globalization.getCurrencyPattern
 
 Returns a pattern string to format and parse currency values according
 to the client's user preferences and ISO 4217 currency code.
 
      navigator.globalization.getCurrencyPattern(currencyCode, successCallback, errorCallback);
 
-Description
------------
+## Description
 
 Returns the pattern to the `successCallback` with a `properties` object
 as a parameter. That object should contain the following properties:
@@ -50,15 +48,13 @@ If there is an error obtaining the pattern, then the `errorCallback`
 executes with a `GlobalizationError` object as a parameter. The
 error's expected code is `GlobalizationError.FORMATTING\_ERROR`.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
 - iOS
 
-Quick Example
--------------
+## Quick Example
 
 When the browser is set to the `en\_US` locale and the selected
 currency is United States Dollars, this example displays a popup
@@ -86,8 +82,7 @@ Expected result:
     decimal: .
     grouping: ,
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE HTML>
     <html>

--- a/docs/en/edge/cordova/globalization/globalization.getDateNames.md
+++ b/docs/en/edge/cordova/globalization/globalization.getDateNames.md
@@ -17,16 +17,14 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-globalization.getDateNames
-===========
+# globalization.getDateNames
 
 Returns an array of the names of the months or days of the week,
 depending on the client's user preferences and calendar.
 
     navigator.globalization.getDateNames(successCallback, errorCallback, options);
 
-Description
------------
+## Description
 
 Returns the array of names to the `successCallback` with a
 `properties` object as a parameter. That object contains a `value`
@@ -46,16 +44,14 @@ The value of `options.type` can be `narrow` or `wide`.
 
 The value of `options.item` can be `months` or `days`.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
 - iOS
 - Windows Phone 8
 
-Quick Example
--------------
+## Quick Example
 
 When the browser is set to the `en\_US` locale, this example displays
 a series of twelve popup dialogs, one per month, with text similar to
@@ -71,8 +67,7 @@ a series of twelve popup dialogs, one per month, with text similar to
         { type: 'wide', item: 'months' }
     );
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE HTML>
     <html>

--- a/docs/en/edge/cordova/globalization/globalization.getDatePattern.md
+++ b/docs/en/edge/cordova/globalization/globalization.getDatePattern.md
@@ -17,16 +17,14 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-globalization.getDatePattern
-===========
+# globalization.getDatePattern
 
 Returns a pattern string to format and parse dates according to the
 client's user preferences.
 
     navigator.globalization.getDatePattern(successCallback, errorCallback, options);
 
-Description
------------
+## Description
 
 Returns the pattern to the `successCallback`. The object passed in as
 a parameter contains the following properties:
@@ -51,16 +49,14 @@ The `options.formatLength` can be `short`, `medium`, `long`, or
 `full`.  The `options.selector` can be `date`, `time` or `date and
 time`.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
 - iOS
 - Windows Phone 8
 
-Quick Example
--------------
+## Quick Example
 
 When the browser is set to the `en\_US` locale, this example displays
 a popup dialog with text such as `pattern: M/d/yyyy h:mm a`:
@@ -73,8 +69,7 @@ a popup dialog with text such as `pattern: M/d/yyyy h:mm a`:
         );
     }
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE HTML>
     <html>
@@ -98,8 +93,7 @@ Full Example
       </body>
     </html>
 
-Windows Phone 8 Quirks
---------------
+## Windows Phone 8 Quirks
 
 - The `formatLength` supports only `short` and `full` values.
 

--- a/docs/en/edge/cordova/globalization/globalization.getFirstDayOfWeek.md
+++ b/docs/en/edge/cordova/globalization/globalization.getFirstDayOfWeek.md
@@ -17,16 +17,14 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-globalization.getFirstDayOfWeek
-===========
+# globalization.getFirstDayOfWeek
 
 Returns the first day of the week according to the client's user
 preferences and calendar.
 
     navigator.globalization.getFirstDayOfWeek(successCallback, errorCallback);
 
-Description
------------
+## Description
 
 The days of the week are numbered starting from 1, where 1 is assumed
 to be Sunday.  Returns the day to the `successCallback` with a
@@ -37,16 +35,14 @@ If there is an error obtaining the pattern, then the `errorCallback`
 executes with a `GlobalizationError` object as a parameter. The
 error's expected code is `GlobalizationError.UNKNOWN\_ERROR`.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
 - iOS
 - Windows Phone 8
 
-Quick Example
--------------
+## Quick Example
 
 When the browser is set to the `en\_US` locale, this displays a
 popup dialog with text similar to `day: 1`.
@@ -56,8 +52,7 @@ popup dialog with text similar to `day: 1`.
         function () {alert('Error getting day\n');}
     );
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE HTML>
     <html>

--- a/docs/en/edge/cordova/globalization/globalization.getLocaleName.md
+++ b/docs/en/edge/cordova/globalization/globalization.getLocaleName.md
@@ -17,15 +17,13 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-globalization.getLocaleName
-===========
+# globalization.getLocaleName
 
 Get the string identifier for the client's current locale setting.
 
     navigator.globalization.getLocaleName(successCallback, errorCallback);
 
-Description
------------
+## Description
 
 Returns the locale identifier string to the `successCallback` with a
 `properties` object as a parameter. That object should have a `value`
@@ -35,16 +33,14 @@ If there is an error getting the locale, then the `errorCallback`
 executes with a `GlobalizationError` object as a parameter. The
 error's expected code is `GlobalizationError.UNKNOWN\_ERROR`.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
 - iOS
 - Windows Phone 8
 
-Quick Example
--------------
+## Quick Example
 
 When the browser is set to the `en\_US` locale, this displays a popup
 dialog with the text `locale: en\_US`.
@@ -54,8 +50,7 @@ dialog with the text `locale: en\_US`.
         function () {alert('Error getting locale\n');}
     );
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE HTML>
     <html>
@@ -77,7 +72,6 @@ Full Example
       </body>
     </html>
 
-Windows Phone 8 Quirks
----------------------
+## Windows Phone 8 Quirks
 
 - Returns the two-letter code defined in ISO 3166 for the current country/region.

--- a/docs/en/edge/cordova/globalization/globalization.getNumberPattern.md
+++ b/docs/en/edge/cordova/globalization/globalization.getNumberPattern.md
@@ -17,15 +17,13 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-globalization.getNumberPattern
-===========
+# globalization.getNumberPattern
 
 Returns a pattern string to format and parse numbers according to the client's user preferences.
 
     navigator.globalization.getNumberPattern(successCallback, errorCallback, options);
 
-Description
------------
+## Description
 
 Returns the pattern to the `successCallback` with a `properties` object
 as a parameter. That object contains the following properties:
@@ -56,16 +54,14 @@ The `options` parameter is optional, and default values are:
 
 The `options.type` can be `decimal`, `percent`, or `currency`.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
 - iOS
 - Windows Phone 8
 
-Quick Example
--------------
+## Quick Example
 
 When the browser is set to the `en\_US` locale, this should display a
 popup dialog with text similar to the results that follow:
@@ -94,8 +90,7 @@ Results:
     decimal: .
     grouping: ,
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE HTML>
     <html>
@@ -126,8 +121,7 @@ Full Example
       </body>
     </html>
 
-Windows Phone 8 Quirks
-----------------
+## Windows Phone 8 Quirks
 
 - The `pattern` property is not supported, and retuens an empty string.
 

--- a/docs/en/edge/cordova/globalization/globalization.getPreferredLanguage.md
+++ b/docs/en/edge/cordova/globalization/globalization.getPreferredLanguage.md
@@ -17,15 +17,13 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-globalization.getPreferredLanguage
-===========
+# globalization.getPreferredLanguage
 
 Get the string identifier for the client's current language.
 
     navigator.globalization.getPreferredLanguage(successCallback, errorCallback);
 
-Description
------------
+## Description
 
 Returns the language identifier string to the `successCallback` with a
 `properties` object as a parameter. That object should have a `value`
@@ -35,16 +33,14 @@ If there is an error getting the language, then the `errorCallback`
 executes with a `GlobalizationError` object as a parameter. The
 error's expected code is `GlobalizationError.UNKNOWN\_ERROR`.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
 - iOS
 - Windows Phone 8
 
-Quick Example
--------------
+## Quick Example
 
 When the browser is set to the `en\_US` locale, this should display a
 popup dialog with the text `language: English`:
@@ -54,8 +50,7 @@ popup dialog with the text `language: English`:
         function () {alert('Error getting language\n');}
     );
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE HTML>
     <html>
@@ -77,7 +72,6 @@ Full Example
       </body>
     </html>
 
-Windows Phone 8 Quirks
--------
+## Windows Phone 8 Quirks
 
 - Returns the ISO 639-1 two-letter code for the current language.

--- a/docs/en/edge/cordova/globalization/globalization.isDayLightSavingsTime.md
+++ b/docs/en/edge/cordova/globalization/globalization.isDayLightSavingsTime.md
@@ -17,16 +17,14 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-globalization.isDayLightSavingsTime
-===========
+# globalization.isDayLightSavingsTime
 
 Indicates whether daylight savings time is in effect for a given date
 using the client's time zone and calendar.
 
     navigator.globalization.isDayLightSavingsTime(date, successCallback, errorCallback);
 
-Description
------------
+## Description
 
 Indicates whether or not daylight savings time is in effect to the
 `successCallback` with a `properties` object as a parameter. That object
@@ -39,16 +37,14 @@ The inbound parameter `date` should be of type `Date`.
 If there is an error reading the date, then the `errorCallback`
 executes. The error's expected code is `GlobalizationError.UNKNOWN\_ERROR`.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
 - iOS
 - Windows Phone 8
 
-Quick Example
--------------
+## Quick Example
 
 During the summer, and if the browser is set to a DST-enabled
 timezone, this should display a popup dialog with text similar to
@@ -60,8 +56,7 @@ timezone, this should display a popup dialog with text similar to
         function () {alert('Error getting names\n');}
     );
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE HTML>
     <html>

--- a/docs/en/edge/cordova/globalization/globalization.md
+++ b/docs/en/edge/cordova/globalization/globalization.md
@@ -17,19 +17,16 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-Globalization
-======
+# Globalization
 
 Obtains information and performs operations specific to the user's
 locale and timezone.
 
-Objects
--------
+## Objects
 
 - GlobalizationError
 
-Methods
--------
+## Methods
 
 - globalization.getPreferredLanguage
 - globalization.getLocaleName
@@ -44,8 +41,7 @@ Methods
 - globalization.getNumberPattern
 - globalization.getCurrencyPattern
 
-Variable Scope
---------------
+## Variable Scope
 
 The `globalization` object is a child of the `navigator` object, and
 therefore has global scope.

--- a/docs/en/edge/cordova/globalization/globalization.numberToString.md
+++ b/docs/en/edge/cordova/globalization/globalization.numberToString.md
@@ -17,15 +17,13 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-globalization.numberToString
-===========
+# globalization.numberToString
 
 Returns a number formatted as a string according to the client's user preferences.
 
     navigator.globalization.numberToString(number, successCallback, errorCallback, options);
 
-Description
------------
+## Description
 
 Returns the formatted number string to the `successCallback` with a
 `properties` object as a parameter. That object should have a `value`
@@ -41,16 +39,14 @@ The `options` parameter is optional, and its default values are:
 
 The `options.type` can be 'decimal', 'percent', or 'currency'.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
 - iOS
 - Windows Phone 8
 
-Quick Example
--------------
+## Quick Example
 
 When the browser is set to the `en\_US` locale, this displays a popup
 dialog with text similar to `number: 3.142`:
@@ -62,8 +58,7 @@ dialog with text similar to `number: 3.142`:
         {type:'decimal'}
     );
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE HTML>
     <html>

--- a/docs/en/edge/cordova/globalization/globalization.stringToDate.md
+++ b/docs/en/edge/cordova/globalization/globalization.stringToDate.md
@@ -17,8 +17,7 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-globalization.stringToDate
-===========
+# globalization.stringToDate
 
 Parses a date formatted as a string, according to the client's user
 preferences and calendar using the time zone of the client, and
@@ -26,8 +25,7 @@ returns the corresponding date object.
 
     navigator.globalization.stringToDate(dateString, successCallback, errorCallback, options);
 
-Description
------------
+## Description
 
 Returns the date to the success callback with a `properties` object as
 a parameter. That object should have the following properties:
@@ -61,16 +59,14 @@ If there is an error parsing the date string, then the `errorCallback`
 executes with a `GlobalizationError` object as a parameter. The
 error's expected code is `GlobalizationError.PARSING\_ERROR`.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
 - iOS
 - Windows Phone 8
 
-Quick Example
--------------
+## Quick Example
 
 When the browser is set to the `en\_US` locale, this displays a
 popup dialog with text similar to `month:8 day:25 year:2012`. Note
@@ -86,8 +82,7 @@ integer represents an array index.
         {selector: 'date'}
     );
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE HTML>
     <html>
@@ -114,7 +109,6 @@ Full Example
       </body>
     </html>
 
-Windows Phone 8 Quirks
-------------------
+## Windows Phone 8 Quirks
 
 - The `formatLength` option supports only `short` and `full` values.

--- a/docs/en/edge/cordova/globalization/globalization.stringToNumber.md
+++ b/docs/en/edge/cordova/globalization/globalization.stringToNumber.md
@@ -17,16 +17,14 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-globalization.stringToNumber
-===========
+# globalization.stringToNumber
 
 Parses a number formatted as a string according to the client's user
 preferences and returns the corresponding number.
 
     navigator.globalization.stringToNumber(string, successCallback, errorCallback, options);
 
-Description
------------
+## Description
 
 Returns the number to the `successCallback` with a `properties` object
 as a parameter. That object should have a `value` property with a
@@ -44,16 +42,14 @@ values:
 
 The `options.type` can be `decimal`, `percent`, or `currency`.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
 - iOS
 - Windows Phone 8
 
-Quick Example
--------------
+## Quick Example
 
 When the browser is set to the `en\_US` locale, this should display a
 popup dialog with text similar to `number: 1234.56`:
@@ -65,8 +61,7 @@ popup dialog with text similar to `number: 1234.56`:
         {type:'decimal'}
     );
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE HTML>
     <html>

--- a/docs/en/edge/cordova/inappbrowser/inappbrowser.md
+++ b/docs/en/edge/cordova/inappbrowser/inappbrowser.md
@@ -17,20 +17,17 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-InAppBrowser
-============
+# InAppBrowser
 
 > The `InAppBrowser` is a web browser that displays in the app when calling `window.open`.
 
     var ref = window.open('http://apache.org', '_blank', 'location=yes');
 
-Description
------------
+## Description
 
 The object returned from a call to `window.open`.
 
-Methods
-----------
+## Methods
 
 - addEventListener
 - removeEventListener
@@ -70,8 +67,7 @@ platform-specific configuration settings described below:
 Some platforms may support this feature without requiring any special
 configuration.  See Platform Support for an overview.
 
-addEventListener
-================
+# addEventListener
 
 > Adds a listener for an event from the `InAppBrowser`.
 
@@ -88,22 +84,19 @@ addEventListener
 
 - __callback__: the function that executes when the event fires. The function is passed an `InAppBrowserEvent` object as a parameter.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry
 - iOS
 - Windows Phone 7 and 8
 
-Quick Example
--------------
+## Quick Example
 
     var ref = window.open('http://apache.org', '_blank', 'location=yes');
     ref.addEventListener('loadstart', function() { alert(event.url); });
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>
@@ -133,8 +126,7 @@ Full Example
       </body>
     </html>
 
-removeEventListener
-===================
+# removeEventListener
 
 > Removes a listener for an event from the `InAppBrowser`.
 
@@ -152,24 +144,21 @@ removeEventListener
 - __callback__: the function to execute when the event fires.
 The function is passed an `InAppBrowserEvent` object.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry
 - iOS
 - Windows Phone 7 and 8
 
-Quick Example
--------------
+## Quick Example
 
     var ref = window.open('http://apache.org', '_blank', 'location=yes');
     var myCallback = function() { alert(event.url); }
     ref.addEventListener('loadstart', myCallback);
     ref.removeEventListener('loadstart', myCallback);
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>
@@ -222,8 +211,7 @@ Full Example
       </body>
     </html>
 
-close
-=====
+# close
 
 > Closes the `InAppBrowser` window.
 
@@ -231,22 +219,19 @@ close
 
 - __ref__: reference to the `InAppBrowser` window _(InAppBrowser)_
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry
 - iOS
 - Windows Phone 7 and 8
 
-Quick Example
--------------
+## Quick Example
 
     var ref = window.open('http://apache.org', '_blank', 'location=yes');
     ref.close();
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>
@@ -276,8 +261,7 @@ Full Example
       </body>
     </html>
 
-show
-=====
+# show
 
 > Displays an InAppBrowser window that was opened hidden. Calling this has no effect if the InAppBrowser was already visible.
 
@@ -285,21 +269,18 @@ show
 
 - __ref:__ reference to the InAppBrowser window (`InAppBrowser`)
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry
 - iOS
 
-Quick Example
--------------
+## Quick Example
 
     var ref = window.open('http://apache.org', '_blank', 'hidden=yes');
     ref.show();
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>
@@ -332,8 +313,7 @@ Full Example
       </body>
     </html>
 
-executeScript
-=============
+# executeScript
 
 > Injects JavaScript code into the `InAppBrowser` window
 
@@ -352,23 +332,20 @@ executeScript
       the return value of the last statement, or the last expression
       evaluated.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry
 - iOS
 
-Quick Example
--------------
+## Quick Example
 
     var ref = window.open('http://apache.org', '_blank', 'location=yes');
     ref.addEventListener('loadstop', function() {
         ref.executeSript({file: "myscript.js"});
     });
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>
@@ -414,8 +391,7 @@ Full Example
       </body>
     </html>
 
-insertCSS
-=========
+# insertCSS
 
 > Injects CSS into the `InAppBrowser` window.
 
@@ -429,23 +405,20 @@ insertCSS
 
 - __callback__: the function that executes after the CSS is injected.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry
 - iOS
 
-Quick Example
--------------
+## Quick Example
 
     var ref = window.open('http://apache.org', '_blank', 'location=yes');
     ref.addEventListener('loadstop', function() {
         ref.insertCSS({file: "mystyles.css"});
     });
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>
@@ -491,14 +464,12 @@ Full Example
       </body>
     </html>
 
-InAppBrowserEvent
-=================
+# InAppBrowserEvent
 
 The object that is passed to the callback function from an
 `addEventListener` call on an `InAppBrowser` object.
 
-Properties
-----------
+## Properties
 
 - __type__: the eventname, either `loadstart`, `loadstop`, `loaderror`, or `exit`. _(String)_
 

--- a/docs/en/edge/cordova/inappbrowser/window.open.md
+++ b/docs/en/edge/cordova/inappbrowser/window.open.md
@@ -17,8 +17,7 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-window.open
-===========
+# window.open
 
 Opens a URL in a new `InAppBrowser` instance, the current browser
 instance, or the system browser.
@@ -61,22 +60,19 @@ instance, or the system browser.
     - __presentationstyle__:  Set to `pagesheet`, `formsheet` or `fullscreen` to set the [presentation style](http://developer.apple.com/library/ios/documentation/UIKit/Reference/UIViewController_Class/Reference/Reference.html#//apple_ref/occ/instp/UIViewController/modalPresentationStyle) (defaults to `fullscreen`).
     - __transitionstyle__: Set to `fliphorizontal`, `crossdissolve` or `coververtical` to set the [transition style](http://developer.apple.com/library/ios/#documentation/UIKit/Reference/UIViewController_Class/Reference/Reference.html#//apple_ref/occ/instp/UIViewController/modalTransitionStyle) (defaults to `coververtical`).
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry
 - iOS
 - Windows Phone 7 and 8
 
-Quick Example
--------------
+## Quick Example
 
     var ref = window.open('http://apache.org', '_blank', 'location=yes');
     var ref2 = window.open(encodeURI('http://ja.m.wikipedia.org/wiki/ハングル'), '_blank', 'location=yes');
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>

--- a/docs/en/edge/cordova/media/MediaError/mediaError.md
+++ b/docs/en/edge/cordova/media/MediaError/mediaError.md
@@ -17,29 +17,25 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-MediaError
-==========
+# MediaError
 
 A `MediaError` object is returned to the `mediaError` callback
 function when an error occurs.
 
-Properties
-----------
+## Properties
 
 - __code__: One of the predefined error codes listed below.
 
 - __message__: An error message describing the details of the error.
 
-Constants
----------
+## Constants
 
 - `MediaError.MEDIA_ERR_ABORTED`
 - `MediaError.MEDIA_ERR_NETWORK`
 - `MediaError.MEDIA_ERR_DECODE`
 - `MediaError.MEDIA_ERR_NONE_SUPPORTED`
 
-Description
------------
+## Description
 
 The `MediaError` object is passed to a `mediaError` callback function
 when an error occurs.

--- a/docs/en/edge/cordova/media/Parameters/mediaError.md
+++ b/docs/en/edge/cordova/media/Parameters/mediaError.md
@@ -17,8 +17,7 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-mediaError
-==========
+# mediaError
 
 A user-specified callback function that executes when there is an
 error in media functions.
@@ -27,7 +26,6 @@ error in media functions.
         // Handle the error
     }
 
-Parameters
-----------
+## Parameters
 
 - __error__: The error returned by the device. _(MediaError)_

--- a/docs/en/edge/cordova/media/capture/CaptureCB.md
+++ b/docs/en/edge/cordova/media/capture/CaptureCB.md
@@ -17,15 +17,13 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-CaptureCB
-=========
+# CaptureCB
 
 > Invoked upon a successful media capture operation.
 
     function captureSuccess( MediaFile[] mediaFiles ) { ... };
 
-Description
------------
+## Description
 
 This function executes after a successful capture operation completes.
 At this point a media file has been captured, and either the user has
@@ -34,8 +32,7 @@ reached.
 
 Each `MediaFile` object describes a captured media file.
 
-Quick Example
--------------
+## Quick Example
 
     // capture callback
     function captureSuccess(mediaFiles) {

--- a/docs/en/edge/cordova/media/capture/CaptureError.md
+++ b/docs/en/edge/cordova/media/capture/CaptureError.md
@@ -17,18 +17,15 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-CaptureError
-============
+# CaptureError
 
 > Encapsulates the error code resulting from a failed media capture operation.
 
-Properties
-----------
+## Properties
 
 - __code__: One of the pre-defined error codes listed below.
 
-Constants
----------
+## Constants
 
 - `CaptureError.CAPTURE_INTERNAL_ERR`: The camera or microphone failed to capture image or sound.
 

--- a/docs/en/edge/cordova/media/capture/CaptureErrorCB.md
+++ b/docs/en/edge/cordova/media/capture/CaptureErrorCB.md
@@ -17,15 +17,13 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-CaptureErrorCB
-==============
+# CaptureErrorCB
 
 > Invoked if an error occurs during a media capture operation.
 
     function captureError( CaptureError error ) { ... };
 
-Description
------------
+## Description
 
 This function executes if an error occurs when trying to launch a
 media capture operation. Failure scenarios include when the capture
@@ -35,8 +33,7 @@ the user cancels the operation before any media files are captured.
 This function executes with a `CaptureError` object containing an
 appropriate error `code`.
 
-Quick Example
--------------
+## Quick Example
 
     // capture error callback
     var captureError = function(error) {

--- a/docs/en/edge/cordova/media/capture/ConfigurationData.md
+++ b/docs/en/edge/cordova/media/capture/ConfigurationData.md
@@ -17,13 +17,11 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-ConfigurationData
-=================
+# ConfigurationData
 
 > Encapsulates a set of media capture parameters that a device supports.
 
-Description
------------
+## Description
 
 Describes media capture modes supported by the device.  The
 configuration data includes the MIME type, and capture dimensions for
@@ -37,8 +35,7 @@ The MIME types should adhere to [RFC2046](http://www.ietf.org/rfc/rfc2046.txt). 
 - `audio/amr`
 - `audio/wav`
 
-Properties
-----------
+## Properties
 
 - __type__: The ASCII-encoded lowercase string representing the media type. (DOMString)
 
@@ -46,8 +43,7 @@ Properties
 
 - __width__: The width of the image or video in pixels.  The value is zero for sound clips. (Number)
 
-Quick Example
--------------
+## Quick Example
 
     // retrieve supported image modes
     var imageModes = navigator.device.capture.supportedImageModes;

--- a/docs/en/edge/cordova/media/capture/MediaFile.getFormatData.md
+++ b/docs/en/edge/cordova/media/capture/MediaFile.getFormatData.md
@@ -17,8 +17,7 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-MediaFile.getFormatData
-=======================
+# MediaFile.getFormatData
 
 > Retrieves format information about the media capture file.
 
@@ -27,8 +26,7 @@ MediaFile.getFormatData
         [MediaFileDataErrorCB errorCallback]
     );
 
-Description
------------
+## Description
 
 This function asynchronously attempts to retrieve the format
 information for the media file.  If successful, it invokes the
@@ -36,8 +34,7 @@ information for the media file.  If successful, it invokes the
 the attempt fails, this function invokes the `MediaFileDataErrorCB`
 callback.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
@@ -45,20 +42,17 @@ Supported Platforms
 - Windows Phone 7 and 8
 - Windows 8
 
-BlackBerry WebWorks Quirks
---------------------------
+## BlackBerry WebWorks Quirks
 
 Does not provide an API for information about media files, so all
 `MediaFileData` objects return with default values.
 
-Android Quirks
---------------
+## Android Quirks
 
 The API to access media file format information is limited, so not all
 `MediaFileData` properties are supported.
 
-iOS Quirks
-----------
+## iOS Quirks
 
 The API to access media file format information is limited, so not all
 `MediaFileData` properties are supported.

--- a/docs/en/edge/cordova/media/capture/MediaFile.md
+++ b/docs/en/edge/cordova/media/capture/MediaFile.md
@@ -17,13 +17,11 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-MediaFile
-=========
+# MediaFile
 
 > Encapsulates properties of a media capture file.
 
-Properties
-----------
+## Properties
 
 - __name__: The name of the file, without path information. (DOMString)
 
@@ -35,7 +33,6 @@ Properties
 
 - __size__: The size of the file, in bytes. (Number)
 
-Methods
--------
+## Methods
 
 - __MediaFile.getFormatData__: Retrieves the format information of the media file.

--- a/docs/en/edge/cordova/media/capture/MediaFileData.md
+++ b/docs/en/edge/cordova/media/capture/MediaFileData.md
@@ -17,13 +17,11 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-MediaFileData
-=============
+# MediaFileData
 
 > Encapsulates format information about a media file.
 
-Properties
-----------
+## Properties
 
 - __codecs__: The actual format of the audio and video content. (DOMString)
 
@@ -35,8 +33,7 @@ Properties
 
 - __duration__: The length of the video or sound clip in seconds. The value is zero for images. (Number)
 
-BlackBerry WebWorks Quirks
---------------------------
+## BlackBerry WebWorks Quirks
 
 No API provides format information for media files, so the
 `MediaFileData` object returned by `MediaFile.getFormatData` features
@@ -52,8 +49,8 @@ the following default values:
 
 - __duration__: Not supported, and returns zero.
 
-Android Quirks
---------------
+## Android Quirks
+
 Supports the following `MediaFileData` properties:
 
 - __codecs__: Not supported, and returns `null`.
@@ -66,8 +63,8 @@ Supports the following `MediaFileData` properties:
 
 - __duration__: Supported: audio and video files only.
 
-iOS Quirks
-----------
+## iOS Quirks
+
 Supports the following `MediaFileData` properties:
 
 - __codecs__: Not supported, and returns null.

--- a/docs/en/edge/cordova/media/capture/capture.md
+++ b/docs/en/edge/cordova/media/capture/capture.md
@@ -17,15 +17,13 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-Capture
-=======
+# Capture
 
 > Provides access to the device's audio, image, and video capture capabilities.
 
 **Important privacy note:** Collection and use of images, video, or audio from the device's camera or microphone raises important privacy issues.  Your app's privacy policy should discuss how the app uses such sensors and whether the data recorded is shared with any other parties.  In addition, if the app's use of the camera or microphone is not apparent in the user interface, you should provide a just-in-time notice prior to your app accessing the camera or microphone (if the device operating system doesn't do so already). That notice should provide the same information noted above, as well as obtaining the user's permission (e.g., by presenting choices for "OK" and "No Thanks").  Note that some app marketplaces may require your app to provide just-in-time notice and obtain permission from the user prior to accessing the camera or microphone.  For more information, please see the Privacy Guide.
 
-Objects
--------
+## Objects
 
 - Capture
 - CaptureAudioOptions
@@ -37,16 +35,14 @@ Objects
 - MediaFile
 - MediaFileData
 
-Methods
--------
+## Methods
 
 - capture.captureAudio
 - capture.captureImage
 - capture.captureVideo
 - MediaFile.getFormatData
 
-Scope
------
+## Scope
 
 The `capture` object is assigned to the `navigator.device` object, and
 therefore has global scope.
@@ -54,8 +50,7 @@ therefore has global scope.
     // The global capture object
     var capture = navigator.device.capture;
 
-Properties
-----------
+## Properties
 
 - __supportedAudioModes__: The audio recording formats supported by the device. (ConfigurationData[])
 
@@ -63,8 +58,7 @@ Properties
 
 - __supportedVideoModes__: The recording video resolutions and formats supported by the device. (ConfigurationData[])
 
-Methods
--------
+## Methods
 
 - `capture.captureAudio`: Launch the device's audio recording application to record audio clips.
 
@@ -72,8 +66,7 @@ Methods
 
 - `capture.captureVideo`: Launch the device's video recorder application to record videos.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)

--- a/docs/en/edge/cordova/media/capture/captureAudio.md
+++ b/docs/en/edge/cordova/media/capture/captureAudio.md
@@ -17,8 +17,7 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-capture.captureAudio
-====================
+# capture.captureAudio
 
 > Start the audio recorder application and return information about captured audio clip files.
 
@@ -26,8 +25,7 @@ capture.captureAudio
         CaptureCB captureSuccess, CaptureErrorCB captureError,  [CaptureAudioOptions options]
     );
 
-Description
------------
+## Description
 
 Starts an asynchronous operation to capture audio recordings using the
 device's default audio recording application.  The operation allows
@@ -46,8 +44,7 @@ is captured, the `CaptureErrorCallback` executes with a `CaptureError`
 object, featuring the `CaptureError.CAPTURE_NO_MEDIA_FILES` error
 code.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
@@ -55,8 +52,7 @@ Supported Platforms
 - Windows Phone 7 and 8
 - Windows 8
 
-Quick Example
--------------
+## Quick Example
 
     // capture callback
     var captureSuccess = function(mediaFiles) {
@@ -75,8 +71,7 @@ Quick Example
     // start audio capture
     navigator.device.capture.captureAudio(captureSuccess, captureError, {limit:2});
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>
@@ -136,17 +131,14 @@ Full Example
         </body>
     </html>
 
-BlackBerry WebWorks Quirks
---------------------------
+## BlackBerry WebWorks Quirks
 
 - Cordova for BlackBerry WebWorks attempts to launch the __Voice Notes Recorder__ application, provided by RIM, to capture audio recordings. The app receives a `CaptureError.CAPTURE_NOT_SUPPORTED` error code if the application is not installed on the device.
 
-iOS Quirks
-----------
+## iOS Quirks
 
 - iOS does not have a default audio recording application, so a simple user interface is provided.
 
-Windows Phone 7 and 8 Quirks
-----------
+## Windows Phone 7 and 8 Quirks
 
 - Windows Phone 7 does not have a default audio recording application, so a simple user interface is provided.

--- a/docs/en/edge/cordova/media/capture/captureAudioOptions.md
+++ b/docs/en/edge/cordova/media/capture/captureAudioOptions.md
@@ -17,37 +17,31 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-CaptureAudioOptions
-===================
+# CaptureAudioOptions
 
 > Encapsulates audio capture configuration options.
 
-Properties
-----------
+## Properties
 
 - __limit__: The maximum number of audio clips the device user can record in a single capture operation.  The value must be greater than or equal to 1 (defaults to 1).
 
 - __duration__: The maximum duration of an audio sound clip, in seconds.
 
-Quick Example
--------------
+## Quick Example
 
     // limit capture operation to 3 media files, no longer than 10 seconds each
     var options = { limit: 3, duration: 10 };
 
     navigator.device.capture.captureAudio(captureSuccess, captureError, options);
 
-Android Quirks
---------------
+## Android Quirks
 
 - The `duration` parameter is not supported.  Recording lengths cannot be limited programmatically.
 
-BlackBerry WebWorks Quirks
---------------------------
+## BlackBerry WebWorks Quirks
 
 - The `duration` parameter is not supported.  Recording lengths cannot be limited programmatically.
 
-iOS Quirks
-----------
+## iOS Quirks
 
 - The `limit` parameter is not supported, so only one recording can be created for each invocation.

--- a/docs/en/edge/cordova/media/capture/captureImage.md
+++ b/docs/en/edge/cordova/media/capture/captureImage.md
@@ -17,8 +17,7 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-capture.captureImage
-====================
+# capture.captureImage
 
 > Start the camera application and return information about captured image files.
 
@@ -26,8 +25,7 @@ capture.captureImage
         CaptureCB captureSuccess, CaptureErrorCB captureError, [CaptureImageOptions options]
     );
 
-Description
------------
+## Description
 
 Starts an asynchronous operation to capture images using the device's
 camera application.  The operation allows users to capture more than
@@ -45,8 +43,7 @@ image file.  If the user terminates the operation before capturing an
 image, the `CaptureErrorCB` callback executes with a `CaptureError`
 object featuring a `CaptureError.CAPTURE_NO_MEDIA_FILES` error code.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
@@ -54,14 +51,12 @@ Supported Platforms
 - Windows Phone 7 and 8
 - Windows 8
 
-Windows Phone 7 Quirks
-----------------------
+## Windows Phone 7 Quirks
 
 Invoking the native camera application while your device is connected
 via Zune does not work, and the error callback executes.
 
-Quick Example
--------------
+## Quick Example
 
     // capture callback
     var captureSuccess = function(mediaFiles) {
@@ -80,8 +75,7 @@ Quick Example
     // start image capture
     navigator.device.capture.captureImage(captureSuccess, captureError, {limit:2});
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>

--- a/docs/en/edge/cordova/media/capture/captureImageOptions.md
+++ b/docs/en/edge/cordova/media/capture/captureImageOptions.md
@@ -17,25 +17,21 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-CaptureImageOptions
-===================
+# CaptureImageOptions
 
 > Encapsulates image capture configuration options.
 
-Properties
-----------
+## Properties
 
 - __limit__: The maximum number of images the user can capture in a single capture operation. The value must be greater than or equal to 1 (defaults to 1).
 
-Quick Example
--------------
+## Quick Example
 
     // limit capture operation to 3 images
     var options = { limit: 3 };
 
     navigator.device.capture.captureImage(captureSuccess, captureError, options);
 
-iOS Quirks
-----------
+## iOS Quirks
 
 - The __limit__ parameter is not supported, and only one image is taken per invocation.

--- a/docs/en/edge/cordova/media/capture/captureVideo.md
+++ b/docs/en/edge/cordova/media/capture/captureVideo.md
@@ -17,8 +17,7 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-capture.captureVideo
-====================
+# capture.captureVideo
 
 > Start the video recorder application and return information about captured video clip files.
 
@@ -26,8 +25,7 @@ capture.captureVideo
         CaptureCB captureSuccess, CaptureErrorCB captureError, [CaptureVideoOptions options]
     );
 
-Description
------------
+## Description
 
 Starts an asynchronous operation to capture video recordings using the
 device's video recording application.  The operation allows the user
@@ -46,8 +44,7 @@ capturing a video clip, the `CaptureErrorCB` callback executes with a
 `CaptureError` object featuring a
 `CaptureError.CAPTURE_NO_MEDIA_FILES` error code.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
@@ -55,8 +52,7 @@ Supported Platforms
 - Windows Phone 7 and 8
 - Windows 8
 
-Quick Example
--------------
+## Quick Example
 
     // capture callback
     var captureSuccess = function(mediaFiles) {
@@ -75,8 +71,7 @@ Quick Example
     // start video capture
     navigator.device.capture.captureVideo(captureSuccess, captureError, {limit:2});
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>
@@ -136,8 +131,7 @@ Full Example
         </body>
     </html>
 
-BlackBerry WebWorks Quirks
---------------------------
+## BlackBerry WebWorks Quirks
 
 - Cordova for BlackBerry WebWorks attempts to launch the __Video Recorder__ application, provided by RIM, to capture video recordings. The app receives a `CaptureError.CAPTURE_NOT_SUPPORTED` error code if the application is not installed on the device.
 

--- a/docs/en/edge/cordova/media/capture/captureVideoOptions.md
+++ b/docs/en/edge/cordova/media/capture/captureVideoOptions.md
@@ -17,33 +17,28 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-CaptureVideoOptions
-===================
+# CaptureVideoOptions
 
 > Encapsulates video capture configuration options.
 
-Properties
-----------
+## Properties
 
 - __limit__: The maximum number of video clips the device's user can capture in a single capture operation.  The value must be greater than or equal to 1 (defaults to 1).
 
 - __duration__: The maximum duration of a video clip, in seconds.
 
-Quick Example
--------------
+## Quick Example
 
     // limit capture operation to 3 video clips
     var options = { limit: 3 };
 
     navigator.device.capture.captureVideo(captureSuccess, captureError, options);
 
-BlackBerry WebWorks Quirks
---------------------------
+## BlackBerry WebWorks Quirks
 
 - The __duration__ parameter is not supported, so the length of recordings cannot be limited programmatically.
 
-iOS Quirks
-----------
+## iOS Quirks
 
 - The __limit__ parameter is not supported.  Only one video is recorded per invocation.
 

--- a/docs/en/edge/cordova/media/media.getCurrentPosition.md
+++ b/docs/en/edge/cordova/media/media.getCurrentPosition.md
@@ -17,29 +17,25 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-media.getCurrentPosition
-========================
+# media.getCurrentPosition
 
 Returns the current position within an audio file.
 
     media.getCurrentPosition(mediaSuccess, [mediaError]);
 
-Parameters
-----------
+## Parameters
 
 - __mediaSuccess__: The callback that is passed the current position in seconds.
 
 - __mediaError__: (Optional) The callback to execute if an error occurs.
 
-Description
------------
+## Description
 
 An asynchronous function that returns the current position of the
 underlying audio file of a `Media` object. Also updates the `Media`
 object's `position` parameter.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 
@@ -53,8 +49,7 @@ Supported Platforms
 
 - Windows 8
 
-Quick Example
--------------
+## Quick Example
 
     // Audio player
     //
@@ -77,8 +72,7 @@ Quick Example
         );
     }, 1000);
 
-Full Example
-------------
+## Full Example
 
         <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
                       "http://www.w3.org/TR/html4/strict.dtd">

--- a/docs/en/edge/cordova/media/media.getDuration.md
+++ b/docs/en/edge/cordova/media/media.getDuration.md
@@ -17,22 +17,19 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-media.getDuration
-=================
+# media.getDuration
 
 Returns the duration of an audio file.
 
     media.getDuration();
 
-Description
------------
+## Description
 
 The `media.getDuration` method executes synchronously, returning the
 duration of the audio file in seconds, if known.  If the duration is
 unknown, it returns a value of -1.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
@@ -41,8 +38,7 @@ Supported Platforms
 - Tizen
 - Windows 8
 
-Quick Example
--------------
+## Quick Example
 
     // Audio player
     //
@@ -62,8 +58,7 @@ Quick Example
         }
     }, 100);
 
-Full Example
-------------
+## Full Example
 
         <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
                               "http://www.w3.org/TR/html4/strict.dtd">

--- a/docs/en/edge/cordova/media/media.md
+++ b/docs/en/edge/cordova/media/media.md
@@ -17,8 +17,7 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-Media
-=====
+# Media
 
 > The `Media` object provides the ability to record and play back audio files on a device.
 
@@ -29,8 +28,7 @@ specification for media capture, and is provided for convenience only.
 A future implementation will adhere to the latest W3C specification
 and may deprecate the current APIs.
 
-Parameters
-----------
+## Parameters
 
 - __src__: A URI containing the audio content. _(DOMString)_
 
@@ -40,8 +38,7 @@ Parameters
 
 - __mediaStatus__: (Optional) The callback that executes to indicate status changes. _(Function)_
 
-Constants
----------
+## Constants
 
 The following constants are reported as the only parameter to the
 `mediaStatus` callback:
@@ -52,8 +49,7 @@ The following constants are reported as the only parameter to the
 - `Media.MEDIA_PAUSED`   = 3;
 - `Media.MEDIA_STOPPED`  = 4;
 
-Methods
--------
+## Methods
 
 - `media.getCurrentPosition`: Returns the current position within an audio file.
 
@@ -75,16 +71,14 @@ Methods
 
 - `media.stop`: Stop playing an audio file.
 
-Additional ReadOnly Parameters
----------------------
+## Additional ReadOnly Parameters
 
 - __position__: The position within the audio playback, in seconds.
     - Not automatically updated during play; call `getCurrentPosition` to update.
 
 - __duration__: The duration of the media, in seconds.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)

--- a/docs/en/edge/cordova/media/media.pause.md
+++ b/docs/en/edge/cordova/media/media.pause.md
@@ -17,20 +17,17 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-media.pause
-===========
+# media.pause
 
 Pauses playing an audio file.
 
     media.pause();
 
-Description
------------
+## Description
 
 The `media.pause` method executes synchronously, and pauses playing an audio file.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
@@ -39,8 +36,7 @@ Supported Platforms
 - Tizen
 - Windows 8
 
-Quick Example
--------------
+## Quick Example
 
     // Play audio
     //
@@ -62,8 +58,7 @@ Quick Example
         }, 10000);
     }
 
-Full Example
-------------
+## Full Example
 
         <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
                               "http://www.w3.org/TR/html4/strict.dtd">

--- a/docs/en/edge/cordova/media/media.play.md
+++ b/docs/en/edge/cordova/media/media.play.md
@@ -17,21 +17,18 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-media.play
-==========
+# media.play
 
 Starts or resumes playing an audio file.
 
     media.play();
 
-Description
------------
+## Description
 
 The `media.play` method executes synchronously, and starts or resumes
 playing an audio file.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
@@ -40,8 +37,7 @@ Supported Platforms
 - Tizen
 - Windows 8
 
-Quick Example
--------------
+## Quick Example
 
     // Play audio
     //
@@ -61,8 +57,7 @@ Quick Example
         my_media.play();
     }
 
-Full Example
-------------
+## Full Example
 
         <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
                               "http://www.w3.org/TR/html4/strict.dtd">
@@ -166,8 +161,7 @@ Full Example
           </body>
         </html>
 
-BlackBerry WebWorks Quirks
-----------
+## BlackBerry WebWorks Quirks
 
 - BlackBerry devices support a limited number of simultaneous audio
   channels. CDMA devices only support a single audio channel. Other
@@ -175,8 +169,7 @@ BlackBerry WebWorks Quirks
   more audio files than the supported amount results in previous
   playback being stopped.
 
-iOS Quirks
-----------
+## iOS Quirks
 
 - __numberOfLoops__: Pass this option to the `play` method to specify
   the number of times you want the media file to play, e.g.:

--- a/docs/en/edge/cordova/media/media.release.md
+++ b/docs/en/edge/cordova/media/media.release.md
@@ -17,15 +17,13 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-media.release
-=================
+# media.release
 
 Releases the underlying operating system's audio resources.
 
     media.release();
 
-Description
------------
+## Description
 
 The `media.release` method executes synchronously, releasing the
 underlying operating system's audio resources.  This is particularly
@@ -33,8 +31,7 @@ important for Android, since there are a finite amount of OpenCore
 instances for media playback. Applications should call the `release`
 function for any `Media` resource that is no longer needed.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
@@ -43,8 +40,7 @@ Supported Platforms
 - Tizen
 - Windows 8
 
-Quick Example
--------------
+## Quick Example
 
     // Audio player
     //
@@ -54,8 +50,7 @@ Quick Example
     my_media.stop();
     my_media.release();
 
-Full Example
-------------
+## Full Example
 
         <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
                               "http://www.w3.org/TR/html4/strict.dtd">

--- a/docs/en/edge/cordova/media/media.seekTo.md
+++ b/docs/en/edge/cordova/media/media.seekTo.md
@@ -17,27 +17,23 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-media.seekTo
-========================
+# media.seekTo
 
 Sets the current position within an audio file.
 
     media.seekTo(milliseconds);
 
-Parameters
-----------
+## Parameters
 
 - __milliseconds__: The position to set the playback position within the audio, in milliseconds.
 
-Description
------------
+## Description
 
 The `media.seekTo` executes asynchronously, updating the current
 playback position within an audio file referenced by a `Media`
 object. Also updates the `Media` object's `position` parameter.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 6.0 and higher)
@@ -46,8 +42,7 @@ Supported Platforms
 - Tizen
 - Windows 8
 
-Quick Example
--------------
+## Quick Example
 
     // Audio player
     //
@@ -58,8 +53,7 @@ Quick Example
         my_media.seekTo(10000);
     }, 5000);
 
-Full Example
-------------
+## Full Example
 
         <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" 
                               "http://www.w3.org/TR/html4/strict.dtd">
@@ -155,7 +149,6 @@ Full Example
           </body>
         </html>
 
-BlackBerry WebWorks Quirks
-----------
+## BlackBerry WebWorks Quirks
 
 - Not supported on BlackBerry OS 5 devices.

--- a/docs/en/edge/cordova/media/media.setVolume.md
+++ b/docs/en/edge/cordova/media/media.setVolume.md
@@ -17,31 +17,26 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-media.setVolume
-===========
+# media.setVolume
 
 Set the volume for an audio file.
 
     media.setVolume(volume);
 
-Parameters
----------
+## Parameters
 
 - __volume__: The volume to set for playback.  The value must be within the range of 0.0 to 1.0.
 
-Description
------------
+## Description
 
 Function `media.setVolume` is an asynchronous function that sets the volume during audio playback.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - iOS
 
-Quick Example
--------------
+## Quick Example
 
     // Play audio
     //
@@ -71,8 +66,7 @@ Quick Example
         }, 5000);
     }
 
-Full Example
-------------
+## Full Example
 
         <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
                               "http://www.w3.org/TR/html4/strict.dtd">

--- a/docs/en/edge/cordova/media/media.startRecord.md
+++ b/docs/en/edge/cordova/media/media.startRecord.md
@@ -17,21 +17,18 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-media.startRecord
-=================
+# media.startRecord
 
 Starts recording an audio file.
 
     media.startRecord();
 
-Description
------------
+## Description
 
 The `media.startRecord` method executes synchronously, starts a
 recording for an audio file.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
@@ -39,8 +36,7 @@ Supported Platforms
 - Windows Phone 7 and 8
 - Windows 8
 
-Quick Example
--------------
+## Quick Example
 
     // Record audio
     //
@@ -61,8 +57,7 @@ Quick Example
         mediaRec.startRecord();
     }
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>
@@ -130,18 +125,15 @@ Full Example
       </body>
     </html>
 
-Android Quirks
-----------
+## Android Quirks
 
 - Android devices record audio in Adaptive Multi-Rate format. The specified file should end with a _.amr_ extension.
 
-BlackBerry WebWorks Quirks
-----------
+## BlackBerry WebWorks Quirks
 
 - BlackBerry devices record audio in Adaptive Multi-Rate format. The specified file must end with a _.amr_ extension.
 
-iOS Quirks
-----------
+## iOS Quirks
 
 - iOS only records to files of type _.wav_ and returns an error if the file name extension is not correct.
 
@@ -151,7 +143,6 @@ iOS Quirks
 
         var myMedia = new Media("documents://beer.mp3")
 
-Tizen Quirks
-----------
+## Tizen Quirks
 
 - Not supported on Tizen devices.

--- a/docs/en/edge/cordova/media/media.stop.md
+++ b/docs/en/edge/cordova/media/media.stop.md
@@ -17,21 +17,18 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-media.stop
-==========
+# media.stop
 
 Stops playing an audio file.
 
     media.stop();
 
-Description
------------
+## Description
 
 The `media.stop` method executes synchronously to stop playing an
 audio file.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
@@ -40,8 +37,7 @@ Supported Platforms
 - Tizen
 - Windows 8
 
-Quick Example
--------------
+## Quick Example
 
     // Play audio
     //
@@ -67,8 +63,7 @@ Quick Example
         }, 10000);
     }
 
-Full Example
-------------
+## Full Example
 
         <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
                               "http://www.w3.org/TR/html4/strict.dtd">

--- a/docs/en/edge/cordova/media/media.stopRecord.md
+++ b/docs/en/edge/cordova/media/media.stopRecord.md
@@ -17,21 +17,18 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-media.stopRecord
-================
+# media.stopRecord
 
 Stops recording an audio file.
 
     media.stopRecord();
 
-Description
------------
+## Description
 
 The `media.stopRecord` method executes synchronously, stopping the
 recording of an audio file.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
@@ -39,8 +36,7 @@ Supported Platforms
 - Windows Phone 7 and 8
 - Windows 8
 
-Quick Example
--------------
+## Quick Example
 
     // Record audio
     //
@@ -67,8 +63,7 @@ Quick Example
         }, 10000);
     }
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>
@@ -136,7 +131,6 @@ Full Example
       </body>
     </html>
 
-Tizen Quirks
-----------
+## Tizen Quirks
 
 - Not supported on Tizen devices.

--- a/docs/en/edge/cordova/notification/notification.alert.md
+++ b/docs/en/edge/cordova/notification/notification.alert.md
@@ -17,8 +17,7 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-notification.alert
-==================
+# notification.alert
 
 Shows a custom alert or dialog box.
 
@@ -32,15 +31,13 @@ Shows a custom alert or dialog box.
 
 - __buttonName__: Button name. _(String)_ (Optional, defaults to `OK`)
 
-Description
------------
+## Description
 
 Most Cordova implementations use a native dialog box for this feature,
 but some platforms use the browser's `alert` function, which is
 typically less customizable.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
@@ -49,8 +46,7 @@ Supported Platforms
 - Windows Phone 7 and 8
 - Windows 8
 
-Quick Example
--------------
+## Quick Example
 
     // Android / BlackBerry WebWorks (OS 5.0 and higher) / iOS / Tizen
     //
@@ -65,8 +61,7 @@ Quick Example
         'Done'                  // buttonName
     );
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>
@@ -109,8 +104,7 @@ Full Example
       </body>
     </html>
 
-Windows Phone 7 and 8 Quirks
--------------
+## Windows Phone 7 and 8 Quirks
 
 - There is no built-in browser alert, but you can bind one as follows to call `alert()` in the global scope:
 

--- a/docs/en/edge/cordova/notification/notification.beep.md
+++ b/docs/en/edge/cordova/notification/notification.beep.md
@@ -17,8 +17,7 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-notification.beep
-=================
+# notification.beep
 
 The device plays a beep sound.
 
@@ -26,8 +25,7 @@ The device plays a beep sound.
 
 - __times__: The number of times to repeat the beep. _(Number)_
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
@@ -35,14 +33,12 @@ Supported Platforms
 - Tizen
 - Windows Phone 7 and 8
 
-Quick Example
--------------
+## Quick Example
 
     // Beep twice!
     navigator.notification.beep(2);
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>
@@ -93,18 +89,15 @@ Full Example
       </body>
     </html>
 
-Android Quirks
---------------
+## Android Quirks
 
 - Android plays the default __Notification ringtone__ specified under the __Settings/Sound & Display__ panel.
 
-Windows Phone 7 and 8 Quirks
--------------
+## Windows Phone 7 and 8 Quirks
 
 - Relies on a generic beep file from the Cordova distribution.
 
-Tizen Quirks
--------------
+## Tizen Quirks
 
 - Tizen implements beeps by playing an audio file via the media API.
 

--- a/docs/en/edge/cordova/notification/notification.confirm.md
+++ b/docs/en/edge/cordova/notification/notification.confirm.md
@@ -17,8 +17,7 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-notification.confirm
-====================
+# notification.confirm
 
 Displays a customizable confirmation dialog box.
 
@@ -32,14 +31,12 @@ Displays a customizable confirmation dialog box.
 
 - __buttonLabels__: Comma-separated string specifying button labels. _(String)_ (Optional, defaults to `OK,Cancel`)
 
-Description
------------
+## Description
 
 The `notification.confirm` method displays a native dialog box that is
 more customizable than the browser's `confirm` function.
 
-confirmCallback
----------------
+## confirmCallback
 
 The `confirmCallback` executes when the user presses one of the
 buttons in the confirmation dialog box.
@@ -48,8 +45,7 @@ The callback takes the argument `buttonIndex` _(Number)_, which is the
 index of the pressed button. Note that the index uses one-based
 indexing, so the value is `1`, `2`, `3`, etc.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
@@ -58,8 +54,7 @@ Supported Platforms
 - Windows Phone 7 and 8
 - Windows 8
 
-Quick Example
--------------
+## Quick Example
 
     // process the confirmation dialog result
     function onConfirm(buttonIndex) {
@@ -77,8 +72,7 @@ Quick Example
         );
     }
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>
@@ -121,8 +115,7 @@ Full Example
       </body>
     </html>
 
-Windows Phone 7 and 8 Quirks
-----------------------
+## Windows Phone 7 and 8 Quirks
 
 - There is no built-in browser function for `window.confirm`, but you can bind it by assigning:
 

--- a/docs/en/edge/cordova/notification/notification.md
+++ b/docs/en/edge/cordova/notification/notification.md
@@ -17,13 +17,11 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-Notification
-============
+# Notification
 
 > Visual, audible, and tactile device notifications.
 
-Methods
--------
+## Methods
 
 - `notification.alert`
 - `notification.confirm`

--- a/docs/en/edge/cordova/notification/notification.prompt.md
+++ b/docs/en/edge/cordova/notification/notification.prompt.md
@@ -17,8 +17,7 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-notification.prompt
-====================
+# notification.prompt
 
 Shows a customizable prompt dialog box.
 
@@ -34,14 +33,12 @@ Shows a customizable prompt dialog box.
 
 - __defaultText__: Default textbox input value (`String`) (Optional, Default: empty string)
 
-Description
------------
+## Description
 
 The `notification.prompt` method displays a native dialog box that is
 more customizable than the browser's `prompt` function.
 
-promptCallback
----------------
+## promptCallback
 
 The `promptCallback` executes when the user presses one of the buttons
 in the prompt dialog box. The `results` object passed to the callback
@@ -51,14 +48,12 @@ contains the following properties:
 
 - __input1__: The text entered in the prompt dialog box. _(String)_
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - iOS
 
-Quick Example
--------------
+## Quick Example
 
     // process the promp dialog results
     function onPrompt(results) {
@@ -77,8 +72,7 @@ Quick Example
         );
     }
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>
@@ -122,8 +116,7 @@ Full Example
       </body>
     </html>
 
-Android Quirks
-----------------------
+## Android Quirks
 
 - Android supports a maximum of three buttons, and ignores any more than that.
 

--- a/docs/en/edge/cordova/notification/notification.vibrate.md
+++ b/docs/en/edge/cordova/notification/notification.vibrate.md
@@ -17,8 +17,7 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-notification.vibrate
-====================
+# notification.vibrate
 
 Vibrates the device for the specified amount of time.
 
@@ -26,23 +25,20 @@ Vibrates the device for the specified amount of time.
 
 - __time__: Milliseconds to vibrate the device, where 1000 milliseconds equals 1 second. _(Number)_
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 5.0 and higher)
 - iOS
 - Windows Phone 7 and 8
 
-Quick Example
--------------
+## Quick Example
 
     // Vibrate for 2.5 seconds
     //
     navigator.notification.vibrate(2500);
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>
@@ -93,8 +89,7 @@ Full Example
       </body>
     </html>
 
-iOS Quirks
--------------
+## iOS Quirks
 
 - __time__: Ignores the specified time and vibrates for a pre-set amount of time.
 

--- a/docs/en/edge/cordova/splashscreen/splashscreen.hide.md
+++ b/docs/en/edge/cordova/splashscreen/splashscreen.hide.md
@@ -17,20 +17,17 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-splashscreen.hide
-===============
+# splashscreen.hide
 
 Dismiss the splash screen.
 
     navigator.splashscreen.hide();
 
-Description
------------
+## Description
 
 This method dismisses the application's splash screen.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry 10
@@ -38,13 +35,11 @@ Supported Platforms
 - Windows Phone 7 and 8
 - Windows 8
 
-Quick Example
--------------
+## Quick Example
 
     navigator.splashscreen.hide();
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>
@@ -71,8 +66,7 @@ Full Example
       </body>
     </html>
 
-iOS Quirk
-------------
+## iOS Quirk
 
 The `config.xml` file's `AutoHideSplashScreen` setting must be
 `false`. To delay hiding the splash screen for two seconds, add a

--- a/docs/en/edge/cordova/splashscreen/splashscreen.md
+++ b/docs/en/edge/cordova/splashscreen/splashscreen.md
@@ -17,13 +17,11 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-Splashscreen
-==========
+# Splashscreen
 
 > Displays and hides the application's splash screen.
 
-Methods
--------
+## Methods
 
 - splashscreen.show
 - splashscreen.hide
@@ -55,8 +53,7 @@ platform-specific configuration settings described below:
 Some platforms may support this feature without requiring any special
 configuration.  See Platform Support for an overview.
 
-Setup
------
+## Setup
 
 ### Android
 

--- a/docs/en/edge/cordova/splashscreen/splashscreen.show.md
+++ b/docs/en/edge/cordova/splashscreen/splashscreen.show.md
@@ -17,20 +17,17 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-splashscreen.show
-===============
+# splashscreen.show
 
 Displays the splash screen.
 
     navigator.splashscreen.show();
 
-Description
------------
+## Description
 
 This method displays the application's splash screen.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry 10
@@ -38,13 +35,11 @@ Supported Platforms
 - Windows Phone 7 and 8
 - Windows 8
 
-Quick Example
--------------
+## Quick Example
 
     navigator.splashscreen.show();
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>

--- a/docs/en/edge/cordova/storage/database/database.md
+++ b/docs/en/edge/cordova/storage/database/database.md
@@ -17,33 +17,29 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-Database
-=======
+# Database
 
 Provides access to an SQL database.
 
-Methods
--------
+## Methods
 
 - __transaction__: Runs a database transaction.
 
 - __changeVersion__: Allows scripts to automatically verify the version number and change it when updating a schema.
 
-Details
--------
+## Details
 
 The `window.openDatabase()` method returns a `Database` object.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 6.0 and higher)
 - iOS
 - Tizen
 
-Transaction Quick Example
-------------------
+## Transaction Quick Example
+
     function populateDB(tx) {
         tx.executeSql('DROP TABLE IF EXISTS DEMO');
         tx.executeSql('CREATE TABLE IF NOT EXISTS DEMO (id unique, data)');
@@ -62,14 +58,12 @@ Transaction Quick Example
     var db = window.openDatabase("Database", "1.0", "Cordova Demo", 200000);
     db.transaction(populateDB, errorCB, successCB);
 
-Change Version Quick Example
--------------------
+## Change Version Quick Example
 
     var db = window.openDatabase("Database", "1.0", "Cordova Demo", 200000);
     db.changeVersion("1.0", "1.1");
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>

--- a/docs/en/edge/cordova/storage/localstorage/localstorage.md
+++ b/docs/en/edge/cordova/storage/localstorage/localstorage.md
@@ -17,8 +17,7 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-localStorage
-===============
+# localStorage
 
 Provides access to the W3C's
 [Web Storage interface](http://dev.w3.org/html5/webstorage/#the-localstorage-attribute)
@@ -26,8 +25,7 @@ Provides access to the W3C's
     var permanentStorage = window.localStorage;
     var tempStorage = window.sessionStorage;
 
-Methods
--------
+## Methods
 
 - __key__: Returns the name of the key at the specified position.
 
@@ -39,8 +37,7 @@ Methods
 
 - __clear__: Removes all of the key/value pairs.
 
-Details
------------
+## Details
 
 The `window.localStorage` interface implements the W3C's [Web Storage
 interface](http://dev.w3.org/html5/webstorage/).  An app can use it to
@@ -49,8 +46,7 @@ save persistent data using key-value pairs.  The
 except that all data is cleared each time the app closes. Each
 database provides a separate namespace.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 6.0 and higher)
@@ -58,34 +54,28 @@ Supported Platforms
 - Tizen
 - Windows Phone 7 and 8
 
-Key Quick Example
--------------
+## Key Quick Example
 
     var keyName = window.localStorage.key(0);
 
-Set Item Quick Example
--------------
+## Set Item Quick Example
 
     window.localStorage.setItem("key", "value");
 
-Get Item Quick Example
--------------
+## Get Item Quick Example
 
         var value = window.localStorage.getItem("key");
         // value is now equal to "value"
 
-Remove Item Quick Example
--------------
+## Remove Item Quick Example
 
         window.localStorage.removeItem("key");
 
-Clear Quick Example
--------------
+## Clear Quick Example
 
         window.localStorage.clear();
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>
@@ -121,8 +111,7 @@ Full Example
       </body>
     </html>
 
-Windows Phone 7 Quirks
--------------
+## Windows Phone 7 Quirks
 
 Dot notation is _not_ available on Windows Phone 7. Be sure to use
 `setItem` or `getItem`, rather than accessing keys directly from the

--- a/docs/en/edge/cordova/storage/parameters/display_name.md
+++ b/docs/en/edge/cordova/storage/parameters/display_name.md
@@ -17,7 +17,6 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-database_displayname
-==================
+# database_displayname
 
 The display name of the database.

--- a/docs/en/edge/cordova/storage/parameters/name.md
+++ b/docs/en/edge/cordova/storage/parameters/name.md
@@ -17,7 +17,6 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-database_name
-============
+# database_name
 
 The name of the database.

--- a/docs/en/edge/cordova/storage/parameters/size.md
+++ b/docs/en/edge/cordova/storage/parameters/size.md
@@ -17,7 +17,6 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-database_size
-==============
+# database_size
 
 The size of the database in bytes.

--- a/docs/en/edge/cordova/storage/parameters/version.md
+++ b/docs/en/edge/cordova/storage/parameters/version.md
@@ -17,7 +17,6 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-database_version
-=============
+# database_version
 
 The version of the database.

--- a/docs/en/edge/cordova/storage/sqlerror/sqlerror.md
+++ b/docs/en/edge/cordova/storage/sqlerror/sqlerror.md
@@ -17,20 +17,17 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-SQLError
-========
+# SQLError
 
 A `SQLError` object is thrown when an error occurs.
 
-Properties
-----------
+## Properties
 
 - __code__: One of the predefined error codes listed below.
 
 - __message__: A description of the error.
 
-Constants
----------
+## Constants
 
 - `SQLError.UNKNOWN_ERR`
 - `SQLError.DATABASE_ERR`
@@ -41,7 +38,6 @@ Constants
 - `SQLError.CONSTRAINT_ERR`
 - `SQLError.TIMEOUT_ERR`
 
-Description
------------
+## Description
 
 The `SQLError` object is thrown when an error occurs when manipulating a database.

--- a/docs/en/edge/cordova/storage/sqlresultset/sqlresultset.md
+++ b/docs/en/edge/cordova/storage/sqlresultset/sqlresultset.md
@@ -17,14 +17,12 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-SQLResultSet
-=======
+# SQLResultSet
 
 When a `SQLTransaction` object's `executeSql` method is called, the
 specified callback executes with a `SQLResultSet` parameter.
 
-Properties
--------
+## Properties
 
 - __insertId__: The row ID of the row that the `SQLResultSet` object's SQL statement inserted into the database.
 
@@ -32,8 +30,7 @@ Properties
 
 - __rows__: a `SQLResultSetRowList` representing the rows returned, empty if no rows are returned.
 
-Details
--------
+## Details
 
 When a `SQLTransaction` object's `executeSql` method is called, the
 specified callback executes with a `SQLResultSet` parameter containing
@@ -50,16 +47,14 @@ three properties:
 * The final `SQLResultSetList` contains the data returned from a SQL
   select statement.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 6.0 and higher)
 - iOS
 - Tizen
 
-Execute SQL Quick Example
-------------------
+## Execute SQL Quick Example
 
     function queryDB(tx) {
         tx.executeSql('SELECT * FROM DEMO', [], querySuccess, errorCB);
@@ -83,8 +78,7 @@ Execute SQL Quick Example
     var db = window.openDatabase("Database", "1.0", "Cordova Demo", 200000);
     db.transaction(queryDB, errorCB);
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>

--- a/docs/en/edge/cordova/storage/sqlresultsetrowlist/sqlresultsetrowlist.md
+++ b/docs/en/edge/cordova/storage/sqlresultsetrowlist/sqlresultsetrowlist.md
@@ -17,24 +17,20 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-SQLResultSetRowList
-=======
+# SQLResultSetRowList
 
 One of the properties of the `SQLResultSet` containing the rows
 returned from a SQL query.
 
-Properties
--------
+## Properties
 
 - __length__: the number of rows returned by the SQL query.
 
-Methods
--------
+## Methods
 
 - __item__: returns the row at the specified index represented by a JavaScript object.
 
-Details
--------
+## Details
 
 The `SQLResultSetRowList` contains the data returned from a SQL
 `select` statement.  The object contains a `length` property
@@ -43,16 +39,14 @@ of data, call the `item` method to specify an index.  It returns a
 JavaScript `Object` whose properties are the database columns the
 `select` statement was executed against.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 6.0 and higher)
 - iOS
 - Tizen
 
-Execute SQL Quick Example
-------------------
+## Execute SQL Quick Example
 
     function queryDB(tx) {
         tx.executeSql('SELECT * FROM DEMO', [], querySuccess, errorCB);
@@ -73,8 +67,7 @@ Execute SQL Quick Example
         var db = window.openDatabase("Database", "1.0", "Cordova Demo", 200000);
         db.transaction(queryDB, errorCB);
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>

--- a/docs/en/edge/cordova/storage/sqltransaction/sqltransaction.md
+++ b/docs/en/edge/cordova/storage/sqltransaction/sqltransaction.md
@@ -17,32 +17,27 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-SQLTransaction
-=======
+# SQLTransaction
 
 Allows execution of SQL statements against the Database.
 
-Methods
--------
+## Methods
 
 - __executeSql__: executes a SQL statement.
 
-Details
--------
+## Details
 
 Calling a `Database` object's transaction method, passes a
 `SQLTransaction` object to the specified callback method.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 6.0 and higher)
 - iOS
 - Tizen
 
-Execute SQL Quick Example
-------------------
+## Execute SQL Quick Example
 
     function populateDB(tx) {
         tx.executeSql('DROP TABLE IF EXISTS DEMO');
@@ -62,8 +57,7 @@ Execute SQL Quick Example
     var db = window.openDatabase("Database", "1.0", "Cordova Demo", 200000);
     db.transaction(populateDB, errorCB, successCB);
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>

--- a/docs/en/edge/cordova/storage/storage.md
+++ b/docs/en/edge/cordova/storage/storage.md
@@ -17,8 +17,7 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-Storage
-==========
+# Storage
 
 > Provides access to the device's storage options.
 
@@ -39,21 +38,18 @@ Cordova provides access to both interfaces for the minority of devices
 that don't already support them. Otherwise the built-in
 implementations apply.
 
-Methods
--------
+## Methods
 
 - openDatabase
 
-Arguments
----------
+## Arguments
 
 - database_name
 - database_version
 - database_displayname
 - database_size
 
-Objects
--------
+## Objects
 
 - Database
 - SQLTransaction

--- a/docs/en/edge/cordova/storage/storage.opendatabase.md
+++ b/docs/en/edge/cordova/storage/storage.opendatabase.md
@@ -17,34 +17,29 @@ license: Licensed to the Apache Software Foundation (ASF) under one
          under the License.
 ---
 
-openDatabase
-===============
+# openDatabase
 
 Returns a new `Database` object.
 
     var dbShell = window.openDatabase(database_name, database_version, database_displayname, database_size);
 
-Description
------------
+## Description
 
 The method creates a new SQL Lite Database and returns a `Database`
 object that allows manipulation of the data.
 
-Supported Platforms
--------------------
+## Supported Platforms
 
 - Android
 - BlackBerry WebWorks (OS 6.0 and higher)
 - iOS
 - Tizen
 
-Quick Example
--------------
+## Quick Example
 
     var db = window.openDatabase("test", "1.0", "Test DB", 1000000);
 
-Full Example
-------------
+## Full Example
 
     <!DOCTYPE html>
     <html>

--- a/docs/en/edge/guide/platforms/win8/index.md
+++ b/docs/en/edge/guide/platforms/win8/index.md
@@ -70,6 +70,7 @@ expose the same APIs as on other Cordova-supported platforms.
 - Edit the code for `index.html`. Add a reference to `cordova.js`. You can do this manually, or by dragging the file from Solution Explorer.
 
 ### Adding the reference...
+
 	    <!-- WinJS references -->
 	    <link href="//Microsoft.WinJS.1.0/css/ui-dark.css" rel="stylesheet" />
 	    <script src="//Microsoft.WinJS.1.0/js/base.js"></script>
@@ -85,6 +86,7 @@ expose the same APIs as on other Cordova-supported platforms.
 - Next, add some code that demonstrates Cordova is working.
 
 ### Adding a 'deviceready' handler...
+
 	<body>
 	    <p>Content goes here</p>
 


### PR DESCRIPTION
Would prefer same-line heading syntax throughout before splitting content into different repos, to make it easier to use grep to debug x-refs & other consistency issues
