### PR TITLE
CB-7971 Add cordova-plugin-battery-status support for Windows Phone 8.1

### DIFF
--- a/docs/en/edge/guide/support/index.md
+++ b/docs/en/edge/guide/support/index.md
@@ -113,7 +113,7 @@ CLI's shorthand names.
         <td data-col="ios"        class="y"></td>
         <td data-col="ubuntu"        class="n"></td>
         <td data-col="winphone8"  class="y"></td>
-        <td data-col="win8"       class="n"></td>
+        <td data-col="win8"       class="y">* Windows Phone 8.1 only</td>
         <td data-col="tizen"       class="y"></td>
     </tr>
 


### PR DESCRIPTION
Updated the platforms support table

[JIRA issue](https://issues.apache.org/jira/browse/CB-7971)
[Related PR with the implementation](https://github.com/apache/cordova-plugin-battery-status/pull/19)
