### PR TITLE
CB-4890: fix edge and backport to 3.0, 3.1

### DIFF
--- a/docs/en/3.0.0/cordova/media/capture/capture.md
+++ b/docs/en/3.0.0/cordova/media/capture/capture.md
@@ -108,7 +108,7 @@ platform-specific configuration settings described below:
 
 * Android
 
-        (in app/res/xml/plugins.xml)
+        (in app/res/xml/config.xml)
         <feature name="Capture">
             <param name="android-package" value="org.apache.cordova.Capture" />
         </feature>

--- a/docs/en/3.1.0/cordova/media/capture/capture.md
+++ b/docs/en/3.1.0/cordova/media/capture/capture.md
@@ -103,7 +103,7 @@ platform-specific configuration settings described below:
 
 * Android
 
-        (in app/res/xml/plugins.xml)
+        (in app/res/xml/config.xml)
         <feature name="Capture">
             <param name="android-package" value="org.apache.cordova.Capture" />
         </feature>

--- a/docs/en/edge/cordova/media/capture/capture.md
+++ b/docs/en/edge/cordova/media/capture/capture.md
@@ -104,7 +104,7 @@ platform-specific configuration settings described below:
 
 * Android
 
-        (in app/res/xml/plugins.xml)
+        (in app/res/xml/config.xml)
         <feature name="File">
             <param name="android-package" value="org.apache.cordova.file.FileUtils" />
         </feature>


### PR DESCRIPTION
Replace "plugins.xml" with "config.xml" on media capture's doc on edge, 3.1, and 3.0. The original ticket was just about backporting this to 2.9...somehow I forgot it in 3.0, 3.1, edge -.-
