### PR TITLE
Implemented 404 page with redirect for old docs links

### DIFF
--- a/www/http/404.html
+++ b/www/http/404.html
@@ -4,4 +4,12 @@ title: Page Not Found
 permalink: 404.html
 ---
 
-Uh-oh.
+<div class="not-found-container">
+    <div class="not-found-header">
+        <h1>404: Not Found</h1>
+    </div>
+    <div id="not-found-redirect-alert" class="not-found-redirect">
+        <div class="alert alert-warning" role="alert">We recently moved our documentation. It looks like the page you were trying to access may have moved <a id="redirect-link">here</a></div>
+    </div>
+</div>
+<script type="text/javascript" src="{{ site.baseurl }}/static/js/404.js" defer></script>

--- a/www/static/css-src/_home.scss
+++ b/www/static/css-src/_home.scss
@@ -2,7 +2,11 @@
 
 
 body {
+	height: 100%;
+}
 
+html {
+	height: 100%;
 }
 
 #hero {
@@ -259,4 +263,21 @@ img#logo_top {
 .add_seemore_links {
 	margin: 15px 0;
 	a {	padding-left:30px; }
+}
+
+.not-found-container {
+	height: 60%;
+	margin: auto;
+	width: 75%;
+}
+
+.not-found-header {
+	padding-top: 15%;
+	text-align: center;
+}
+
+.not-found-redirect {
+	margin-bottom: 20px;
+	text-align: center;
+	display: none;
 }

--- a/www/static/js/404.js
+++ b/www/static/js/404.js
@@ -1,0 +1,30 @@
+
+var splitUrl =  window.location.href.split(/(docs\/..\/[\d\.edge]+)/);
+
+if(splitUrl.length > 2) {
+    var baseUrl = splitUrl[0];
+    var versionString = splitUrl[1];
+    var pageExtension = splitUrl.slice(2).join("");
+
+    pageExtension = pageExtension.split("#")[0];
+    pageExtension = pageExtension.replace(".md", "");
+    pageExtension = pageExtension.replace(/_/g, "/");
+    pageExtension = pageExtension.replace("config/ref", "config_ref");
+    pageExtension = pageExtension.replace("plugin/ref", "plugin_ref");
+    pageExtension = pageExtension.replace("display/name", "display_name");
+    pageExtension = pageExtension.replace("platform/plugin/versioning/ref", "platform_plugin_versioning_ref");
+
+    var newUrl = baseUrl + versionString + pageExtension;
+
+    // Try the new URL to see if it exists
+    $.ajax({
+        url: newUrl,
+        statusCode: {
+            200: function() {
+                // If it does, show it to the user
+                $("#redirect-link").attr("href", newUrl);
+                $("#not-found-redirect-alert").css("display", "block");
+            }
+        }
+    });
+}


### PR DESCRIPTION
Adds a simple 404 page in desperate need of styling that redirects old documentation links to their new paths (if they exist).