### PR TITLE
Fix syntax errors - insertCSS() Full Example

### DIFF
--- a/docs/en/3.1.0/cordova/inappbrowser/inappbrowser.md
+++ b/docs/en/3.1.0/cordova/inappbrowser/inappbrowser.md
@@ -444,10 +444,10 @@ The function is passed an `InAppBrowserEvent` object.
         //
         function changeBackgroundColor() {
             iabRef.insertCSS({
-                code: "body { background: #ffff00"
+                code: "body { background: #ffff00; }"
             }, function() {
                 alert("Styles Altered");
-            }
+            });
         }
 
         function iabClose(event) {


### PR DESCRIPTION
Fixed syntax errors in changeBackgroundColor() in insertCSS() full example.
