### PR TITLE
Fix plugin example to ubuntu platform

### DIFF
--- a/docs/en/edge/guide/platforms/ubuntu/index.md
+++ b/docs/en/edge/guide/platforms/ubuntu/index.md
@@ -95,7 +95,7 @@ Creates an app in a `hello` directory whose display name is
 
     $ cordova run ubuntu
 
-### Add the Battery Status Plugin
+### Add the Camera Plugin
 
-    $ cordova plugin add org.apache.cordova.battery-status
+    $ cordova plugin add org.apache.cordova.camera
 


### PR DESCRIPTION
The Platform Support[1] guide tell ubuntu platform dont support Battery Status plugin

[1]: http://cordova.apache.org/docs/en/4.0.0/guide_support_index.md.html#Platform%20Support