### PR TITLE
[CB-5834] remove/hide references to unsupported FireFox OS

### DIFF
--- a/docs/en/edge/guide/cli/index.md
+++ b/docs/en/edge/guide/cli/index.md
@@ -45,7 +45,8 @@ platform's SDK. The CLI supports the following combinations:
 * Windows Phone 7 (Windows)
 * Windows Phone 8 (Windows)
 * Windows 8       (Windows)
-* Firefox OS      (Mac, Linux, Windows)
+
+<!-- * Firefox OS      (Mac, Linux, Windows) -->
 
 On the Mac, the command-line is available via the _Terminal_
 application. On the PC, it's available as _Command Prompt_ under
@@ -126,7 +127,6 @@ SDK.  Run any of these from a Mac:
         $ cordova platform add amazon-fireos
         $ cordova platform add android
         $ cordova platform add blackberry10
-        $ cordova platform add firefoxos
 
 Run any of these from a Windows machine, where _wp_ refers to
 different versions of the Windows Phone operating system:
@@ -137,7 +137,6 @@ different versions of the Windows Phone operating system:
         $ cordova platform add amazon-fireos
         $ cordova platform add android
         $ cordova platform add blackberry10
-        $ cordova platform add firefoxos
 
 Run this to check your current set of platforms:
 


### PR DESCRIPTION
Shouldn't use platforms in CLI examples for which there's no supporting guide doc
