### PR TITLE
Cordova website restyle docs

### DIFF
--- a/www/static/css-src/_docs.scss
+++ b/www/static/css-src/_docs.scss
@@ -132,4 +132,48 @@
             background-color: khaki;
         }
     }
+
+    // Styling for the /docs/language/version/index.html pages
+    #home {
+        h1 {
+            border-bottom: 1px solid #919395;
+            padding-bottom: 20px;
+            margin: 30px 0px;
+        }
+
+        h2 {
+            font-weight: normal;
+            margin: 0px 0px 10px 0px;
+            padding: 0px;
+            display: block;
+        }
+
+        h2:after {
+            content: '';
+        }
+
+        span {
+            font-size: 14px;
+        }
+
+        ul {
+            float:left;
+            margin: 0px;
+            padding: 0px;
+        }
+
+        ul li {
+            float: left;
+            list-style: none;
+            margin-bottom: 20px;
+            padding: 0px 20px;
+            width: 240px;
+            height: 120px;
+        }
+    }
+}
+
+// Workaround for the spacing on the Russian /docs/ru/version/index.html pages
+html[lang="ru"] .docs #home ul li {
+    height: 160px;
 }


### PR DESCRIPTION
Restyles the /docs/language/version/index.html pages using the styling from the [old website](https://github.com/apache/cordova-docs/blob/master/template/docs/default/index.css)