### PR TITLE
Storage.md link to file plugin readme

### DIFF
--- a/docs/en/4.0.0/cordova/storage/storage.md
+++ b/docs/en/4.0.0/cordova/storage/storage.md
@@ -62,7 +62,7 @@ The following platforms support IndexedDB:
 ## Plugin-Based Options
 
 In addition to the storage APIs listed above, the
-[File API](https://github.com/apache/cordova-plugin-file/blob/master/doc/index.md)
+[File API](https://github.com/apache/cordova-plugin-file/blob/master/README.md)
 allows you to cache data on the local file system.  Other
 [Cordova plugins](http://plugins.cordova.io/) provide similar storage options.
 


### PR DESCRIPTION
Storage.md file plugin link changed to point to the projects readme and not the doc index as it no longer exists on master.