### PR TITLE
Fixed Syntax Error - executeScript() Full Example

### DIFF
--- a/docs/en/3.1.0/cordova/inappbrowser/inappbrowser.md
+++ b/docs/en/3.1.0/cordova/inappbrowser/inappbrowser.md
@@ -374,7 +374,7 @@ The function is passed an `InAppBrowserEvent` object.
                 code: "var img=document.querySelector('#header img'); img.src='http://cordova.apache.org/images/cordova_bot.png';"
             }, function() {
                 alert("Image Element Successfully Hijacked");
-            }
+            });
         }
 
         function iabClose(event) {


### PR DESCRIPTION
Added missing ');' in replaceHeaderImage() in the Full Example of executeScript().
