### PR TITLE
CB-4890: update Android docs

### DIFF
--- a/docs/en/2.9.0/cordova/media/capture/capture.md
+++ b/docs/en/2.9.0/cordova/media/capture/capture.md
@@ -82,7 +82,7 @@ Permissions
 
 ### Android
 
-#### app/res/xml/plugins.xml
+#### app/res/xml/config.xml
 
     <plugin name="Capture" value="org.apache.cordova.Capture"/>
 


### PR DESCRIPTION
Change 'plugins.xml' to 'config.xml' on Android section of Capture docs in 2.9.x branch. 
https://issues.apache.org/jira/browse/CB-4890
I was not sure how/if we are backporting doc fixes to 2.9.x  - please let me know if there is a better way!
