### PR TITLE
Fixing consistency and grammatical errors on front page

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -93,8 +93,8 @@ permalink: /
         </div>
         <div class="col-md-7">
             <h2>Create a project</h2>
-            <p>Create a Cordova project using the command-line tool to create a blank project.  Navigate to the directory where to create your project and type <code>cordova create &lt;PATH&gt;</code></p>
-            <p>For a complete set of options, type cordova help create</p>
+            <p>Create a Cordova project using the command-line tool to create a blank project.  Navigate to the directory where you wish to create your project and type <code>cordova create &lt;path&gt;</code></p>
+            <p>For a complete set of options, type <code>cordova help create</code></p>
         </div>
         <div class="col-md-4">
             <div class="well_code">
@@ -112,8 +112,8 @@ permalink: /
         </div>
         <div class="col-md-7">
             <h2>Add a platform</h2>
-            <p>After creating a Cordova project, navigate to the project directory.  From the project directory, you need to add a platform you want to build your app.</p>
-            <p>To add platform, type <code>cordova platform add &lt;platform name&gt;</code>.</p>
+            <p>After creating a Cordova project, navigate to the project directory.  From the project directory, you need to add a platform you want to build your app for.</p>
+            <p>To add a platform, type <code>cordova platform add &lt;platform name&gt;</code>.</p>
             <p>For a complete list of platforms you can add, run <code>cordova platform</code></p>
         </div>
         <div class="col-md-4">
@@ -134,7 +134,7 @@ permalink: /
         <div class="col-md-7">
             <h2>Run your app</h2>
             <p>From the command line, run <code>cordova run &lt;platform name&gt;</code>.</p>
-            <p>You can replace browser with the platform that you would like to run (e.g. iOS, Android, Windows)</p>
+            <p>You can replace browser with the platform that you would like to run (e.g. ios, android, windows)</p>
         </div>
         <div class="col-md-4">
             <div class="well_code">


### PR DESCRIPTION
Other possible improvements:

* In the first bullet, is "Terminal" capitalized for a reason?
* In the second bullet, "Create a Cordova project using the command-line tool to create a blank project" is redundant
* In the fourth bullet, "You can replace browser with the platform that you would like to run (e.g. ios, android, windows)" seems unnecessary (and if it is necessary, should also be mentioned in the preceding bullet)
