### PR TITLE
CB-5578 Documents new hooks introduced by 'clean' command

### DIFF
--- a/docs/en/edge/guide/appdev/hooks/index.md
+++ b/docs/en/edge/guide/appdev/hooks/index.md
@@ -36,6 +36,7 @@ The following hook types are supported:
 
     after_build
     after_compile
+    after_clean
     after_docs
     after_emulate
     after_platform_add
@@ -50,6 +51,7 @@ The following hook types are supported:
     after_run
     after_serve
     before_build
+    before_clean
     before_compile
     before_docs
     before_emulate


### PR DESCRIPTION
This adds `before_clean` and `after_clean` hooks, introduced by https://github.com/apache/cordova-cli/pull/216, to list of available hooks.