### PR TITLE
Docs whitespace and Plugins page HTTPS alert

### DIFF
--- a/www/_includes/tools_and_showcase.html
+++ b/www/_includes/tools_and_showcase.html
@@ -1,7 +1,7 @@
 <div class="container">
     <div class="row showcase_section_intro">
         <div class="col-md-12 text-center">
-            <h1>Codorva Tools</h1>
+            <h1>Cordova Tools</h1>
             <h2>Work with Cordova even more efficiently</h2>
         </div>
     </div>

--- a/www/static/css-src/_docs.scss
+++ b/www/static/css-src/_docs.scss
@@ -1,4 +1,6 @@
 .docs {
+    margin-bottom: 20px;
+
     .site-toc-title {
         font-weight: 300;
         font-size: 22px;

--- a/www/static/plugins/app.js
+++ b/www/static/plugins/app.js
@@ -421,6 +421,13 @@ var App = React.createClass({
                 <PlatformButton platform={platform} keyword={keyword} initiallyActive={active}/>
             );
         }
+        var listContent = null;
+        if(window.location.protocol !== "https:") {
+            listContent = <PluginList plugins={this.state.searchResults} />;
+        } else {
+            var httpUrl = window.location.href.replace("https://", "http://");
+            listContent = <div className="alert alert-warning" role="alert">Search results are not currently supported over HTTPS. Please visit this page <a href={httpUrl}>using HTTP</a></div>;
+        }
         return (
             <div>
                 <div className="container">
@@ -473,7 +480,7 @@ var App = React.createClass({
                         </div>
                     </div>
                 </div>
-                <PluginList plugins={this.state.searchResults} />
+                {listContent}
                 <div className="row plugin-search-credit">
                     Search results powered by <a href="http://npmsearch.com/">npmsearch.com</a>
                 </div>


### PR DESCRIPTION
Adds whitespace to the bottom of the docs pages and an alert for the plugins page for when it is visited over HTTPS (because it does not support HTTPS). Also fixes a typo on the tools part of the main page