### PR TITLE
Remove permissions note from device.md

### DIFF
--- a/docs/en/edge/cordova/device/device.md
+++ b/docs/en/edge/cordova/device/device.md
@@ -57,9 +57,6 @@ platform-specific configuration settings described below:
             <param name="android-package" value="org.apache.cordova.Device" />
         </feature>
 
-        (in app/AndroidManifest.xml)
-        <uses-permission android:name="android.permission.READ_PHONE_STATE" />
-
 * BlackBerry WebWorks
 
         (in www/plugins.xml)


### PR DESCRIPTION
For https://issues.apache.org/jira/browse/CB-4811, remove the line about permissions since the Device plugin doesn't use any permissions and doesn't change the AndroidManifest.xml file. 
