### PR TITLE
Remove stray 'i'

### DIFF
--- a/docs/en/3.0.0/guide/platforms/ios/plugin.md
+++ b/docs/en/3.0.0/guide/platforms/ios/plugin.md
@@ -44,7 +44,7 @@ application's project's `config.xml` file.
 
 The feature `name` attribute should match what you use in the JavaScript
 `exec` call's `service` parameter, and the `value` attribute should match the name of the plugin's
-Objective-C class. `<param name>` should always be i`"ios-package"`.
+Objective-C class. `<param name>` should always be `"ios-package"`.
 If you do not follow this setup, the plugin may compile but will not be
 reachable by Cordova.
 

--- a/docs/en/3.1.0/guide/platforms/ios/plugin.md
+++ b/docs/en/3.1.0/guide/platforms/ios/plugin.md
@@ -44,7 +44,7 @@ application's project's `config.xml` file.
 
 The feature `name` attribute should match what you use in the JavaScript
 `exec` call's `service` parameter, and the `value` attribute should match the name of the plugin's
-Objective-C class. `<param name>` should always be i`"ios-package"`.
+Objective-C class. `<param name>` should always be `"ios-package"`.
 If you do not follow this setup, the plugin may compile but will not be
 reachable by Cordova.
 

--- a/docs/en/edge/guide/platforms/ios/plugin.md
+++ b/docs/en/edge/guide/platforms/ios/plugin.md
@@ -44,7 +44,7 @@ application's project's `config.xml` file.
 
 The feature `name` attribute should match what you use in the JavaScript
 `exec` call's `service` parameter, and the `value` attribute should match the name of the plugin's
-Objective-C class. `<param name>` should always be i`"ios-package"`.
+Objective-C class. `<param name>` should always be `"ios-package"`.
 If you do not follow this setup, the plugin may compile but will not be
 reachable by Cordova.
 


### PR DESCRIPTION
Visible on this page, for example: 

http://docs.phonegap.com/en/edge/guide_platforms_ios_plugin.md.html

I think the intend may have been to italicize, but based on the guideline "Do not combine in-line formatting such as monospace italic." from https://github.com/apache/cordova-docs/blob/master/STYLESHEET.md, and the other references in the page using monospace for similar terms, and a visual comparison, I think it's better without italics.  
