### PR TITLE
Volume events work on Android

### DIFF
--- a/docs/en/4.0.0/cordova/events/events.volumedownbutton.md
+++ b/docs/en/4.0.0/cordova/events/events.volumedownbutton.md
@@ -33,6 +33,7 @@ attach an event listener once the `deviceready` event fires.
 
 ## Supported Platforms
 
+- Android
 - BlackBerry 10
 
 ## Quick Example

--- a/docs/en/4.0.0/cordova/events/events.volumeupbutton.md
+++ b/docs/en/4.0.0/cordova/events/events.volumeupbutton.md
@@ -33,6 +33,7 @@ attach an event listener once the `deviceready` event fires.
 
 ## Supported Platforms
 
+- Android
 - BlackBerry 10
 
 ## Quick Example


### PR DESCRIPTION
Hi,

The volumedownbutton and volumeupbutton work on Android in addition to BlackBerry on Cordova 4.0.0.  I've updated the docs to add Android as a working platform for these events.