### PR TITLE
CB-6032: Cordova download & SDK links updated

### DIFF
--- a/docs/en/edge/guide/platforms/wp7/index.md
+++ b/docs/en/edge/guide/platforms/wp7/index.md
@@ -53,10 +53,10 @@ insights on developing solutions.
 ## Install SDK and Cordova
 
 Download and install the [Windows Phone
-SDK](http://www.microsoft.com/download/en/details.aspx?displaylang=en&amp;id=27570/).
+SDK](http://www.microsoft.com/en-us/download/details.aspx?id=27570).
 
 Download and extract the latest copy of
-[Cordova](http://phonegap.com/download). You need to work in the
+[Cordova](http://cordova.apache.org/#download). You need to work in the
 `lib\windows-phone-8\wp7` subdirectory, `lib\windows-phone-8\wp8`
 contains the Windows Phone 8 version of Cordova.
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CB-6032

This is about updates for the SDK and Cordova download link.

The WP7 SDK link was obsolete, and the Cordova download link led to the
Phonegap download site.

Now both are updated.
