### PR TITLE
CB-7970 Add cordova-plugin-vibration support for Windows Phone 8.1

### DIFF
--- a/docs/en/edge/guide/support/index.md
+++ b/docs/en/edge/guide/support/index.md
@@ -334,7 +334,7 @@ CLI's shorthand names.
         <td data-col="ios"        class="y"></td>
         <td data-col="ubuntu"        class="n"></td>
         <td data-col="winphone8"  class="y"></td>
-        <td data-col="win8"       class="n"></td>
+        <td data-col="win8"       class="y">* Windows Phone 8.1 only</td>
         <td data-col="tizen"       class="n"></td>
     </tr>
 


### PR DESCRIPTION
Updated the platforms support table

[JIRA issue](https://issues.apache.org/jira/browse/CB-7970)
[Related PR with the implementation](https://github.com/apache/cordova-plugin-vibration/pull/25)
