### PR TITLE
CB-8724 Added info about getting Cordova command-line to work

### DIFF
--- a/docs/en/4.0.0/guide/platforms/wp8/index.md
+++ b/docs/en/4.0.0/guide/platforms/wp8/index.md
@@ -56,6 +56,8 @@ You need the following:
 
 - The [Windows Phone SDK](https://dev.windowsphone.com/en-us/downloadsdk).
 
+- In order to deploy via the command-line with the Windows Phone 8.0 SDK, the latest [Visual Studio 2012 Update](http://www.microsoft.com/en-us/download/details.aspx?id=39305) must be installed.
+
 To develop Cordova apps for Windows Phone devices, you may use a PC
 running Windows, but you may also develop on a Mac, either by running
 a virtual machine environment or by using Boot Camp to dual-boot a


### PR DESCRIPTION
- Added information about having to install the newest Visual
  Studio 2012 Update. Otherwise, Cordova command-line functionality will
  not work with Windows Phone 8 SDK.