### PR TITLE
Minor layout fixes for home and docs

### DIFF
--- a/www/_layouts/docs.html
+++ b/www/_layouts/docs.html
@@ -155,7 +155,7 @@ analytics_id: UA-64283057-1
         <!-- Show warning if this version isn't the latest -->
         {% if page.version != 'edge' %}
         <a href="{{ site.baseurl }}/docs/{{ page.language }}/edge">
-            <div class="alert alert-warning" role="alert">
+            <div class="alert alert-warning not-latest-version-alert" role="alert">
                 <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
                 {{ page.not_latest_warning_text }}
             </div>

--- a/www/index.html
+++ b/www/index.html
@@ -20,7 +20,7 @@ permalink: /
                 <p>Native mobile apps with HTML, CSS & JavaScript</p>
                 <p>Target multiple platforms with one code base</p>
                 <p>Free and open source</p>
-                <div>
+                <div class="hero_supported_platforms">
                     <img src="{{ site.baseurl }}/static/img/platform-logos.svg" width="188px" /><a href="#supported_platforms_section" class="platforms_more">+4 more...</a>
                 </div>
                 <div>

--- a/www/static/css-src/_docs.scss
+++ b/www/static/css-src/_docs.scss
@@ -101,6 +101,10 @@
         color: gray !important;
     }
 
+    .not-latest-version-alert {
+        margin-top: 22px;
+    }
+
     /* Formatting for compatibility table on plugin docs page */
     .compat {
         td {

--- a/www/static/css-src/_home.scss
+++ b/www/static/css-src/_home.scss
@@ -42,10 +42,18 @@ html {
 			div {
 				padding-bottom:20px;
 			}
-			.platforms_more {
-		    	font-size: 12px;
-			    padding-left: 20px;
-			    font-weight: bold;
+			.hero_supported_platforms {
+				img {
+					margin-right: 15px;
+				}
+				.platforms_more {
+					font-size: 12px;
+					font-weight: bold;
+					white-space: nowrap;
+					display: inline-block;
+					margin-top: 10px;
+					padding-left: 5px;
+				}
 			}
 		}
         .btn {


### PR DESCRIPTION
Adds padding to the not latest version text in docs

Also fixes the "+4 more..." text on the front page so that it doesn't wrap awkwardly on small screens(e.g. "+4" on one line and "more..." spilling over to the next).