### PR TITLE
eliminate unnecessary packages from ubuntu install command

### DIFF
--- a/docs/en/3.3.0/guide/platforms/ubuntu/index.md
+++ b/docs/en/3.3.0/guide/platforms/ubuntu/index.md
@@ -65,9 +65,9 @@ to your Ubuntu system:
     $ sudo add-apt-repository ppa:cordova-ubuntu/ppa
     $ sudo apt-get update
 
-Install packages:
+Install cordova-cli package (and its dependencies):
 
-    $ sudo apt-get install cordova-cli nodejs-legacy npm cmake debhelper libx11-dev libicu-dev pkg-config qtbase5-dev qtchooser qtdeclarative5-dev qtfeedback5-dev qtlocation5-dev qtmultimedia5-dev qtpim5-dev qtsensors5-dev qtsystems5-dev
+    $ sudo apt-get install cordova-cli
 
 ## Project Workflow
 


### PR DESCRIPTION
The 3.3.0 documented command to install cordova-cli on Ubuntu incorrectly requires the user to explicitly list a large number of packages that are redundant and unnecessary since they are all dependencies of the single cordova-cli package that they do need to installed. 

This branch correctly reduces the install command to the single needed package.

https://issues.apache.org/jira/browse/CB-5700
