### PR TITLE
Fixed RemoveEventListener Full Example

### DIFF
--- a/docs/en/3.1.0/cordova/inappbrowser/inappbrowser.md
+++ b/docs/en/3.1.0/cordova/inappbrowser/inappbrowser.md
@@ -206,7 +206,7 @@ The function is passed an `InAppBrowserEvent` object.
              iabRef = window.open('http://apache.org', '_blank', 'location=yes');
              iabRef.addEventListener('loadstart', iabLoadStart);
              iabRef.addEventListener('loadstop', iabLoadStop);
-             iabRef.removeEventListener('loaderror', iabLoadError);
+             iabRef.addEventListener('loaderror', iabLoadError);
              iabRef.addEventListener('exit', iabClose);
         }
 


### PR DESCRIPTION
addEventListener() should be called onDeviceReady() instead of removeEventListener().
