### PR TITLE
Add Keyword Index back to the table of contents

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -152,7 +152,7 @@ gulp.task("serve", ["build"], function () {
     });
 });
 
-gulp.task("gen-full", ["configs", "styles", "plugins"], function (done) {
+gulp.task("gen-full", ["toc", "configs", "styles", "plugins"], function (done) {
     jekyllBuild(done);
 });
 

--- a/www/_data/toc/de-3-1-0-manual.yml
+++ b/www/_data/toc/de-3-1-0-manual.yml
@@ -25,3 +25,4 @@
 - {name: !!python/unicode 'Benachrichtigung', url: !!python/unicode '/docs/de/3.1.0/cordova/notification/notification.html'}
 - {name: !!python/unicode 'SplashScreen', url: !!python/unicode '/docs/de/3.1.0/cordova/splashscreen/splashscreen.html'}
 - {name: !!python/unicode 'Speicher', url: !!python/unicode '/docs/de/3.1.0/cordova/storage/storage.html'}
+- {name: !!python/unicode 'Stichwort-Index', url: !!python/unicode '/docs/de/3.1.0/page_index.html'}

--- a/www/_data/toc/de-3-4-0-manual.yml
+++ b/www/_data/toc/de-3-4-0-manual.yml
@@ -13,3 +13,4 @@
 - {name: !!python/unicode 'Speicher', url: !!python/unicode '/docs/de/3.4.0/cordova/storage/storage.html'}
 - {name: !!python/unicode 'Veranstaltungen', url: !!python/unicode '/docs/de/3.4.0/cordova/events/events.html'}
 - {name: !!python/unicode 'Plugin APIs', url: !!python/unicode '/docs/de/3.4.0/cordova/plugins/pluginapis.html'}
+- {name: !!python/unicode 'Stichwort-Index', url: !!python/unicode '/docs/de/3.4.0/page_index.html'}

--- a/www/_data/toc/de-3-5-0-manual.yml
+++ b/www/_data/toc/de-3-5-0-manual.yml
@@ -13,3 +13,4 @@
 - {name: !!python/unicode 'Speicher', url: !!python/unicode '/docs/de/3.5.0/cordova/storage/storage.html'}
 - {name: !!python/unicode 'Veranstaltungen', url: !!python/unicode '/docs/de/3.5.0/cordova/events/events.html'}
 - {name: !!python/unicode 'Plugin APIs', url: !!python/unicode '/docs/de/3.5.0/cordova/plugins/pluginapis.html'}
+- {name: !!python/unicode 'Stichwort-Index', url: !!python/unicode '/docs/de/3.5.0/page_index.html'}

--- a/www/_data/toc/de-edge-manual.yml
+++ b/www/_data/toc/de-edge-manual.yml
@@ -15,3 +15,4 @@
 - {name: "Die n\xE4chsten Schritte", url: !!python/unicode '/docs/de/edge/guide/next/index.html'}
 - {name: !!python/unicode 'Veranstaltungen', url: !!python/unicode '/docs/de/edge/cordova/events/events.html'}
 - {name: !!python/unicode 'Plugin APIs', url: !!python/unicode '/docs/de/edge/cordova/plugins/pluginapis.html'}
+- {name: !!python/unicode 'Stichwort-Index', url: !!python/unicode '/docs/de/edge/page_index.html'}

--- a/www/_data/toc/en-1-5-0-manual.yml
+++ b/www/_data/toc/en-1-5-0-manual.yml
@@ -13,3 +13,4 @@
 - {name: !!python/unicode 'Notification', url: !!python/unicode '/docs/en/1.5.0/phonegap/notification/notification.html'}
 - {name: !!python/unicode 'Storage', url: !!python/unicode '/docs/en/1.5.0/phonegap/storage/storage.html'}
 - {name: !!python/unicode 'Getting Started Guides', url: !!python/unicode '/docs/en/1.5.0/guide/getting-started/index.html'}
+- {name: !!python/unicode 'Keyword Index', url: !!python/unicode '/docs/en/1.5.0/page_index.html'}

--- a/www/_data/toc/en-1-6-0-manual.yml
+++ b/www/_data/toc/en-1-6-0-manual.yml
@@ -13,3 +13,4 @@
 - {name: !!python/unicode 'Notification', url: !!python/unicode '/docs/en/1.6.0/cordova/notification/notification.html'}
 - {name: !!python/unicode 'Storage', url: !!python/unicode '/docs/en/1.6.0/cordova/storage/storage.html'}
 - {name: !!python/unicode 'Getting Started Guides', url: !!python/unicode '/docs/en/1.6.0/guide/getting-started/index.html'}
+- {name: !!python/unicode 'Keyword Index', url: !!python/unicode '/docs/en/1.6.0/page_index.html'}

--- a/www/_data/toc/en-1-6-1-manual.yml
+++ b/www/_data/toc/en-1-6-1-manual.yml
@@ -13,3 +13,4 @@
 - {name: !!python/unicode 'Notification', url: !!python/unicode '/docs/en/1.6.1/cordova/notification/notification.html'}
 - {name: !!python/unicode 'Storage', url: !!python/unicode '/docs/en/1.6.1/cordova/storage/storage.html'}
 - {name: !!python/unicode 'Getting Started Guides', url: !!python/unicode '/docs/en/1.6.1/guide/getting-started/index.html'}
+- {name: !!python/unicode 'Keyword Index', url: !!python/unicode '/docs/en/1.6.1/page_index.html'}

--- a/www/_data/toc/en-1-7-0-manual.yml
+++ b/www/_data/toc/en-1-7-0-manual.yml
@@ -13,3 +13,4 @@
 - {name: !!python/unicode 'Notification', url: !!python/unicode '/docs/en/1.7.0/cordova/notification/notification.html'}
 - {name: !!python/unicode 'Storage', url: !!python/unicode '/docs/en/1.7.0/cordova/storage/storage.html'}
 - {name: !!python/unicode 'Getting Started Guides', url: !!python/unicode '/docs/en/1.7.0/guide/getting-started/index.html'}
+- {name: !!python/unicode 'Keyword Index', url: !!python/unicode '/docs/en/1.7.0/page_index.html'}

--- a/www/_data/toc/en-1-8-0-manual.yml
+++ b/www/_data/toc/en-1-8-0-manual.yml
@@ -15,3 +15,4 @@
 - {name: !!python/unicode 'Getting Started Guides', url: !!python/unicode '/docs/en/1.8.0/guide/getting-started/index.html'}
 - {name: !!python/unicode 'Upgrading Guides', url: !!python/unicode '/docs/en/1.8.0/guide/upgrading/index.html'}
 - {name: !!python/unicode 'Domain Whitelist Guide', url: !!python/unicode '/docs/en/1.8.0/guide/whitelist/index.html'}
+- {name: !!python/unicode 'Keyword Index', url: !!python/unicode '/docs/en/1.8.0/page_index.html'}

--- a/www/_data/toc/en-1-8-1-manual.yml
+++ b/www/_data/toc/en-1-8-1-manual.yml
@@ -15,3 +15,4 @@
 - {name: !!python/unicode 'Getting Started Guides', url: !!python/unicode '/docs/en/1.8.1/guide/getting-started/index.html'}
 - {name: !!python/unicode 'Upgrading Guides', url: !!python/unicode '/docs/en/1.8.1/guide/upgrading/index.html'}
 - {name: !!python/unicode 'Domain Whitelist Guide', url: !!python/unicode '/docs/en/1.8.1/guide/whitelist/index.html'}
+- {name: !!python/unicode 'Keyword Index', url: !!python/unicode '/docs/en/1.8.1/page_index.html'}

--- a/www/_data/toc/en-1-9-0-manual.yml
+++ b/www/_data/toc/en-1-9-0-manual.yml
@@ -17,3 +17,4 @@
 - {name: !!python/unicode 'Upgrading Guides', url: !!python/unicode '/docs/en/1.9.0/guide/upgrading/index.html'}
 - {name: !!python/unicode 'Domain Whitelist Guide', url: !!python/unicode '/docs/en/1.9.0/guide/whitelist/index.html'}
 - {name: !!python/unicode 'Embedding WebView', url: !!python/unicode '/docs/en/1.9.0/guide/cordova-webview/index.html'}
+- {name: !!python/unicode 'Keyword Index', url: !!python/unicode '/docs/en/1.9.0/page_index.html'}

--- a/www/_data/toc/en-2-0-0-manual.yml
+++ b/www/_data/toc/en-2-0-0-manual.yml
@@ -18,3 +18,4 @@
 - {name: !!python/unicode 'Plugin Development Guide', url: !!python/unicode '/docs/en/2.0.0/guide/plugin-development/index.html'}
 - {name: !!python/unicode 'Domain Whitelist Guide', url: !!python/unicode '/docs/en/2.0.0/guide/whitelist/index.html'}
 - {name: !!python/unicode 'Embedding WebView', url: !!python/unicode '/docs/en/2.0.0/guide/cordova-webview/index.html'}
+- {name: !!python/unicode 'Keyword Index', url: !!python/unicode '/docs/en/2.0.0/page_index.html'}

--- a/www/_data/toc/en-2-1-0-manual.yml
+++ b/www/_data/toc/en-2-1-0-manual.yml
@@ -18,3 +18,4 @@
 - {name: !!python/unicode 'Plugin Development Guide', url: !!python/unicode '/docs/en/2.1.0/guide/plugin-development/index.html'}
 - {name: !!python/unicode 'Domain Whitelist Guide', url: !!python/unicode '/docs/en/2.1.0/guide/whitelist/index.html'}
 - {name: !!python/unicode 'Embedding WebView', url: !!python/unicode '/docs/en/2.1.0/guide/cordova-webview/index.html'}
+- {name: !!python/unicode 'Keyword Index', url: !!python/unicode '/docs/en/2.1.0/page_index.html'}

--- a/www/_data/toc/en-2-2-0-manual.yml
+++ b/www/_data/toc/en-2-2-0-manual.yml
@@ -21,3 +21,4 @@
 - {name: !!python/unicode 'Plugin Development Guide', url: !!python/unicode '/docs/en/2.2.0/guide/plugin-development/index.html'}
 - {name: !!python/unicode 'Domain Whitelist Guide', url: !!python/unicode '/docs/en/2.2.0/guide/whitelist/index.html'}
 - {name: !!python/unicode 'Embedding WebView', url: !!python/unicode '/docs/en/2.2.0/guide/cordova-webview/index.html'}
+- {name: !!python/unicode 'Keyword Index', url: !!python/unicode '/docs/en/2.2.0/page_index.html'}

--- a/www/_data/toc/en-2-3-0-manual.yml
+++ b/www/_data/toc/en-2-3-0-manual.yml
@@ -22,3 +22,4 @@
 - {name: !!python/unicode 'Plugin Development Guide', url: !!python/unicode '/docs/en/2.3.0/guide/plugin-development/index.html'}
 - {name: !!python/unicode 'Domain Whitelist Guide', url: !!python/unicode '/docs/en/2.3.0/guide/whitelist/index.html'}
 - {name: !!python/unicode 'Embedding WebView', url: !!python/unicode '/docs/en/2.3.0/guide/cordova-webview/index.html'}
+- {name: !!python/unicode 'Keyword Index', url: !!python/unicode '/docs/en/2.3.0/page_index.html'}

--- a/www/_data/toc/en-2-4-0-manual.yml
+++ b/www/_data/toc/en-2-4-0-manual.yml
@@ -22,3 +22,4 @@
 - {name: !!python/unicode 'Plugin Development Guide', url: !!python/unicode '/docs/en/2.4.0/guide/plugin-development/index.html'}
 - {name: !!python/unicode 'Domain Whitelist Guide', url: !!python/unicode '/docs/en/2.4.0/guide/whitelist/index.html'}
 - {name: !!python/unicode 'Embedding WebView', url: !!python/unicode '/docs/en/2.4.0/guide/cordova-webview/index.html'}
+- {name: !!python/unicode 'Keyword Index', url: !!python/unicode '/docs/en/2.4.0/page_index.html'}

--- a/www/_data/toc/en-2-5-0-manual.yml
+++ b/www/_data/toc/en-2-5-0-manual.yml
@@ -22,3 +22,4 @@
 - {name: !!python/unicode 'Plugin Development Guide', url: !!python/unicode '/docs/en/2.5.0/guide/plugin-development/index.html'}
 - {name: !!python/unicode 'Domain Whitelist Guide', url: !!python/unicode '/docs/en/2.5.0/guide/whitelist/index.html'}
 - {name: !!python/unicode 'Embedding WebView', url: !!python/unicode '/docs/en/2.5.0/guide/cordova-webview/index.html'}
+- {name: !!python/unicode 'Keyword Index', url: !!python/unicode '/docs/en/2.5.0/page_index.html'}

--- a/www/_data/toc/en-2-6-0-manual.yml
+++ b/www/_data/toc/en-2-6-0-manual.yml
@@ -22,3 +22,4 @@
 - {name: !!python/unicode 'Plugin Development Guide', url: !!python/unicode '/docs/en/2.6.0/guide/plugin-development/index.html'}
 - {name: !!python/unicode 'Domain Whitelist Guide', url: !!python/unicode '/docs/en/2.6.0/guide/whitelist/index.html'}
 - {name: !!python/unicode 'Embedding WebView', url: !!python/unicode '/docs/en/2.6.0/guide/cordova-webview/index.html'}
+- {name: !!python/unicode 'Keyword Index', url: !!python/unicode '/docs/en/2.6.0/page_index.html'}

--- a/www/_data/toc/en-2-7-0-manual.yml
+++ b/www/_data/toc/en-2-7-0-manual.yml
@@ -22,3 +22,4 @@
 - {name: !!python/unicode 'Plugin Development Guide', url: !!python/unicode '/docs/en/2.7.0/guide/plugin-development/index.html'}
 - {name: !!python/unicode 'Domain Whitelist Guide', url: !!python/unicode '/docs/en/2.7.0/guide/whitelist/index.html'}
 - {name: !!python/unicode 'Embedding WebView', url: !!python/unicode '/docs/en/2.7.0/guide/cordova-webview/index.html'}
+- {name: !!python/unicode 'Keyword Index', url: !!python/unicode '/docs/en/2.7.0/page_index.html'}

--- a/www/_data/toc/en-2-8-0-manual.yml
+++ b/www/_data/toc/en-2-8-0-manual.yml
@@ -23,3 +23,4 @@
 - {name: !!python/unicode 'Plugin Development Guide', url: !!python/unicode '/docs/en/2.8.0/guide/plugin-development/index.html'}
 - {name: !!python/unicode 'Domain Whitelist Guide', url: !!python/unicode '/docs/en/2.8.0/guide/whitelist/index.html'}
 - {name: !!python/unicode 'Embedding WebView', url: !!python/unicode '/docs/en/2.8.0/guide/cordova-webview/index.html'}
+- {name: !!python/unicode 'Keyword Index', url: !!python/unicode '/docs/en/2.8.0/page_index.html'}

--- a/www/_data/toc/en-2-9-0-manual.yml
+++ b/www/_data/toc/en-2-9-0-manual.yml
@@ -25,3 +25,4 @@
 - {name: !!python/unicode 'Plugin Development Guide', url: !!python/unicode '/docs/en/2.9.0/guide/plugin-development/index.html'}
 - {name: !!python/unicode 'Domain Whitelist Guide', url: !!python/unicode '/docs/en/2.9.0/guide/whitelist/index.html'}
 - {name: !!python/unicode 'Embedding WebView', url: !!python/unicode '/docs/en/2.9.0/guide/cordova-webview/index.html'}
+- {name: !!python/unicode 'Keyword Index', url: !!python/unicode '/docs/en/2.9.0/page_index.html'}

--- a/www/_data/toc/en-3-0-0-manual.yml
+++ b/www/_data/toc/en-3-0-0-manual.yml
@@ -23,3 +23,4 @@
 - {name: !!python/unicode 'Notification', url: !!python/unicode '/docs/en/3.0.0/cordova/notification/notification.html'}
 - {name: !!python/unicode 'Splashscreen', url: !!python/unicode '/docs/en/3.0.0/cordova/splashscreen/splashscreen.html'}
 - {name: !!python/unicode 'Storage', url: !!python/unicode '/docs/en/3.0.0/cordova/storage/storage.html'}
+- {name: !!python/unicode 'Keyword Index', url: !!python/unicode '/docs/en/3.0.0/page_index.html'}

--- a/www/_data/toc/en-3-1-0-manual.yml
+++ b/www/_data/toc/en-3-1-0-manual.yml
@@ -23,3 +23,4 @@
 - {name: !!python/unicode 'Notification', url: !!python/unicode '/docs/en/3.1.0/cordova/notification/notification.html'}
 - {name: !!python/unicode 'Splashscreen', url: !!python/unicode '/docs/en/3.1.0/cordova/splashscreen/splashscreen.html'}
 - {name: !!python/unicode 'Storage', url: !!python/unicode '/docs/en/3.1.0/cordova/storage/storage.html'}
+- {name: !!python/unicode 'Keyword Index', url: !!python/unicode '/docs/en/3.1.0/page_index.html'}

--- a/www/_data/toc/en-3-2-0-manual.yml
+++ b/www/_data/toc/en-3-2-0-manual.yml
@@ -26,3 +26,4 @@
 - {name: !!python/unicode 'Notification', url: !!python/unicode '/docs/en/3.2.0/cordova/notification/notification.html'}
 - {name: !!python/unicode 'Splashscreen', url: !!python/unicode '/docs/en/3.2.0/cordova/splashscreen/splashscreen.html'}
 - {name: !!python/unicode 'Storage', url: !!python/unicode '/docs/en/3.2.0/cordova/storage/storage.html'}
+- {name: !!python/unicode 'Keyword Index', url: !!python/unicode '/docs/en/3.2.0/page_index.html'}

--- a/www/_data/toc/en-3-3-0-manual.yml
+++ b/www/_data/toc/en-3-3-0-manual.yml
@@ -26,3 +26,4 @@
 - {name: !!python/unicode 'Notification', url: !!python/unicode '/docs/en/3.3.0/cordova/notification/notification.html'}
 - {name: !!python/unicode 'Splashscreen', url: !!python/unicode '/docs/en/3.3.0/cordova/splashscreen/splashscreen.html'}
 - {name: !!python/unicode 'Storage', url: !!python/unicode '/docs/en/3.3.0/cordova/storage/storage.html'}
+- {name: !!python/unicode 'Keyword Index', url: !!python/unicode '/docs/en/3.3.0/page_index.html'}

--- a/www/_data/toc/en-3-4-0-manual.yml
+++ b/www/_data/toc/en-3-4-0-manual.yml
@@ -13,3 +13,4 @@
 - {name: !!python/unicode 'Storage', url: !!python/unicode '/docs/en/3.4.0/cordova/storage/storage.html'}
 - {name: !!python/unicode 'Events', url: !!python/unicode '/docs/en/3.4.0/cordova/events/events.html'}
 - {name: !!python/unicode 'Plugin APIs', url: !!python/unicode '/docs/en/3.4.0/cordova/plugins/pluginapis.html'}
+- {name: !!python/unicode 'Keyword Index', url: !!python/unicode '/docs/en/3.4.0/page_index.html'}

--- a/www/_data/toc/en-3-5-0-manual.yml
+++ b/www/_data/toc/en-3-5-0-manual.yml
@@ -15,3 +15,4 @@
 - {name: !!python/unicode 'Next Steps', url: !!python/unicode '/docs/en/3.5.0/guide/next/index.html'}
 - {name: !!python/unicode 'Events', url: !!python/unicode '/docs/en/3.5.0/cordova/events/events.html'}
 - {name: !!python/unicode 'Plugin APIs', url: !!python/unicode '/docs/en/3.5.0/cordova/plugins/pluginapis.html'}
+- {name: !!python/unicode 'Keyword Index', url: !!python/unicode '/docs/en/3.5.0/page_index.html'}

--- a/www/_data/toc/en-3-6-0-manual.yml
+++ b/www/_data/toc/en-3-6-0-manual.yml
@@ -15,3 +15,4 @@
 - {name: !!python/unicode 'Next Steps', url: !!python/unicode '/docs/en/3.6.0/guide/next/index.html'}
 - {name: !!python/unicode 'Events', url: !!python/unicode '/docs/en/3.6.0/cordova/events/events.html'}
 - {name: !!python/unicode 'Plugin APIs', url: !!python/unicode '/docs/en/3.6.0/cordova/plugins/pluginapis.html'}
+- {name: !!python/unicode 'Keyword Index', url: !!python/unicode '/docs/en/3.6.0/page_index.html'}

--- a/www/_data/toc/en-4-0-0-manual.yml
+++ b/www/_data/toc/en-4-0-0-manual.yml
@@ -15,3 +15,4 @@
 - {name: !!python/unicode 'Next Steps', url: !!python/unicode '/docs/en/4.0.0/guide/next/index.html'}
 - {name: !!python/unicode 'Events', url: !!python/unicode '/docs/en/4.0.0/cordova/events/events.html'}
 - {name: !!python/unicode 'Plugin APIs', url: !!python/unicode '/docs/en/4.0.0/cordova/plugins/pluginapis.html'}
+- {name: !!python/unicode 'Keyword Index', url: !!python/unicode '/docs/en/4.0.0/page_index.html'}

--- a/www/_data/toc/en-5-0-0-manual.yml
+++ b/www/_data/toc/en-5-0-0-manual.yml
@@ -15,3 +15,4 @@
 - {name: !!python/unicode 'Next Steps', url: !!python/unicode '/docs/en/5.0.0/guide/next/index.html'}
 - {name: !!python/unicode 'Events', url: !!python/unicode '/docs/en/5.0.0/cordova/events/events.html'}
 - {name: !!python/unicode 'Plugin APIs', url: !!python/unicode '/docs/en/5.0.0/cordova/plugins/pluginapis.html'}
+- {name: !!python/unicode 'Keyword Index', url: !!python/unicode '/docs/en/5.0.0/page_index.html'}

--- a/www/_data/toc/en-5-1-1-manual.yml
+++ b/www/_data/toc/en-5-1-1-manual.yml
@@ -17,3 +17,4 @@
 - {name: !!python/unicode 'Next Steps', url: !!python/unicode '/docs/en/5.1.1/guide/next/index.html'}
 - {name: !!python/unicode 'Events', url: !!python/unicode '/docs/en/5.1.1/cordova/events/events.html'}
 - {name: !!python/unicode 'Plugin APIs', url: !!python/unicode '/docs/en/5.1.1/cordova/plugins/pluginapis.html'}
+- {name: !!python/unicode 'Keyword Index', url: !!python/unicode '/docs/en/5.1.1/page_index.html'}

--- a/www/_data/toc/en-edge-manual.yml
+++ b/www/_data/toc/en-edge-manual.yml
@@ -17,3 +17,4 @@
 - {name: !!python/unicode 'Next Steps', url: !!python/unicode '/docs/en/edge/guide/next/index.html'}
 - {name: !!python/unicode 'Events', url: !!python/unicode '/docs/en/edge/cordova/events/events.html'}
 - {name: !!python/unicode 'Plugin APIs', url: !!python/unicode '/docs/en/edge/cordova/plugins/pluginapis.html'}
+- {name: !!python/unicode 'Keyword Index', url: !!python/unicode '/docs/en/edge/page_index.html'}

--- a/www/_data/toc/es-3-1-0-manual.yml
+++ b/www/_data/toc/es-3-1-0-manual.yml
@@ -24,3 +24,4 @@
 - {name: "Notificaci\xF3n", url: !!python/unicode '/docs/es/3.1.0/cordova/notification/notification.html'}
 - {name: !!python/unicode 'SplashScreen', url: !!python/unicode '/docs/es/3.1.0/cordova/splashscreen/splashscreen.html'}
 - {name: "Almacenamiento de informaci\xF3n", url: !!python/unicode '/docs/es/3.1.0/cordova/storage/storage.html'}
+- {name: "\xCDndice de palabras clave", url: !!python/unicode '/docs/es/3.1.0/page_index.html'}

--- a/www/_data/toc/es-3-4-0-manual.yml
+++ b/www/_data/toc/es-3-4-0-manual.yml
@@ -9,3 +9,4 @@
 - {name: "Gu\xEDa Whitelist", url: !!python/unicode '/docs/es/3.4.0/guide/appdev/whitelist/index.html'}
 - {name: !!python/unicode 'Almacenamiento', url: !!python/unicode '/docs/es/3.4.0/cordova/storage/storage.html'}
 - {name: !!python/unicode 'Plugin APIs', url: !!python/unicode '/docs/es/3.4.0/cordova/plugins/pluginapis.html'}
+- {name: "\xCDndice de palabras clave", url: !!python/unicode '/docs/es/3.4.0/page_index.html'}

--- a/www/_data/toc/es-3-5-0-manual.yml
+++ b/www/_data/toc/es-3-5-0-manual.yml
@@ -9,3 +9,4 @@
 - {name: "Gu\xEDa Whitelist", url: !!python/unicode '/docs/es/3.5.0/guide/appdev/whitelist/index.html'}
 - {name: !!python/unicode 'Almacenamiento', url: !!python/unicode '/docs/es/3.5.0/cordova/storage/storage.html'}
 - {name: !!python/unicode 'Plugin APIs', url: !!python/unicode '/docs/es/3.5.0/cordova/plugins/pluginapis.html'}
+- {name: "\xCDndice de palabras clave", url: !!python/unicode '/docs/es/3.5.0/page_index.html'}

--- a/www/_data/toc/es-edge-manual.yml
+++ b/www/_data/toc/es-edge-manual.yml
@@ -15,3 +15,4 @@
 - {name: "Ganchos de gu\xEDa", url: !!python/unicode '/docs/es/edge/guide/appdev/hooks/index.html'}
 - {name: !!python/unicode 'Eventos', url: !!python/unicode '/docs/es/edge/cordova/events/events.html'}
 - {name: !!python/unicode 'Plugin APIs', url: !!python/unicode '/docs/es/edge/cordova/plugins/pluginapis.html'}
+- {name: "\xCDndice de palabra clave", url: !!python/unicode '/docs/es/edge/page_index.html'}

--- a/www/_data/toc/fr-3-1-0-manual.yml
+++ b/www/_data/toc/fr-3-1-0-manual.yml
@@ -22,3 +22,4 @@
 - {name: !!python/unicode 'Notification', url: !!python/unicode '/docs/fr/3.1.0/cordova/notification/notification.html'}
 - {name: !!python/unicode 'SplashScreen', url: !!python/unicode '/docs/fr/3.1.0/cordova/splashscreen/splashscreen.html'}
 - {name: !!python/unicode 'Stockage', url: !!python/unicode '/docs/fr/3.1.0/cordova/storage/storage.html'}
+- {name: "Index de mots-cl\xE9s", url: !!python/unicode '/docs/fr/3.1.0/page_index.html'}

--- a/www/_data/toc/fr-3-4-0-manual.yml
+++ b/www/_data/toc/fr-3-4-0-manual.yml
@@ -9,3 +9,4 @@
 - {name: !!python/unicode 'Guide de la liste blanche', url: !!python/unicode '/docs/fr/3.4.0/guide/appdev/whitelist/index.html'}
 - {name: !!python/unicode 'Stockage', url: !!python/unicode '/docs/fr/3.4.0/cordova/storage/storage.html'}
 - {name: !!python/unicode 'Plugin API', url: !!python/unicode '/docs/fr/3.4.0/cordova/plugins/pluginapis.html'}
+- {name: "Index de mots-cl\xE9s", url: !!python/unicode '/docs/fr/3.4.0/page_index.html'}

--- a/www/_data/toc/fr-3-5-0-manual.yml
+++ b/www/_data/toc/fr-3-5-0-manual.yml
@@ -9,3 +9,4 @@
 - {name: !!python/unicode 'Guide de la liste blanche', url: !!python/unicode '/docs/fr/3.5.0/guide/appdev/whitelist/index.html'}
 - {name: !!python/unicode 'Stockage', url: !!python/unicode '/docs/fr/3.5.0/cordova/storage/storage.html'}
 - {name: !!python/unicode 'Plugin API', url: !!python/unicode '/docs/fr/3.5.0/cordova/plugins/pluginapis.html'}
+- {name: "Index de mots-cl\xE9s", url: !!python/unicode '/docs/fr/3.5.0/page_index.html'}

--- a/www/_data/toc/fr-edge-manual.yml
+++ b/www/_data/toc/fr-edge-manual.yml
@@ -12,3 +12,4 @@
 - {name: !!python/unicode 'Guide de crochets', url: !!python/unicode '/docs/fr/edge/guide/appdev/hooks/index.html'}
 - {name: "Prochaines \xE9tapes", url: !!python/unicode '/docs/fr/edge/guide/next/index.html'}
 - {name: !!python/unicode 'Plugin API', url: !!python/unicode '/docs/fr/edge/cordova/plugins/pluginapis.html'}
+- {name: "Index des mots cl\xE9s", url: !!python/unicode '/docs/fr/edge/page_index.html'}

--- a/www/_data/toc/it-3-1-0-manual.yml
+++ b/www/_data/toc/it-3-1-0-manual.yml
@@ -24,3 +24,4 @@
 - {name: !!python/unicode 'Notifica', url: !!python/unicode '/docs/it/3.1.0/cordova/notification/notification.html'}
 - {name: !!python/unicode 'Splashscreen', url: !!python/unicode '/docs/it/3.1.0/cordova/splashscreen/splashscreen.html'}
 - {name: !!python/unicode 'Archiviazione', url: !!python/unicode '/docs/it/3.1.0/cordova/storage/storage.html'}
+- {name: !!python/unicode 'Parola chiave indice', url: !!python/unicode '/docs/it/3.1.0/page_index.html'}

--- a/www/_data/toc/it-3-4-0-manual.yml
+++ b/www/_data/toc/it-3-4-0-manual.yml
@@ -13,3 +13,4 @@
 - {name: !!python/unicode 'Archiviazione', url: !!python/unicode '/docs/it/3.4.0/cordova/storage/storage.html'}
 - {name: !!python/unicode 'Eventi', url: !!python/unicode '/docs/it/3.4.0/cordova/events/events.html'}
 - {name: !!python/unicode 'Plugin API', url: !!python/unicode '/docs/it/3.4.0/cordova/plugins/pluginapis.html'}
+- {name: !!python/unicode 'Parola chiave indice', url: !!python/unicode '/docs/it/3.4.0/page_index.html'}

--- a/www/_data/toc/it-3-5-0-manual.yml
+++ b/www/_data/toc/it-3-5-0-manual.yml
@@ -13,3 +13,4 @@
 - {name: !!python/unicode 'Archiviazione', url: !!python/unicode '/docs/it/3.5.0/cordova/storage/storage.html'}
 - {name: !!python/unicode 'Eventi', url: !!python/unicode '/docs/it/3.5.0/cordova/events/events.html'}
 - {name: !!python/unicode 'Plugin API', url: !!python/unicode '/docs/it/3.5.0/cordova/plugins/pluginapis.html'}
+- {name: !!python/unicode 'Parola chiave indice', url: !!python/unicode '/docs/it/3.5.0/page_index.html'}

--- a/www/_data/toc/it-edge-manual.yml
+++ b/www/_data/toc/it-edge-manual.yml
@@ -16,3 +16,4 @@
 - {name: !!python/unicode 'Prossimi passi', url: !!python/unicode '/docs/it/edge/guide/next/index.html'}
 - {name: !!python/unicode 'Eventi', url: !!python/unicode '/docs/it/edge/cordova/events/events.html'}
 - {name: !!python/unicode 'Plugin API', url: !!python/unicode '/docs/it/edge/cordova/plugins/pluginapis.html'}
+- {name: !!python/unicode 'Indice delle parole chiave', url: !!python/unicode '/docs/it/edge/page_index.html'}

--- a/www/_data/toc/ja-1-7-0-manual.yml
+++ b/www/_data/toc/ja-1-7-0-manual.yml
@@ -13,3 +13,4 @@
 - {name: !!python/unicode 'Notification', url: !!python/unicode '/docs/ja/1.7.0/cordova/notification/notification.html'}
 - {name: !!python/unicode 'Storage', url: !!python/unicode '/docs/ja/1.7.0/cordova/storage/storage.html'}
 - {name: "\u5165\u9580\u30AC\u30A4\u30C9", url: !!python/unicode '/docs/ja/1.7.0/guide/getting-started/index.html'}
+- {name: "\u7D22\u5F15", url: !!python/unicode '/docs/ja/1.7.0/page_index.html'}

--- a/www/_data/toc/ja-1-8-1-manual.yml
+++ b/www/_data/toc/ja-1-8-1-manual.yml
@@ -16,3 +16,4 @@
 - {name: "\u30A2\u30C3\u30D7\u30B0\u30EC\u30FC\u30C9\u30AC\u30A4\u30C9", url: !!python/unicode '/docs/ja/1.8.1/guide/upgrading/index.html'}
 - {name: "\u30C9\u30E1\u30A4\u30F3\u30DB\u30EF\u30A4\u30C8\u30EA\u30B9\u30C8\u30AC\
     \u30A4\u30C9", url: !!python/unicode '/docs/ja/1.8.1/guide/whitelist/index.html'}
+- {name: "\u7D22\u5F15", url: !!python/unicode '/docs/ja/1.8.1/page_index.html'}

--- a/www/_data/toc/ja-1-9-0-manual.yml
+++ b/www/_data/toc/ja-1-9-0-manual.yml
@@ -19,3 +19,4 @@
 - {name: "\u30C9\u30E1\u30A4\u30F3\u30DB\u30EF\u30A4\u30C8\u30EA\u30B9\u30C8\u30AC\
     \u30A4\u30C9", url: !!python/unicode '/docs/ja/1.9.0/guide/whitelist/index.html'}
 - {name: "WebView \u306E\u57CB\u3081\u8FBC\u307F", url: !!python/unicode '/docs/ja/1.9.0/guide/cordova-webview/index.html'}
+- {name: "\u7D22\u5F15", url: !!python/unicode '/docs/ja/1.9.0/page_index.html'}

--- a/www/_data/toc/ja-2-0-0-manual.yml
+++ b/www/_data/toc/ja-2-0-0-manual.yml
@@ -20,3 +20,4 @@
 - {name: "\u30C9\u30E1\u30A4\u30F3\u30DB\u30EF\u30A4\u30C8\u30EA\u30B9\u30C8\u30AC\
     \u30A4\u30C9", url: !!python/unicode '/docs/ja/2.0.0/guide/whitelist/index.html'}
 - {name: "WebView \u306E\u57CB\u3081\u8FBC\u307F", url: !!python/unicode '/docs/ja/2.0.0/guide/cordova-webview/index.html'}
+- {name: "\u7D22\u5F15", url: !!python/unicode '/docs/ja/2.0.0/page_index.html'}

--- a/www/_data/toc/ja-2-1-0-manual.yml
+++ b/www/_data/toc/ja-2-1-0-manual.yml
@@ -20,3 +20,4 @@
 - {name: "\u30C9\u30E1\u30A4\u30F3\u30DB\u30EF\u30A4\u30C8\u30EA\u30B9\u30C8\u30AC\
     \u30A4\u30C9", url: !!python/unicode '/docs/ja/2.1.0/guide/whitelist/index.html'}
 - {name: "WebView \u306E\u57CB\u3081\u8FBC\u307F", url: !!python/unicode '/docs/ja/2.1.0/guide/cordova-webview/index.html'}
+- {name: "\u7D22\u5F15", url: !!python/unicode '/docs/ja/2.1.0/page_index.html'}

--- a/www/_data/toc/ja-2-2-0-manual.yml
+++ b/www/_data/toc/ja-2-2-0-manual.yml
@@ -23,3 +23,4 @@
 - {name: "\u30C9\u30E1\u30A4\u30F3\u30DB\u30EF\u30A4\u30C8\u30EA\u30B9\u30C8\u30AC\
     \u30A4\u30C9", url: !!python/unicode '/docs/ja/2.2.0/guide/whitelist/index.html'}
 - {name: "WebView \u306E\u57CB\u3081\u8FBC\u307F", url: !!python/unicode '/docs/ja/2.2.0/guide/cordova-webview/index.html'}
+- {name: "\u7D22\u5F15", url: !!python/unicode '/docs/ja/2.2.0/page_index.html'}

--- a/www/_data/toc/ja-3-1-0-manual.yml
+++ b/www/_data/toc/ja-3-1-0-manual.yml
@@ -27,3 +27,4 @@
 - {name: "\u901A\u77E5", url: !!python/unicode '/docs/ja/3.1.0/cordova/notification/notification.html'}
 - {name: "\u30B9\u30D7\u30E9\u30C3\u30B7\u30E5 \u30B9\u30AF\u30EA\u30FC\u30F3", url: !!python/unicode '/docs/ja/3.1.0/cordova/splashscreen/splashscreen.html'}
 - {name: "\u30B9\u30C8\u30EC\u30FC\u30B8", url: !!python/unicode '/docs/ja/3.1.0/cordova/storage/storage.html'}
+- {name: "\u30AD\u30FC\u30EF\u30FC\u30C9 \u30A4\u30F3\u30C7\u30C3\u30AF\u30B9", url: !!python/unicode '/docs/ja/3.1.0/page_index.html'}

--- a/www/_data/toc/ja-3-4-0-manual.yml
+++ b/www/_data/toc/ja-3-4-0-manual.yml
@@ -18,3 +18,4 @@
 - {name: "\u30B9\u30C8\u30EC\u30FC\u30B8", url: !!python/unicode '/docs/ja/3.4.0/cordova/storage/storage.html'}
 - {name: "\u30A4\u30D9\u30F3\u30C8", url: !!python/unicode '/docs/ja/3.4.0/cordova/events/events.html'}
 - {name: "\u30D7\u30E9\u30B0\u30A4\u30F3 Api", url: !!python/unicode '/docs/ja/3.4.0/cordova/plugins/pluginapis.html'}
+- {name: "\u30AD\u30FC\u30EF\u30FC\u30C9 \u30A4\u30F3\u30C7\u30C3\u30AF\u30B9", url: !!python/unicode '/docs/ja/3.4.0/page_index.html'}

--- a/www/_data/toc/ja-3-5-0-manual.yml
+++ b/www/_data/toc/ja-3-5-0-manual.yml
@@ -18,3 +18,4 @@
 - {name: "\u30B9\u30C8\u30EC\u30FC\u30B8", url: !!python/unicode '/docs/ja/3.5.0/cordova/storage/storage.html'}
 - {name: "\u30A4\u30D9\u30F3\u30C8", url: !!python/unicode '/docs/ja/3.5.0/cordova/events/events.html'}
 - {name: "\u30D7\u30E9\u30B0\u30A4\u30F3 Api", url: !!python/unicode '/docs/ja/3.5.0/cordova/plugins/pluginapis.html'}
+- {name: "\u30AD\u30FC\u30EF\u30FC\u30C9 \u30A4\u30F3\u30C7\u30C3\u30AF\u30B9", url: !!python/unicode '/docs/ja/3.5.0/page_index.html'}

--- a/www/_data/toc/ja-edge-manual.yml
+++ b/www/_data/toc/ja-edge-manual.yml
@@ -22,3 +22,4 @@
 - {name: "\u6B21\u306E\u30B9\u30C6\u30C3\u30D7", url: !!python/unicode '/docs/ja/edge/guide/next/index.html'}
 - {name: "\u30A4\u30D9\u30F3\u30C8", url: !!python/unicode '/docs/ja/edge/cordova/events/events.html'}
 - {name: "\u30D7\u30E9\u30B0\u30A4\u30F3 Api", url: !!python/unicode '/docs/ja/edge/cordova/plugins/pluginapis.html'}
+- {name: "\u30AD\u30FC\u30EF\u30FC\u30C9 \u30A4\u30F3\u30C7\u30C3\u30AF\u30B9", url: !!python/unicode '/docs/ja/edge/page_index.html'}

--- a/www/_data/toc/ko-2-0-0-manual.yml
+++ b/www/_data/toc/ko-2-0-0-manual.yml
@@ -18,3 +18,4 @@
 - {name: !!python/unicode 'Plugin Development Guide', url: !!python/unicode '/docs/ko/2.0.0/guide/plugin-development/index.html'}
 - {name: !!python/unicode 'Domain Whitelist Guide', url: !!python/unicode '/docs/ko/2.0.0/guide/whitelist/index.html'}
 - {name: !!python/unicode 'Embedding WebView', url: !!python/unicode '/docs/ko/2.0.0/guide/cordova-webview/index.html'}
+- {name: !!python/unicode 'Keyword Index', url: !!python/unicode '/docs/ko/2.0.0/page_index.html'}

--- a/www/_data/toc/ko-3-1-0-manual.yml
+++ b/www/_data/toc/ko-3-1-0-manual.yml
@@ -18,3 +18,4 @@
 - {name: "\uC704\uCE58", url: !!python/unicode '/docs/ko/3.1.0/cordova/geolocation/geolocation.html'}
 - {name: "\uC54C\uB9BC", url: !!python/unicode '/docs/ko/3.1.0/cordova/notification/notification.html'}
 - {name: "\uC2A4\uD1A0\uB9AC\uC9C0", url: !!python/unicode '/docs/ko/3.1.0/cordova/storage/storage.html'}
+- {name: "\uD0A4\uC6CC\uB4DC \uC778\uB371\uC2A4", url: !!python/unicode '/docs/ko/3.1.0/page_index.html'}

--- a/www/_data/toc/ko-3-4-0-manual.yml
+++ b/www/_data/toc/ko-3-4-0-manual.yml
@@ -14,3 +14,4 @@
 - {name: "\uC2A4\uD1A0\uB9AC\uC9C0", url: !!python/unicode '/docs/ko/3.4.0/cordova/storage/storage.html'}
 - {name: "\uC774\uBCA4\uD2B8", url: !!python/unicode '/docs/ko/3.4.0/cordova/events/events.html'}
 - {name: "\uD50C\uB7EC\uADF8\uC778 Api", url: !!python/unicode '/docs/ko/3.4.0/cordova/plugins/pluginapis.html'}
+- {name: "\uD0A4\uC6CC\uB4DC \uC778\uB371\uC2A4", url: !!python/unicode '/docs/ko/3.4.0/page_index.html'}

--- a/www/_data/toc/ko-3-5-0-manual.yml
+++ b/www/_data/toc/ko-3-5-0-manual.yml
@@ -14,3 +14,4 @@
 - {name: "\uC2A4\uD1A0\uB9AC\uC9C0", url: !!python/unicode '/docs/ko/3.5.0/cordova/storage/storage.html'}
 - {name: "\uC774\uBCA4\uD2B8", url: !!python/unicode '/docs/ko/3.5.0/cordova/events/events.html'}
 - {name: "\uD50C\uB7EC\uADF8\uC778 Api", url: !!python/unicode '/docs/ko/3.5.0/cordova/plugins/pluginapis.html'}
+- {name: "\uD0A4\uC6CC\uB4DC \uC778\uB371\uC2A4", url: !!python/unicode '/docs/ko/3.5.0/page_index.html'}

--- a/www/_data/toc/ko-edge-manual.yml
+++ b/www/_data/toc/ko-edge-manual.yml
@@ -18,3 +18,4 @@
 - {name: "\uB2E4\uC74C \uB2E8\uACC4", url: !!python/unicode '/docs/ko/edge/guide/next/index.html'}
 - {name: "\uC774\uBCA4\uD2B8", url: !!python/unicode '/docs/ko/edge/cordova/events/events.html'}
 - {name: "\uD50C\uB7EC\uADF8\uC778 Api", url: !!python/unicode '/docs/ko/edge/cordova/plugins/pluginapis.html'}
+- {name: "\uD0A4\uC6CC\uB4DC \uC778\uB371\uC2A4", url: !!python/unicode '/docs/ko/edge/page_index.html'}

--- a/www/_data/toc/pl-edge-manual.yml
+++ b/www/_data/toc/pl-edge-manual.yml
@@ -14,3 +14,4 @@
 - {name: !!python/unicode 'Kolejne kroki', url: !!python/unicode '/docs/pl/edge/guide/next/index.html'}
 - {name: !!python/unicode 'Wydarzenia', url: !!python/unicode '/docs/pl/edge/cordova/events/events.html'}
 - {name: !!python/unicode 'Plugin API', url: !!python/unicode '/docs/pl/edge/cordova/plugins/pluginapis.html'}
+- {name: "Indeks s\u0142\xF3w kluczowych", url: !!python/unicode '/docs/pl/edge/page_index.html'}

--- a/www/_data/toc/ru-3-1-0-manual.yml
+++ b/www/_data/toc/ru-3-1-0-manual.yml
@@ -34,3 +34,5 @@
 - {name: "\u042D\u043A\u0440\u0430\u043D-\u0437\u0430\u0441\u0442\u0430\u0432\u043A\
     \u0430", url: !!python/unicode '/docs/ru/3.1.0/cordova/splashscreen/splashscreen.html'}
 - {name: "\u0425\u0440\u0430\u043D\u0435\u043D\u0438\u044F", url: !!python/unicode '/docs/ru/3.1.0/cordova/storage/storage.html'}
+- {name: "\u0418\u043D\u0434\u0435\u043A\u0441 \u043A\u043B\u044E\u0447\u0435\u0432\
+    \u044B\u0445 \u0441\u043B\u043E\u0432", url: !!python/unicode '/docs/ru/3.1.0/page_index.html'}

--- a/www/_data/toc/ru-3-4-0-manual.yml
+++ b/www/_data/toc/ru-3-4-0-manual.yml
@@ -28,3 +28,5 @@
 - {name: "\u0425\u0440\u0430\u043D\u0438\u043B\u0438\u0449\u0435", url: !!python/unicode '/docs/ru/3.4.0/cordova/storage/storage.html'}
 - {name: "\u0421\u043E\u0431\u044B\u0442\u0438\u044F", url: !!python/unicode '/docs/ru/3.4.0/cordova/events/events.html'}
 - {name: "API \u043F\u043B\u0430\u0433\u0438\u043D\u043E\u0432", url: !!python/unicode '/docs/ru/3.4.0/cordova/plugins/pluginapis.html'}
+- {name: "\u0410\u043B\u0444\u0430\u0432\u0438\u0442\u043D\u044B\u0439 \u0443\u043A\
+    \u0430\u0437\u0430\u0442\u0435\u043B\u044C", url: !!python/unicode '/docs/ru/3.4.0/page_index.html'}

--- a/www/_data/toc/ru-3-5-0-manual.yml
+++ b/www/_data/toc/ru-3-5-0-manual.yml
@@ -28,3 +28,5 @@
 - {name: "\u0425\u0440\u0430\u043D\u0438\u043B\u0438\u0449\u0435", url: !!python/unicode '/docs/ru/3.5.0/cordova/storage/storage.html'}
 - {name: "\u0421\u043E\u0431\u044B\u0442\u0438\u044F", url: !!python/unicode '/docs/ru/3.5.0/cordova/events/events.html'}
 - {name: "API \u043F\u043B\u0430\u0433\u0438\u043D\u043E\u0432", url: !!python/unicode '/docs/ru/3.5.0/cordova/plugins/pluginapis.html'}
+- {name: "\u0410\u043B\u0444\u0430\u0432\u0438\u0442\u043D\u044B\u0439 \u0443\u043A\
+    \u0430\u0437\u0430\u0442\u0435\u043B\u044C", url: !!python/unicode '/docs/ru/3.5.0/page_index.html'}

--- a/www/_data/toc/ru-5-0-0-manual.yml
+++ b/www/_data/toc/ru-5-0-0-manual.yml
@@ -28,3 +28,5 @@
     \u0430\u0433\u0438", url: !!python/unicode '/docs/ru/5.0.0/guide/next/index.html'}
 - {name: "\u0421\u043E\u0431\u044B\u0442\u0438\u044F", url: !!python/unicode '/docs/ru/5.0.0/cordova/events/events.html'}
 - {name: "API \u043F\u043B\u0430\u0433\u0438\u043D\u043E\u0432", url: !!python/unicode '/docs/ru/5.0.0/cordova/plugins/pluginapis.html'}
+- {name: "\u0410\u043B\u0444\u0430\u0432\u0438\u0442\u043D\u044B\u0439 \u0443\u043A\
+    \u0430\u0437\u0430\u0442\u0435\u043B\u044C", url: !!python/unicode '/docs/ru/5.0.0/page_index.html'}

--- a/www/_data/toc/ru-5-1-1-manual.yml
+++ b/www/_data/toc/ru-5-1-1-manual.yml
@@ -38,3 +38,6 @@
     \u0430\u0433\u0438", url: !!python/unicode '/docs/ru/5.1.1/guide/next/index.html'}
 - {name: "\u0421\u043E\u0431\u044B\u0442\u0438\u044F", url: !!python/unicode '/docs/ru/5.1.1/cordova/events/events.html'}
 - {name: "API \u043F\u043B\u0430\u0433\u0438\u043D\u043E\u0432", url: !!python/unicode '/docs/ru/5.1.1/cordova/plugins/pluginapis.html'}
+- {name: "\u0410\u043B\u0444\u0430\u0432\u0438\u0442\u043D\u044B\u0439 \u0443\u043A\
+    \u0430\u0437\u0430\u0442\u0435\u043B\u044C", url: !!python/unicode '/docs/ru/5.1.1/page_index.html'}
+    

--- a/www/_data/toc/ru-edge-manual.yml
+++ b/www/_data/toc/ru-edge-manual.yml
@@ -38,3 +38,5 @@
     \u0430\u0433\u0438", url: !!python/unicode '/docs/ru/edge/guide/next/index.html'}
 - {name: "\u0421\u043E\u0431\u044B\u0442\u0438\u044F", url: !!python/unicode '/docs/ru/edge/cordova/events/events.html'}
 - {name: "API \u043F\u043B\u0430\u0433\u0438\u043D\u043E\u0432", url: !!python/unicode '/docs/ru/edge/cordova/plugins/pluginapis.html'}
+- {name: "\u0410\u043B\u0444\u0430\u0432\u0438\u0442\u043D\u044B\u0439 \u0443\u043A\
+    \u0430\u0437\u0430\u0442\u0435\u043B\u044C", url: !!python/unicode '/docs/ru/edge/page_index.html'}

--- a/www/_data/toc/sl-3-4-0-manual.yml
+++ b/www/_data/toc/sl-3-4-0-manual.yml
@@ -13,3 +13,4 @@
 - {name: !!python/unicode 'Shranjevanje', url: !!python/unicode '/docs/sl/3.4.0/cordova/storage/storage.html'}
 - {name: !!python/unicode 'Dogodki', url: !!python/unicode '/docs/sl/3.4.0/cordova/events/events.html'}
 - {name: !!python/unicode 'Plugin API', url: !!python/unicode '/docs/sl/3.4.0/cordova/plugins/pluginapis.html'}
+- {name: "Klju\u010Dne besede kazalo", url: !!python/unicode '/docs/sl/3.4.0/page_index.html'}

--- a/www/_data/toc/sl-3-5-0-manual.yml
+++ b/www/_data/toc/sl-3-5-0-manual.yml
@@ -13,3 +13,4 @@
 - {name: !!python/unicode 'Shranjevanje', url: !!python/unicode '/docs/sl/3.5.0/cordova/storage/storage.html'}
 - {name: !!python/unicode 'Dogodki', url: !!python/unicode '/docs/sl/3.5.0/cordova/events/events.html'}
 - {name: !!python/unicode 'Plugin API', url: !!python/unicode '/docs/sl/3.5.0/cordova/plugins/pluginapis.html'}
+- {name: "Klju\u010Dne besede kazalo", url: !!python/unicode '/docs/sl/3.5.0/page_index.html'}

--- a/www/_data/toc/sl-edge-manual.yml
+++ b/www/_data/toc/sl-edge-manual.yml
@@ -13,3 +13,4 @@
 - {name: !!python/unicode 'Shranjevanje', url: !!python/unicode '/docs/sl/edge/cordova/storage/storage.html'}
 - {name: !!python/unicode 'Dogodki', url: !!python/unicode '/docs/sl/edge/cordova/events/events.html'}
 - {name: !!python/unicode 'Plugin API', url: !!python/unicode '/docs/sl/edge/cordova/plugins/pluginapis.html'}
+- {name: "Klju\u010Dne besede kazalo", url: !!python/unicode '/docs/sl/edge/page_index.html'}

--- a/www/_data/toc/zh-3-1-0-manual.yml
+++ b/www/_data/toc/zh-3-1-0-manual.yml
@@ -24,3 +24,4 @@
 - {name: "\u901A\u77E5", url: !!python/unicode '/docs/zh/3.1.0/cordova/notification/notification.html'}
 - {name: "\u9583\u5C4F", url: !!python/unicode '/docs/zh/3.1.0/cordova/splashscreen/splashscreen.html'}
 - {name: "\u5B58\u5132", url: !!python/unicode '/docs/zh/3.1.0/cordova/storage/storage.html'}
+- {name: "\u95DC\u9375\u5B57\u7D22\u5F15", url: !!python/unicode '/docs/zh/3.1.0/page_index.html'}

--- a/www/_data/toc/zh-3-4-0-manual.yml
+++ b/www/_data/toc/zh-3-4-0-manual.yml
@@ -13,3 +13,4 @@
 - {name: "\u5B58\u5132", url: !!python/unicode '/docs/zh/3.4.0/cordova/storage/storage.html'}
 - {name: "\u4E8B\u4EF6", url: !!python/unicode '/docs/zh/3.4.0/cordova/events/events.html'}
 - {name: "\u5916\u639B\u7A0B\u5F0F\u7684 Api", url: !!python/unicode '/docs/zh/3.4.0/cordova/plugins/pluginapis.html'}
+- {name: "\u95DC\u9375\u5B57\u7D22\u5F15", url: !!python/unicode '/docs/zh/3.4.0/page_index.html'}

--- a/www/_data/toc/zh-3-5-0-manual.yml
+++ b/www/_data/toc/zh-3-5-0-manual.yml
@@ -13,3 +13,4 @@
 - {name: "\u5B58\u5132", url: !!python/unicode '/docs/zh/3.5.0/cordova/storage/storage.html'}
 - {name: "\u4E8B\u4EF6", url: !!python/unicode '/docs/zh/3.5.0/cordova/events/events.html'}
 - {name: "\u5916\u639B\u7A0B\u5F0F\u7684 Api", url: !!python/unicode '/docs/zh/3.5.0/cordova/plugins/pluginapis.html'}
+- {name: "\u95DC\u9375\u5B57\u7D22\u5F15", url: !!python/unicode '/docs/zh/3.5.0/page_index.html'}

--- a/www/_data/toc/zh-edge-manual.yml
+++ b/www/_data/toc/zh-edge-manual.yml
@@ -15,3 +15,4 @@
 - {name: "\u5B58\u5132", url: !!python/unicode '/docs/zh/edge/cordova/storage/storage.html'}
 - {name: "\u4E8B\u4EF6", url: !!python/unicode '/docs/zh/edge/cordova/events/events.html'}
 - {name: "\u5916\u639B\u7A0B\u5F0F\u7684 Api", url: !!python/unicode '/docs/zh/edge/cordova/plugins/pluginapis.html'}
+- {name: "\u95DC\u9375\u5B57\u7D22\u5F15", url: !!python/unicode '/docs/zh/edge/page_index.html'}

--- a/www/_includes/docs_index.html
+++ b/www/_includes/docs_index.html
@@ -1,8 +1,9 @@
-<h1>Keyword Index</h1>
+<h1 id="keyword-index-page-title"></h1>
 
 <div id="keyword-index-container" class="keyword-index-list row"></div>
 
 <script>
+var pageTitle = "{{ page.keyword_index_text }}";
 var keywordIndex = [
 {% for entry in site.data.toc[page.generated_toc] %}
     {

--- a/www/_includes/docs_index.html
+++ b/www/_includes/docs_index.html
@@ -1,0 +1,19 @@
+<h1>Keyword Index</h1>
+
+<div id="keyword-index-container" class="keyword-index-list row"></div>
+
+<script>
+var keywordIndex = [
+{% for entry in site.data.toc[page.generated_toc] %}
+    {
+        url: "{{ site.baseurl }}{{ entry.url }}",
+        name: "{{entry.name}}"
+    }
+    {% if forloop.last != true %}
+    ,
+    {% endif %}
+{% endfor %}
+];
+</script>
+
+<script defer type="text/javascript" src="{{ site.baseurl }}/static/js/docs-keyword-index.js"></script>

--- a/www/docs/de/3.1.0/page_index.md
+++ b/www/docs/de/3.1.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-de
+---
+{% include docs_index.html %}

--- a/www/docs/de/3.1.0/page_index.md
+++ b/www/docs/de/3.1.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-de
+keyword_index_text: Stichwort-Index
 ---
 {% include docs_index.html %}

--- a/www/docs/de/3.4.0/page_index.md
+++ b/www/docs/de/3.4.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-de
+---
+{% include docs_index.html %}

--- a/www/docs/de/3.4.0/page_index.md
+++ b/www/docs/de/3.4.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-de
+keyword_index_text: Stichwort-Index
 ---
 {% include docs_index.html %}

--- a/www/docs/de/3.5.0/page_index.md
+++ b/www/docs/de/3.5.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-de
+---
+{% include docs_index.html %}

--- a/www/docs/de/3.5.0/page_index.md
+++ b/www/docs/de/3.5.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-de
+keyword_index_text: Stichwort-Index
 ---
 {% include docs_index.html %}

--- a/www/docs/de/edge/page_index.md
+++ b/www/docs/de/edge/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-de
+---
+{% include docs_index.html %}

--- a/www/docs/de/edge/page_index.md
+++ b/www/docs/de/edge/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-de
+keyword_index_text: Stichwort-Index
 ---
 {% include docs_index.html %}

--- a/www/docs/en/1.5.0/page_index.md
+++ b/www/docs/en/1.5.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-en
+keyword_index_text: Keyword Index
 ---
 {% include docs_index.html %}

--- a/www/docs/en/1.5.0/page_index.md
+++ b/www/docs/en/1.5.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-en
+---
+{% include docs_index.html %}

--- a/www/docs/en/1.6.0/page_index.md
+++ b/www/docs/en/1.6.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-en
+keyword_index_text: Keyword Index
 ---
 {% include docs_index.html %}

--- a/www/docs/en/1.6.0/page_index.md
+++ b/www/docs/en/1.6.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-en
+---
+{% include docs_index.html %}

--- a/www/docs/en/1.6.1/page_index.md
+++ b/www/docs/en/1.6.1/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-en
+keyword_index_text: Keyword Index
 ---
 {% include docs_index.html %}

--- a/www/docs/en/1.6.1/page_index.md
+++ b/www/docs/en/1.6.1/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-en
+---
+{% include docs_index.html %}

--- a/www/docs/en/1.7.0/page_index.md
+++ b/www/docs/en/1.7.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-en
+keyword_index_text: Keyword Index
 ---
 {% include docs_index.html %}

--- a/www/docs/en/1.7.0/page_index.md
+++ b/www/docs/en/1.7.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-en
+---
+{% include docs_index.html %}

--- a/www/docs/en/1.8.0/page_index.md
+++ b/www/docs/en/1.8.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-en
+keyword_index_text: Keyword Index
 ---
 {% include docs_index.html %}

--- a/www/docs/en/1.8.0/page_index.md
+++ b/www/docs/en/1.8.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-en
+---
+{% include docs_index.html %}

--- a/www/docs/en/1.8.1/page_index.md
+++ b/www/docs/en/1.8.1/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-en
+keyword_index_text: Keyword Index
 ---
 {% include docs_index.html %}

--- a/www/docs/en/1.8.1/page_index.md
+++ b/www/docs/en/1.8.1/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-en
+---
+{% include docs_index.html %}

--- a/www/docs/en/1.9.0/page_index.md
+++ b/www/docs/en/1.9.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-en
+keyword_index_text: Keyword Index
 ---
 {% include docs_index.html %}

--- a/www/docs/en/1.9.0/page_index.md
+++ b/www/docs/en/1.9.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-en
+---
+{% include docs_index.html %}

--- a/www/docs/en/2.0.0/page_index.md
+++ b/www/docs/en/2.0.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-en
+keyword_index_text: Keyword Index
 ---
 {% include docs_index.html %}

--- a/www/docs/en/2.0.0/page_index.md
+++ b/www/docs/en/2.0.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-en
+---
+{% include docs_index.html %}

--- a/www/docs/en/2.1.0/page_index.md
+++ b/www/docs/en/2.1.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-en
+keyword_index_text: Keyword Index
 ---
 {% include docs_index.html %}

--- a/www/docs/en/2.1.0/page_index.md
+++ b/www/docs/en/2.1.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-en
+---
+{% include docs_index.html %}

--- a/www/docs/en/2.2.0/page_index.md
+++ b/www/docs/en/2.2.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-en
+keyword_index_text: Keyword Index
 ---
 {% include docs_index.html %}

--- a/www/docs/en/2.2.0/page_index.md
+++ b/www/docs/en/2.2.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-en
+---
+{% include docs_index.html %}

--- a/www/docs/en/2.3.0/page_index.md
+++ b/www/docs/en/2.3.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-en
+keyword_index_text: Keyword Index
 ---
 {% include docs_index.html %}

--- a/www/docs/en/2.3.0/page_index.md
+++ b/www/docs/en/2.3.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-en
+---
+{% include docs_index.html %}

--- a/www/docs/en/2.4.0/page_index.md
+++ b/www/docs/en/2.4.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-en
+keyword_index_text: Keyword Index
 ---
 {% include docs_index.html %}

--- a/www/docs/en/2.4.0/page_index.md
+++ b/www/docs/en/2.4.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-en
+---
+{% include docs_index.html %}

--- a/www/docs/en/2.5.0/page_index.md
+++ b/www/docs/en/2.5.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-en
+keyword_index_text: Keyword Index
 ---
 {% include docs_index.html %}

--- a/www/docs/en/2.5.0/page_index.md
+++ b/www/docs/en/2.5.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-en
+---
+{% include docs_index.html %}

--- a/www/docs/en/2.6.0/page_index.md
+++ b/www/docs/en/2.6.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-en
+keyword_index_text: Keyword Index
 ---
 {% include docs_index.html %}

--- a/www/docs/en/2.6.0/page_index.md
+++ b/www/docs/en/2.6.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-en
+---
+{% include docs_index.html %}

--- a/www/docs/en/2.7.0/page_index.md
+++ b/www/docs/en/2.7.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-en
+keyword_index_text: Keyword Index
 ---
 {% include docs_index.html %}

--- a/www/docs/en/2.7.0/page_index.md
+++ b/www/docs/en/2.7.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-en
+---
+{% include docs_index.html %}

--- a/www/docs/en/2.8.0/page_index.md
+++ b/www/docs/en/2.8.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-en
+keyword_index_text: Keyword Index
 ---
 {% include docs_index.html %}

--- a/www/docs/en/2.8.0/page_index.md
+++ b/www/docs/en/2.8.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-en
+---
+{% include docs_index.html %}

--- a/www/docs/en/2.9.0/page_index.md
+++ b/www/docs/en/2.9.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-en
+keyword_index_text: Keyword Index
 ---
 {% include docs_index.html %}

--- a/www/docs/en/2.9.0/page_index.md
+++ b/www/docs/en/2.9.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-en
+---
+{% include docs_index.html %}

--- a/www/docs/en/3.0.0/page_index.md
+++ b/www/docs/en/3.0.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-en
+keyword_index_text: Keyword Index
 ---
 {% include docs_index.html %}

--- a/www/docs/en/3.0.0/page_index.md
+++ b/www/docs/en/3.0.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-en
+---
+{% include docs_index.html %}

--- a/www/docs/en/3.1.0/page_index.md
+++ b/www/docs/en/3.1.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-en
+keyword_index_text: Keyword Index
 ---
 {% include docs_index.html %}

--- a/www/docs/en/3.1.0/page_index.md
+++ b/www/docs/en/3.1.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-en
+---
+{% include docs_index.html %}

--- a/www/docs/en/3.2.0/page_index.md
+++ b/www/docs/en/3.2.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-en
+keyword_index_text: Keyword Index
 ---
 {% include docs_index.html %}

--- a/www/docs/en/3.2.0/page_index.md
+++ b/www/docs/en/3.2.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-en
+---
+{% include docs_index.html %}

--- a/www/docs/en/3.3.0/page_index.md
+++ b/www/docs/en/3.3.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-en
+keyword_index_text: Keyword Index
 ---
 {% include docs_index.html %}

--- a/www/docs/en/3.3.0/page_index.md
+++ b/www/docs/en/3.3.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-en
+---
+{% include docs_index.html %}

--- a/www/docs/en/3.4.0/page_index.md
+++ b/www/docs/en/3.4.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-en
+keyword_index_text: Keyword Index
 ---
 {% include docs_index.html %}

--- a/www/docs/en/3.4.0/page_index.md
+++ b/www/docs/en/3.4.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-en
+---
+{% include docs_index.html %}

--- a/www/docs/en/3.5.0/page_index.md
+++ b/www/docs/en/3.5.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-en
+keyword_index_text: Keyword Index
 ---
 {% include docs_index.html %}

--- a/www/docs/en/3.5.0/page_index.md
+++ b/www/docs/en/3.5.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-en
+---
+{% include docs_index.html %}

--- a/www/docs/en/3.6.0/page_index.md
+++ b/www/docs/en/3.6.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-en
+keyword_index_text: Keyword Index
 ---
 {% include docs_index.html %}

--- a/www/docs/en/3.6.0/page_index.md
+++ b/www/docs/en/3.6.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-en
+---
+{% include docs_index.html %}

--- a/www/docs/en/4.0.0/page_index.md
+++ b/www/docs/en/4.0.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-en
+keyword_index_text: Keyword Index
 ---
 {% include docs_index.html %}

--- a/www/docs/en/4.0.0/page_index.md
+++ b/www/docs/en/4.0.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-en
+---
+{% include docs_index.html %}

--- a/www/docs/en/5.0.0/page_index.md
+++ b/www/docs/en/5.0.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-en
+keyword_index_text: Keyword Index
 ---
 {% include docs_index.html %}

--- a/www/docs/en/5.0.0/page_index.md
+++ b/www/docs/en/5.0.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-en
+---
+{% include docs_index.html %}

--- a/www/docs/en/5.1.1/page_index.md
+++ b/www/docs/en/5.1.1/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-en
+keyword_index_text: Keyword Index
 ---
 {% include docs_index.html %}

--- a/www/docs/en/5.1.1/page_index.md
+++ b/www/docs/en/5.1.1/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-en
+---
+{% include docs_index.html %}

--- a/www/docs/en/edge/page_index.md
+++ b/www/docs/en/edge/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-en
+keyword_index_text: Keyword Index
 ---
 {% include docs_index.html %}

--- a/www/docs/en/edge/page_index.md
+++ b/www/docs/en/edge/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-en
+---
+{% include docs_index.html %}

--- a/www/docs/es/3.1.0/page_index.md
+++ b/www/docs/es/3.1.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-es
+---
+{% include docs_index.html %}

--- a/www/docs/es/3.1.0/page_index.md
+++ b/www/docs/es/3.1.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-es
+keyword_index_text: \xCDndice de palabras clave
 ---
 {% include docs_index.html %}

--- a/www/docs/es/3.4.0/page_index.md
+++ b/www/docs/es/3.4.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-es
+---
+{% include docs_index.html %}

--- a/www/docs/es/3.4.0/page_index.md
+++ b/www/docs/es/3.4.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-es
+keyword_index_text: \xCDndice de palabras clave
 ---
 {% include docs_index.html %}

--- a/www/docs/es/3.5.0/page_index.md
+++ b/www/docs/es/3.5.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-es
+---
+{% include docs_index.html %}

--- a/www/docs/es/3.5.0/page_index.md
+++ b/www/docs/es/3.5.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-es
+keyword_index_text: \xCDndice de palabras clave
 ---
 {% include docs_index.html %}

--- a/www/docs/es/edge/page_index.md
+++ b/www/docs/es/edge/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-es
+keyword_index_text: \xCDndice de palabra clave
 ---
 {% include docs_index.html %}

--- a/www/docs/es/edge/page_index.md
+++ b/www/docs/es/edge/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-es
+---
+{% include docs_index.html %}

--- a/www/docs/fr/3.1.0/page_index.md
+++ b/www/docs/fr/3.1.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-fr
+keyword_index_text: Index de mots-cl\xE9s
 ---
 {% include docs_index.html %}

--- a/www/docs/fr/3.1.0/page_index.md
+++ b/www/docs/fr/3.1.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-fr
+---
+{% include docs_index.html %}

--- a/www/docs/fr/3.4.0/page_index.md
+++ b/www/docs/fr/3.4.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-fr
+keyword_index_text: Index de mots-cl\xE9s
 ---
 {% include docs_index.html %}

--- a/www/docs/fr/3.4.0/page_index.md
+++ b/www/docs/fr/3.4.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-fr
+---
+{% include docs_index.html %}

--- a/www/docs/fr/3.5.0/page_index.md
+++ b/www/docs/fr/3.5.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-fr
+keyword_index_text: Index de mots-cl\xE9s
 ---
 {% include docs_index.html %}

--- a/www/docs/fr/3.5.0/page_index.md
+++ b/www/docs/fr/3.5.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-fr
+---
+{% include docs_index.html %}

--- a/www/docs/fr/edge/page_index.md
+++ b/www/docs/fr/edge/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-fr
+---
+{% include docs_index.html %}

--- a/www/docs/fr/edge/page_index.md
+++ b/www/docs/fr/edge/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-fr
+keyword_index_text: Index des mots cl\xE9s
 ---
 {% include docs_index.html %}

--- a/www/docs/it/3.1.0/page_index.md
+++ b/www/docs/it/3.1.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-it
+---
+{% include docs_index.html %}

--- a/www/docs/it/3.1.0/page_index.md
+++ b/www/docs/it/3.1.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-it
+keyword_index_text: Parola chiave indice
 ---
 {% include docs_index.html %}

--- a/www/docs/it/3.4.0/page_index.md
+++ b/www/docs/it/3.4.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-it
+---
+{% include docs_index.html %}

--- a/www/docs/it/3.4.0/page_index.md
+++ b/www/docs/it/3.4.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-it
+keyword_index_text: Parola chiave indice
 ---
 {% include docs_index.html %}

--- a/www/docs/it/3.5.0/page_index.md
+++ b/www/docs/it/3.5.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-it
+---
+{% include docs_index.html %}

--- a/www/docs/it/3.5.0/page_index.md
+++ b/www/docs/it/3.5.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-it
+keyword_index_text: Parola chiave indice
 ---
 {% include docs_index.html %}

--- a/www/docs/it/edge/page_index.md
+++ b/www/docs/it/edge/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-it
+keyword_index_text: Indice delle parole chiave
 ---
 {% include docs_index.html %}

--- a/www/docs/it/edge/page_index.md
+++ b/www/docs/it/edge/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-it
+---
+{% include docs_index.html %}

--- a/www/docs/ja/1.7.0/page_index.md
+++ b/www/docs/ja/1.7.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-ja
+---
+{% include docs_index.html %}

--- a/www/docs/ja/1.7.0/page_index.md
+++ b/www/docs/ja/1.7.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-ja
+keyword_index_text: \u7D22\u5F15
 ---
 {% include docs_index.html %}

--- a/www/docs/ja/1.8.1/page_index.md
+++ b/www/docs/ja/1.8.1/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-ja
+---
+{% include docs_index.html %}

--- a/www/docs/ja/1.8.1/page_index.md
+++ b/www/docs/ja/1.8.1/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-ja
+keyword_index_text: \u7D22\u5F15
 ---
 {% include docs_index.html %}

--- a/www/docs/ja/1.9.0/page_index.md
+++ b/www/docs/ja/1.9.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-ja
+---
+{% include docs_index.html %}

--- a/www/docs/ja/1.9.0/page_index.md
+++ b/www/docs/ja/1.9.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-ja
+keyword_index_text: \u7D22\u5F15
 ---
 {% include docs_index.html %}

--- a/www/docs/ja/2.0.0/page_index.md
+++ b/www/docs/ja/2.0.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-ja
+---
+{% include docs_index.html %}

--- a/www/docs/ja/2.0.0/page_index.md
+++ b/www/docs/ja/2.0.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-ja
+keyword_index_text: \u7D22\u5F15
 ---
 {% include docs_index.html %}

--- a/www/docs/ja/2.1.0/page_index.md
+++ b/www/docs/ja/2.1.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-ja
+---
+{% include docs_index.html %}

--- a/www/docs/ja/2.1.0/page_index.md
+++ b/www/docs/ja/2.1.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-ja
+keyword_index_text: \u7D22\u5F15
 ---
 {% include docs_index.html %}

--- a/www/docs/ja/2.2.0/page_index.md
+++ b/www/docs/ja/2.2.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-ja
+---
+{% include docs_index.html %}

--- a/www/docs/ja/2.2.0/page_index.md
+++ b/www/docs/ja/2.2.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-ja
+keyword_index_text: \u7D22\u5F15
 ---
 {% include docs_index.html %}

--- a/www/docs/ja/3.1.0/page_index.md
+++ b/www/docs/ja/3.1.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-ja
+---
+{% include docs_index.html %}

--- a/www/docs/ja/3.1.0/page_index.md
+++ b/www/docs/ja/3.1.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-ja
+keyword_index_text: \u30AD\u30FC\u30EF\u30FC\u30C9 \u30A4\u30F3\u30C7\u30C3\u30AF\u30B9
 ---
 {% include docs_index.html %}

--- a/www/docs/ja/3.4.0/page_index.md
+++ b/www/docs/ja/3.4.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-ja
+---
+{% include docs_index.html %}

--- a/www/docs/ja/3.4.0/page_index.md
+++ b/www/docs/ja/3.4.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-ja
+keyword_index_text: \u30AD\u30FC\u30EF\u30FC\u30C9 \u30A4\u30F3\u30C7\u30C3\u30AF\u30B9
 ---
 {% include docs_index.html %}

--- a/www/docs/ja/3.5.0/page_index.md
+++ b/www/docs/ja/3.5.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-ja
+---
+{% include docs_index.html %}

--- a/www/docs/ja/3.5.0/page_index.md
+++ b/www/docs/ja/3.5.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-ja
+keyword_index_text: \u30AD\u30FC\u30EF\u30FC\u30C9 \u30A4\u30F3\u30C7\u30C3\u30AF\u30B9
 ---
 {% include docs_index.html %}

--- a/www/docs/ja/edge/page_index.md
+++ b/www/docs/ja/edge/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-ja
+---
+{% include docs_index.html %}

--- a/www/docs/ja/edge/page_index.md
+++ b/www/docs/ja/edge/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-ja
+keyword_index_text: \u30AD\u30FC\u30EF\u30FC\u30C9 \u30A4\u30F3\u30C7\u30C3\u30AF\u30B9
 ---
 {% include docs_index.html %}

--- a/www/docs/ko/2.0.0/page_index.md
+++ b/www/docs/ko/2.0.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-ko
+---
+{% include docs_index.html %}

--- a/www/docs/ko/2.0.0/page_index.md
+++ b/www/docs/ko/2.0.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-ko
+keyword_index_text: Keyword Index
 ---
 {% include docs_index.html %}

--- a/www/docs/ko/3.1.0/page_index.md
+++ b/www/docs/ko/3.1.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-ko
+---
+{% include docs_index.html %}

--- a/www/docs/ko/3.1.0/page_index.md
+++ b/www/docs/ko/3.1.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-ko
+keyword_index_text: \uD0A4\uC6CC\uB4DC \uC778\uB371\uC2A4
 ---
 {% include docs_index.html %}

--- a/www/docs/ko/3.4.0/page_index.md
+++ b/www/docs/ko/3.4.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-ko
+---
+{% include docs_index.html %}

--- a/www/docs/ko/3.4.0/page_index.md
+++ b/www/docs/ko/3.4.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-ko
+keyword_index_text: \uD0A4\uC6CC\uB4DC \uC778\uB371\uC2A4
 ---
 {% include docs_index.html %}

--- a/www/docs/ko/3.5.0/page_index.md
+++ b/www/docs/ko/3.5.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-ko
+---
+{% include docs_index.html %}

--- a/www/docs/ko/3.5.0/page_index.md
+++ b/www/docs/ko/3.5.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-ko
+keyword_index_text: \uD0A4\uC6CC\uB4DC \uC778\uB371\uC2A4
 ---
 {% include docs_index.html %}

--- a/www/docs/ko/edge/page_index.md
+++ b/www/docs/ko/edge/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-ko
+---
+{% include docs_index.html %}

--- a/www/docs/ko/edge/page_index.md
+++ b/www/docs/ko/edge/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-ko
+keyword_index_text: \uD0A4\uC6CC\uB4DC \uC778\uB371\uC2A4
 ---
 {% include docs_index.html %}

--- a/www/docs/pl/edge/page_index.md
+++ b/www/docs/pl/edge/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-pl
+keyword_index_text: Indeks s\u0142\xF3w kluczowych
 ---
 {% include docs_index.html %}

--- a/www/docs/pl/edge/page_index.md
+++ b/www/docs/pl/edge/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-pl
+---
+{% include docs_index.html %}

--- a/www/docs/ru/3.1.0/page_index.md
+++ b/www/docs/ru/3.1.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-ru
+---
+{% include docs_index.html %}

--- a/www/docs/ru/3.1.0/page_index.md
+++ b/www/docs/ru/3.1.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-ru
+keyword_index_text: Алфавитный указатель
 ---
 {% include docs_index.html %}

--- a/www/docs/ru/3.4.0/page_index.md
+++ b/www/docs/ru/3.4.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-ru
+---
+{% include docs_index.html %}

--- a/www/docs/ru/3.4.0/page_index.md
+++ b/www/docs/ru/3.4.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-ru
+keyword_index_text: Алфавитный указатель
 ---
 {% include docs_index.html %}

--- a/www/docs/ru/3.5.0/page_index.md
+++ b/www/docs/ru/3.5.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-ru
+---
+{% include docs_index.html %}

--- a/www/docs/ru/3.5.0/page_index.md
+++ b/www/docs/ru/3.5.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-ru
+keyword_index_text: Алфавитный указатель
 ---
 {% include docs_index.html %}

--- a/www/docs/ru/5.0.0/page_index.md
+++ b/www/docs/ru/5.0.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-ru
+---
+{% include docs_index.html %}

--- a/www/docs/ru/5.0.0/page_index.md
+++ b/www/docs/ru/5.0.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-ru
+keyword_index_text: Алфавитный указатель
 ---
 {% include docs_index.html %}

--- a/www/docs/ru/5.1.1/page_index.md
+++ b/www/docs/ru/5.1.1/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-ru
+---
+{% include docs_index.html %}

--- a/www/docs/ru/5.1.1/page_index.md
+++ b/www/docs/ru/5.1.1/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-ru
+keyword_index_text: Алфавитный указатель
 ---
 {% include docs_index.html %}

--- a/www/docs/ru/edge/page_index.md
+++ b/www/docs/ru/edge/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-ru
+---
+{% include docs_index.html %}

--- a/www/docs/ru/edge/page_index.md
+++ b/www/docs/ru/edge/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-ru
+keyword_index_text: Алфавитный указатель
 ---
 {% include docs_index.html %}

--- a/www/docs/sl/3.4.0/page_index.md
+++ b/www/docs/sl/3.4.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-sl
+---
+{% include docs_index.html %}

--- a/www/docs/sl/3.4.0/page_index.md
+++ b/www/docs/sl/3.4.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-sl
+keyword_index_text: Klju\u010Dne besede kazalo
 ---
 {% include docs_index.html %}

--- a/www/docs/sl/3.5.0/page_index.md
+++ b/www/docs/sl/3.5.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-sl
+---
+{% include docs_index.html %}

--- a/www/docs/sl/3.5.0/page_index.md
+++ b/www/docs/sl/3.5.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-sl
+keyword_index_text: Klju\u010Dne besede kazalo
 ---
 {% include docs_index.html %}

--- a/www/docs/sl/edge/page_index.md
+++ b/www/docs/sl/edge/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-sl
+---
+{% include docs_index.html %}

--- a/www/docs/sl/edge/page_index.md
+++ b/www/docs/sl/edge/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-sl
+keyword_index_text: Klju\u010Dne besede kazalo
 ---
 {% include docs_index.html %}

--- a/www/docs/zh/3.1.0/page_index.md
+++ b/www/docs/zh/3.1.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-zh
+keyword_index_text: \u95DC\u9375\u5B57\u7D22\u5F15
 ---
 {% include docs_index.html %}

--- a/www/docs/zh/3.1.0/page_index.md
+++ b/www/docs/zh/3.1.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-zh
+---
+{% include docs_index.html %}

--- a/www/docs/zh/3.4.0/page_index.md
+++ b/www/docs/zh/3.4.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-zh
+keyword_index_text: \u95DC\u9375\u5B57\u7D22\u5F15
 ---
 {% include docs_index.html %}

--- a/www/docs/zh/3.4.0/page_index.md
+++ b/www/docs/zh/3.4.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-zh
+---
+{% include docs_index.html %}

--- a/www/docs/zh/3.5.0/page_index.md
+++ b/www/docs/zh/3.5.0/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-zh
+keyword_index_text: \u95DC\u9375\u5B57\u7D22\u5F15
 ---
 {% include docs_index.html %}

--- a/www/docs/zh/3.5.0/page_index.md
+++ b/www/docs/zh/3.5.0/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-zh
+---
+{% include docs_index.html %}

--- a/www/docs/zh/edge/page_index.md
+++ b/www/docs/zh/edge/page_index.md
@@ -1,4 +1,5 @@
 ---
 layout: docs-zh
+keyword_index_text: \u95DC\u9375\u5B57\u7D22\u5F15
 ---
 {% include docs_index.html %}

--- a/www/docs/zh/edge/page_index.md
+++ b/www/docs/zh/edge/page_index.md
@@ -1,0 +1,4 @@
+---
+layout: docs-zh
+---
+{% include docs_index.html %}

--- a/www/static/css-src/_docs.scss
+++ b/www/static/css-src/_docs.scss
@@ -104,6 +104,18 @@
     .keyword-index-list {
         list-style: none;
 
+        // h2 styling for headers to avoid creating sub-headers in the TOC
+        .keyword-index-h2 {
+            margin-top: 20px;
+            margin-bottom: 10px;
+            color: gray;
+            font-size: 18px;
+            display: inline-block;
+            font-family: inherit;
+            font-weight: 500;
+            line-height: 1.1;
+        }
+
         .keyword-index-sublist {
             min-height: 180px;
             list-style: none;

--- a/www/static/css-src/_docs.scss
+++ b/www/static/css-src/_docs.scss
@@ -101,6 +101,15 @@
         color: gray !important;
     }
 
+    .keyword-index-list {
+        list-style: none;
+
+        .keyword-index-sublist {
+            min-height: 180px;
+            list-style: none;
+        }
+    }
+
     /* Formatting for compatibility table on plugin docs page */
     .compat {
         td {

--- a/www/static/js/docs-keyword-index.js
+++ b/www/static/js/docs-keyword-index.js
@@ -1,0 +1,40 @@
+var createSublist = function() {
+    var ul = document.createElement("div");
+    ul.setAttribute("class", "keyword-index-sublist")
+    return ul;
+}
+
+var createLink = function(href, text) {
+    var a = document.createElement("a");
+    a.textContent = text;
+    a.setAttribute("href", href);
+    return a;
+}
+
+var container = document.getElementById("keyword-index-container");
+var currentLetter = null;
+var currentList = null;
+
+keywordIndex.forEach(function(entry) {
+    // Create a separate sublist for each letter
+    if(currentLetter !== entry.name.charAt(0).toUpperCase()) {
+        if(currentList) {
+            var letterHeader = document.createElement("h2");
+            letterHeader.textContent = currentLetter;
+
+            var letterSection = document.createElement("div");
+            letterSection.setAttribute("class", "col-sm-4");
+            letterSection.appendChild(letterHeader);
+            letterSection.appendChild(currentList);
+            container.appendChild(letterSection);
+        }
+
+        currentList = createSublist();
+        currentLetter = entry.name.charAt(0).toUpperCase();
+    }
+
+    var listItem = document.createElement("div");
+    listItem.appendChild(createLink(entry.url, entry.name));
+
+    currentList.appendChild(listItem);
+});

--- a/www/static/js/docs-keyword-index.js
+++ b/www/static/js/docs-keyword-index.js
@@ -17,10 +17,15 @@ var createHeader = function() {
     return header;
 }
 
+// pageTitle is defined in docs_index.html
+var pageTitleTag = document.getElementById("keyword-index-page-title");
+pageTitleTag.textContent = pageTitle;
+
 var container = document.getElementById("keyword-index-container");
 var currentLetter = null;
 var currentList = null;
 
+// keywordIndex is defined in docs_index.html
 keywordIndex.forEach(function(entry) {
     // Create a separate sublist for each letter
     if(currentLetter !== entry.name.charAt(0).toUpperCase()) {

--- a/www/static/js/docs-keyword-index.js
+++ b/www/static/js/docs-keyword-index.js
@@ -11,6 +11,12 @@ var createLink = function(href, text) {
     return a;
 }
 
+var createHeader = function() {
+    var header = document.createElement("div");
+    header.setAttribute("class", "keyword-index-h2");
+    return header;
+}
+
 var container = document.getElementById("keyword-index-container");
 var currentLetter = null;
 var currentList = null;
@@ -19,7 +25,7 @@ keywordIndex.forEach(function(entry) {
     // Create a separate sublist for each letter
     if(currentLetter !== entry.name.charAt(0).toUpperCase()) {
         if(currentList) {
-            var letterHeader = document.createElement("h2");
+            var letterHeader = createHeader();
             letterHeader.textContent = currentLetter;
 
             var letterSection = document.createElement("div");


### PR DESCRIPTION
Adds a translated keyword index page for each version of the docs that lists all the pages for that language/version. Page titles are scraped using toc.js