### PR TITLE
[CB-3816] rewrite plugin search piece

### DIFF
--- a/docs/en/edge/guide/cli/index.md
+++ b/docs/en/edge/guide/cli/index.md
@@ -238,7 +238,7 @@ additional plugins provided by the community, can be found at
 [plugins.cordova.io](http://plugins.cordova.io/). You can use
 the CLI to search for plugins from this registry. For example,
 searching for `bar` and `code` produces a single result that matches
-both substrings:
+both terms as case-insensitive substrings:
 
         $ cordova plugin search bar code
 


### PR DESCRIPTION
explain "cordova plugin search" by example; cordova-only command currently not mirrored by PG
