### PR TITLE
Cordova website misc fixes

### DIFF
--- a/www/plugins/faq.md
+++ b/www/plugins/faq.md
@@ -21,6 +21,10 @@ Cordova team decided to change official plugin IDs from org.apache.cordova.* to 
 
 Plugin Search displays plugins in the form of cards. Each card contains important information about the plugin. Supported platforms are represented in the form of platform icons across the bottom of the card.
 
+## How can I identify official core plugins?
+
+Core plugins have a blue strip on the left side of their card.
+
 ## Can I still download plugins if I'm using Cordova CLI 4.3.0 or lower?
 
 Yes! You can use Cordova Plugins from the [old plugin registry](http://plugins.cordova.io/).
@@ -39,6 +43,3 @@ Yes there are. Please take a look at [Add Plugin Features]({{ site.baseurl }}/do
 ## I don't like X. How can I help improve the website?
 
 You can help improve this site by opening bugs on [JIRA](https://issues.apache.org/jira/issues/?jql=project%20%3D%20CB%20AND%20status%20%3D%20Open%20AND%20component%20%3D%20%22Registry%20Web%22) or by sending PRs on [GitHub](https://github.com/apache/cordova-docs/tree/cordova-website).
-
-
-

--- a/www/static/css-src/_blog.scss
+++ b/www/static/css-src/_blog.scss
@@ -209,7 +209,7 @@
         footer{
             background-color: #FFF;
             margin: 100px 0;
-            
+
             .title{
                 color: #3992ab;
                 font-size: 12pt;
@@ -221,12 +221,12 @@
                 padding: 0 2px;
             }
             .content{
-                max-height: 40px;
+                margin-bottom: 20px;
             }
         }
     }
     .disqus{
-        margin: 30px 0;
+        margin: 10px 0;
     }
 
     section.nextprev-posts{

--- a/www/static/css-src/_contribute.scss
+++ b/www/static/css-src/_contribute.scss
@@ -16,7 +16,7 @@
     width:1em;
     background-image: url("{{ site.baseurl }}/static/img/bug_icon.svg");
     background-size: 2em 1em;
-    display: inline-block;   
+    display: inline-block;
 }
 
 a:hover .report-bug-icon {
@@ -33,6 +33,11 @@ a:hover .report-bug-icon {
     position: relative;
     list-style: none;
     margin-bottom: 16px;
+    padding-right: 80px;
+
+    white-space:nowrap;
+    text-overflow:ellipsis;
+    overflow: hidden;
 }
 
 .platforms-list li a {
@@ -47,17 +52,21 @@ a:hover .report-bug-icon {
     background: url("{{ site.baseurl }}/static/img/sprite.png") no-repeat;
     background-position: 3px -127px;
     background-color: #4cc2e4;
+    height: 36px;
 }
 .platforms-list li a.link-apache {
     right: 39px;
     background-position: 2px -94px;
 }
-.platforms-list li.first a {
-    width: 108px;
-}
-.platforms-list li.first a.link-apache {
-    width: 129px;
-    right: 111px;
+
+@media (min-width: 400px) {
+    .platforms-list li.first a {
+        width: 108px;
+    }
+    .platforms-list li.first a.link-apache {
+        width: 129px;
+        right: 111px;
+    }
 }
 .contribute-get-started-steps {
     list-style: none;
@@ -79,5 +88,5 @@ a:hover .report-bug-icon {
         color: white;
         margin-left:-40px;
         margin-right:19px;
-    }   
+    }
 }

--- a/www/static/plugins/app.js
+++ b/www/static/plugins/app.js
@@ -470,7 +470,7 @@ var App = React.createClass({
                                 {createPlatformButton("Ubuntu", "cordova-ubuntu", this.state)}
                                 {createPlatformButton("Firefox OS", "cordova-firefoxos", this.state)}
                                 {createPlatformButton("Fire OS", "cordova-amazon-fireos", this.state)}
-                                {createPlatformButton("Wp8", "cordova-wp8", this.state)}
+                                {createPlatformButton("WP8", "cordova-wp8", this.state)}
                                 {createPlatformButton("Browser", "cordova-browser", this.state)}
                             </ul>
                         </div>


### PR DESCRIPTION
Fixes:
* Contribute page
    * Amazon Fire OS no longer gets covered up in small screens (expanded icons collapse)
    * No more duplicated icons; text list items now stay single-lined
* Plugins page
    * Added explanation for core plugins to the FAQ (i.e. the blue strip) from cordova-registry-web
    * Fixed capitalization of WP8
* Blog posts
    * Next/Prev excerpts no longer overlap on small screens