### PR TITLE
fix broken plugman command to install a plugin

### DIFF
--- a/docs/en/5.0.0/plugin_ref/plugman.md
+++ b/docs/en/5.0.0/plugin_ref/plugman.md
@@ -71,7 +71,7 @@ listed on the Platform Guides page.
 
 Once you have installed Plugman and have created a Cordova project, you can start adding plugins to the platform with:
 
-    $ plugman --platform <ios|amazon-fireos|android|blackberry10|wp8> --project <directory> --plugin <name|url|path> [--plugins_dir <directory>] [--www <directory>] [--variable <name>=<value> [--variable <name>=<value> ...]]
+    $ plugman install --platform <ios|amazon-fireos|android|blackberry10|wp8> --project <directory> --plugin <name|url|path> [--plugins_dir <directory>] [--www <directory>] [--variable <name>=<value> [--variable <name>=<value> ...]]
 
 Using minimum parameters, this command installs a plugin into a cordova project. You must specify a platform and cordova project location for that platform. You also must specify a plugin, with the different `--plugin` parameter forms being:
 


### PR DESCRIPTION
Trying to install with just "plugman" rather than "plugman install" showed the usage instructions (tested with plugman version 0.23.1).

A few suggestions:

1. Point the doc page over to https://github.com/apache/cordova-plugman/blob/master/README.md, rather than maintaining two in parallel (that's asking for divergence). The options listed in this doc do not match those given by the plugman usage instructions (e.g. doc mentions a "--plugins_dir" option that is not mentioned by the "plugman --help"), implying that one or the other is wrong.
2. Enable the issue tracker here on Github.
3. Link to this repository from the documentation website; I had to hunt to find it.