### PR TITLE
CB-9408: Documented the new `windows-packageVersion` attribute on

### DIFF
--- a/docs/en/edge/config_ref/index.md
+++ b/docs/en/edge/config_ref/index.md
@@ -79,8 +79,9 @@ platforms:
   expressed in major/minor/patch notation.
 
   The widget tag can also have attributes that specify alternative versions,
-  namely versionCode for Android and CFBundleVersion for iOS. See the
-  Additional Versioning section below for details.
+  namely `versionCode` for Android, `CFBundleVersion` for iOS, and 
+  `packageVersion` for Windows. See the Additional Versioning section below 
+  for details.
 
 - The `<name>` element specifies the app's formal name, as it appears
   on the device's home screen and within app-store interfaces.
@@ -105,18 +106,23 @@ platforms:
 
 ### Additional Versioning
 
-Both, Android and iOS support a second version string (or number) in addition
-to the one visible in app stores,
-[versionCode](http://developer.android.com/tools/publishing/versioning.html)
-for Android and
-[CFBundleVersion](http://stackoverflow.com/questions/4933093/cfbundleversion-in-the-info-plist-upload-error)
-for iOS.
-Below is an example that explicitly sets versionCode and CFBundleVersion
+Android, iOS, and Windows support a second version string (or number) in 
+addition to the one visible in app stores:
+
+- [versionCode](http://developer.android.com/tools/publishing/versioning.html)
+  for Android
+- [CFBundleVersion](http://stackoverflow.com/questions/4933093/cfbundleversion-in-the-info-plist-upload-error)
+  for iOS
+- [packageVersion](https://msdn.microsoft.com/en-us/library/windows/apps/br211441.aspx)
+  for Windows
+
+Below is an example that explicitly sets these properties:
 
         <widget id="io.cordova.hellocordova"
           version="0.0.1"
           android-versionCode="7"
-          ios-CFBundleVersion="3.3.3">
+          ios-CFBundleVersion="3.3.3"
+          windows-packageVersion="1.0.1.2">
 
 If alternative version is not specified, the following
 defaults will be used:
@@ -124,6 +130,7 @@ defaults will be used:
         // assuming version = MAJOR.MINOR.PATCH-whatever
         versionCode = PATCH + MINOR * 100 + MAJOR * 10000
         CFBundleVersion = "MAJOR.MINOR.PATCH"
+        packageVersion = "MAJOR.MINOR.PATCH.0"
 
 ## Global Preferences
 


### PR DESCRIPTION
... `<widget>` to allow Windows to have an independent binary version than its
widget.