### PR TITLE
[CB-3961] fix nonfunctioning B-head links to compatibility table

### DIFF
--- a/docs/en/edge/cordova/accelerometer/accelerometer.md
+++ b/docs/en/edge/cordova/accelerometer/accelerometer.md
@@ -81,4 +81,4 @@ platform-specific configuration settings described below:
   Reference: [Application Manifest for Windows Phone](http://msdn.microsoft.com/en-us/library/ff769509%28v=vs.92%29.aspx)
 
 Some platforms may support this feature without requiring any special
-configuration.  See Platform Support for an overview.
+configuration.  See _Platform Support_ in the Overview section.

--- a/docs/en/edge/cordova/camera/camera.md
+++ b/docs/en/edge/cordova/camera/camera.md
@@ -97,4 +97,4 @@ platform-specific configuration settings described below:
   Reference: [Application Manifest for Tizen Web Application](https://developer.tizen.org/help/topic/org.tizen.help.gs/Creating%20a%20Project.html?path=0_1_1_3#8814682_CreatingaProject-EditingconfigxmlFeatures)
 
 Some platforms may support this feature without requiring any special
-configuration.  See Platform Support for an overview.
+configuration.  See _Platform Support_ in the Overview section.

--- a/docs/en/edge/cordova/compass/compass.md
+++ b/docs/en/edge/cordova/compass/compass.md
@@ -69,4 +69,4 @@ platform-specific configuration settings described below:
   Reference: [Application Manifest for Windows Phone](http://msdn.microsoft.com/en-us/library/ff769509%28v=vs.92%29.aspx)
 
 Some platforms may support this feature without requiring any special
-configuration.  See Platform Support for an overview.
+configuration.  See _Platform Support_ in the Overview section.

--- a/docs/en/edge/cordova/connection/connection.md
+++ b/docs/en/edge/cordova/connection/connection.md
@@ -88,4 +88,4 @@ platform-specific configuration settings described below:
   Reference: [Application Manifest for Tizen Web Application](https://developer.tizen.org/help/topic/org.tizen.help.gs/Creating%20a%20Project.html?path=0_1_1_3#8814682_CreatingaProject-EditingconfigxmlFeatures)
 
 Some platforms may support this feature without requiring any special
-configuration.  See Platform Support for an overview.
+configuration.  See _Platform Support_ in the Overview section.

--- a/docs/en/edge/cordova/contacts/contacts.md
+++ b/docs/en/edge/cordova/contacts/contacts.md
@@ -113,4 +113,4 @@ platform-specific configuration settings described below:
   Reference: [Application Manifest for Windows Phone](http://msdn.microsoft.com/en-us/library/ff769509%28v=vs.92%29.aspx)
 
 Some platforms may support this feature without requiring any special
-configuration.  See Platform Support for an overview.
+configuration.  See _Platform Support_ in the Overview section.

--- a/docs/en/edge/cordova/device/device.md
+++ b/docs/en/edge/cordova/device/device.md
@@ -90,4 +90,4 @@ platform-specific configuration settings described below:
   Reference: [Application Manifest for Tizen Web Application](https://developer.tizen.org/help/topic/org.tizen.help.gs/Creating%20a%20Project.html?path=0_1_1_3#8814682_CreatingaProject-EditingconfigxmlFeatures)
 
 Some platforms may support this feature without requiring any special
-configuration.  See Platform Support for an overview.
+configuration.  See _Platform Support_ in the Overview section.

--- a/docs/en/edge/cordova/events/events.md
+++ b/docs/en/edge/cordova/events/events.md
@@ -88,4 +88,4 @@ platform-specific configuration settings described below:
   Reference: [Application Manifest for Tizen Web Application](https://developer.tizen.org/help/topic/org.tizen.help.gs/Creating%20a%20Project.html?path=0_1_1_3#8814682_CreatingaProject-EditingconfigxmlFeatures)
 
 Some platforms may support this feature without requiring any special
-configuration.  See Platform Support for an overview.
+configuration.  See _Platform Support_ in the Overview section.

--- a/docs/en/edge/cordova/file/file.md
+++ b/docs/en/edge/cordova/file/file.md
@@ -97,4 +97,4 @@ platform-specific configuration settings described below:
         </feature>
 
 Some platforms may support this feature without requiring any special
-configuration.  See Platform Support for an overview.
+configuration.  See _Platform Support_ in the Overview section.

--- a/docs/en/edge/cordova/geolocation/geolocation.md
+++ b/docs/en/edge/cordova/geolocation/geolocation.md
@@ -116,4 +116,4 @@ platform-specific configuration settings described below:
   Reference: [Application Manifest for Windows Phone](http://msdn.microsoft.com/en-us/library/ff769509%28v=vs.92%29.aspx)
 
 Some platforms may support this feature without requiring any special
-configuration.  See Platform Support for an overview.
+configuration.  See _Platform Support_ in the Overview section.

--- a/docs/en/edge/cordova/globalization/globalization.md
+++ b/docs/en/edge/cordova/globalization/globalization.md
@@ -68,4 +68,4 @@ platform-specific configuration settings described below:
         </feature>
 
 Some platforms may support this feature without requiring any special
-configuration.  See Platform Support for an overview.
+configuration.  See _Platform Support_ in the Overview section.

--- a/docs/en/edge/cordova/inappbrowser/inappbrowser.md
+++ b/docs/en/edge/cordova/inappbrowser/inappbrowser.md
@@ -65,7 +65,7 @@ platform-specific configuration settings described below:
         <feature name="InAppBrowser" />
 
 Some platforms may support this feature without requiring any special
-configuration.  See Platform Support for an overview.
+configuration.  See _Platform Support_ in the Overview section.
 
 # addEventListener
 

--- a/docs/en/edge/cordova/media/capture/capture.md
+++ b/docs/en/edge/cordova/media/capture/capture.md
@@ -138,4 +138,4 @@ platform-specific configuration settings described below:
         </Capabilities>
 
 Some platforms may support this feature without requiring any special
-configuration.  See Platform Support for an overview.
+configuration.  See _Platform Support_ in the Overview section.

--- a/docs/en/edge/cordova/media/media.md
+++ b/docs/en/edge/cordova/media/media.md
@@ -136,7 +136,7 @@ platform-specific configuration settings described below:
   Reference: [Application Manifest for Windows Phone](http://msdn.microsoft.com/en-us/library/ff769509%28v=vs.92%29.aspx)
 
 Some platforms may support this feature without requiring any special
-configuration.  See Platform Support for an overview.
+configuration.  See _Platform Support_ in the Overview section.
 
 ### Windows Phone Quirks
 

--- a/docs/en/edge/cordova/notification/notification.md
+++ b/docs/en/edge/cordova/notification/notification.md
@@ -70,4 +70,4 @@ platform-specific configuration settings described below:
         </feature>
 
 Some platforms may support this feature without requiring any special
-configuration.  See Platform Support for an overview.
+configuration.  See _Platform Support_ in the Overview section.

--- a/docs/en/edge/cordova/splashscreen/splashscreen.md
+++ b/docs/en/edge/cordova/splashscreen/splashscreen.md
@@ -51,7 +51,7 @@ platform-specific configuration settings described below:
         </feature>
 
 Some platforms may support this feature without requiring any special
-configuration.  See Platform Support for an overview.
+configuration.  See _Platform Support_ in the Overview section.
 
 ## Setup
 

--- a/docs/en/edge/cordova/storage/storage.md
+++ b/docs/en/edge/cordova/storage/storage.md
@@ -78,4 +78,4 @@ required:
         <feature id="blackberry.widgetcache" required="true" version="1.0.0.0" />
 
 Some platforms may support this feature without requiring any special
-configuration.  See Platform Support for an overview.
+configuration.  See _Platform Support_ in the Overview section.


### PR DESCRIPTION
Rephrase links as "See _B-head_ within A-Head", where A-Head autolinks.
