### PR TITLE
Implementing Proper Latest Docs Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Finally, go into the `cordova-website` directory and commit *all* the changes in
 Working on the Documentation
 ============================
 
-Refer to this [README.md](doc/README/en/edge/README.md) for information about writing documentation.
+Refer to this [README.md](doc/README/en/README.md) for information about writing documentation.
 
 Adding a Tool or a Showcase App
 ===============================

--- a/_config.yml
+++ b/_config.yml
@@ -12,6 +12,8 @@ repo:
     uri:    https://github.com/apache/cordova-docs
     branch: cordova-website
 
+latest_version: 5.1.1
+
 # NOTE: defaults are configured in _defaults.yml, which is a generated file
 
 # =======

--- a/www/_includes/docs_language_redirect.html
+++ b/www/_includes/docs_language_redirect.html
@@ -1,0 +1,2 @@
+{% capture url %}/docs/{{ page.language }}/{{ site.latest_version }}/{% endcapture %}
+{% include redirect.html url=url %}

--- a/www/_includes/docs_root_redirect.html
+++ b/www/_includes/docs_root_redirect.html
@@ -1,0 +1,2 @@
+{% capture url %}/docs/en/{% endcapture %}
+{% include redirect.html url=url %}

--- a/www/_includes/header.html
+++ b/www/_includes/header.html
@@ -15,7 +15,7 @@
             <div class="nav_bar_center">
                 <ul class="nav navbar-nav">
                     <li {% if page.docs_tab %}class="active"{% endif %}>
-                        <a href="{{ site.baseurl }}/docs/en/edge/guide/overview/">Documentation</a>
+                        <a href="{{ site.baseurl }}/docs/en/{{ site.latest_version }}/guide/overview/">Documentation</a>
                     </li>
                     <li {% if page.plugins_tab %}class="active"{% endif %}>
                         <a href="{{ site.baseurl }}/plugins">Plugins</a>

--- a/www/_includes/redirect.html
+++ b/www/_includes/redirect.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<meta http-equiv="refresh" content="0;url={{ site.baseurl }}{{ include.url }}" />
+</head>
+</html>

--- a/www/_layouts/docs.html
+++ b/www/_layouts/docs.html
@@ -153,21 +153,13 @@ analytics_id: UA-64283057-1
         </div>
 
         <!-- Show warning if this version isn't the latest -->
-        {% if page.version != 'edge' %}
-        <a href="{{ site.baseurl }}/docs/{{ page.language }}/edge">
+        {% if page.version != site.latest_version %}
+        <a href="{{ site.baseurl }}/docs/{{ page.language }}/{{ site.latest_version }}">
             <div class="alert alert-warning not-latest-version-alert" role="alert">
                 <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
                 {{ page.not_latest_warning_text }}
             </div>
         </a>
-
-        <!--
-            In case the *same* page in the old docs is
-            required, the following link should be used
-            instead:
-
-            {{ site.baseurl }}{{ page.url | replace:page.version,'edge' }}
-        -->
         {% endif %}
 
         <div id="page-toc-source">
@@ -176,5 +168,5 @@ analytics_id: UA-64283057-1
     </div>
 </div>
 
-<script type="text/javascript" src="{{ site.baseurl }}/static/js/lib/toc.min.js" defer></script>
-<script type="text/javascript" src="{{ site.baseurl }}/static/js/docs.js" defer></script>
+<script defer type="text/javascript" src="{{ site.baseurl }}/static/js/lib/toc.min.js"></script>
+<script defer type="text/javascript" src="{{ site.baseurl }}/static/js/docs.js"></script>

--- a/www/docs/de/index.html
+++ b/www/docs/de/index.html
@@ -1,0 +1,7 @@
+---
+# NOTE:
+#      layout is reset here because there
+#      are default layouts set for docs
+layout:
+---
+{% include docs_language_redirect.html %}

--- a/www/docs/en/index.html
+++ b/www/docs/en/index.html
@@ -1,0 +1,7 @@
+---
+# NOTE:
+#      layout is reset here because there
+#      are default layouts set for docs
+layout:
+---
+{% include docs_language_redirect.html %}

--- a/www/docs/es/index.html
+++ b/www/docs/es/index.html
@@ -1,0 +1,7 @@
+---
+# NOTE:
+#      layout is reset here because there
+#      are default layouts set for docs
+layout:
+---
+{% include docs_language_redirect.html %}

--- a/www/docs/fr/index.html
+++ b/www/docs/fr/index.html
@@ -1,0 +1,7 @@
+---
+# NOTE:
+#      layout is reset here because there
+#      are default layouts set for docs
+layout:
+---
+{% include docs_language_redirect.html %}

--- a/www/docs/index.html
+++ b/www/docs/index.html
@@ -1,0 +1,3 @@
+---
+---
+{% include docs_root_redirect.html %}

--- a/www/docs/it/index.html
+++ b/www/docs/it/index.html
@@ -1,0 +1,7 @@
+---
+# NOTE:
+#      layout is reset here because there
+#      are default layouts set for docs
+layout:
+---
+{% include docs_language_redirect.html %}

--- a/www/docs/ja/index.html
+++ b/www/docs/ja/index.html
@@ -1,0 +1,7 @@
+---
+# NOTE:
+#      layout is reset here because there
+#      are default layouts set for docs
+layout:
+---
+{% include docs_language_redirect.html %}

--- a/www/docs/ko/index.html
+++ b/www/docs/ko/index.html
@@ -1,0 +1,7 @@
+---
+# NOTE:
+#      layout is reset here because there
+#      are default layouts set for docs
+layout:
+---
+{% include docs_language_redirect.html %}

--- a/www/docs/pl/index.html
+++ b/www/docs/pl/index.html
@@ -1,0 +1,7 @@
+---
+# NOTE:
+#      layout is reset here because there
+#      are default layouts set for docs
+layout:
+---
+{% include docs_language_redirect.html %}

--- a/www/docs/ru/index.html
+++ b/www/docs/ru/index.html
@@ -1,0 +1,7 @@
+---
+# NOTE:
+#      layout is reset here because there
+#      are default layouts set for docs
+layout:
+---
+{% include docs_language_redirect.html %}

--- a/www/docs/sl/index.html
+++ b/www/docs/sl/index.html
@@ -1,0 +1,7 @@
+---
+# NOTE:
+#      layout is reset here because there
+#      are default layouts set for docs
+layout:
+---
+{% include docs_language_redirect.html %}

--- a/www/docs/zh/index.html
+++ b/www/docs/zh/index.html
@@ -1,0 +1,7 @@
+---
+# NOTE:
+#      layout is reset here because there
+#      are default layouts set for docs
+layout:
+---
+{% include docs_language_redirect.html %}

--- a/www/index.html
+++ b/www/index.html
@@ -27,7 +27,7 @@ permalink: /
                     <a href="#getstarted" class="col-xs-12 col-sm-5 btn btn-lg btn-primary">
                         Get Started
                     </a>
-                    <a href="{{ site.baseurl }}/docs/en/edge/guide/overview/" class="col-xs-12 col-sm-6 btn btn-lg btn-primary">
+                    <a href="{{ site.baseurl }}/docs/en/{{ site.latest_version }}/guide/overview/" class="col-xs-12 col-sm-6 btn btn-lg btn-primary">
                         Documentation
                     </a>
                 </div>
@@ -75,7 +75,7 @@ permalink: /
         </div>
         <div class="col-md-7 col-xs-10">
             <h2>Installing Cordova</h2>
-            <p>Cordova command-line runs on <a target="_blank" href="http://nodejs.org/">Node.js</a> and is available on <a target="_blank" href="https://npmjs.org/package/cordova">NPM</a>. Follow <a href="{{ site.baseurl }}/docs/en/edge/guide/platforms/">platform specific guides</a> to install additional platform dependencies. Open a command prompt or Terminal, and type <code>npm install -g cordova</code>.</p>
+            <p>Cordova command-line runs on <a target="_blank" href="http://nodejs.org/">Node.js</a> and is available on <a target="_blank" href="https://npmjs.org/package/cordova">NPM</a>. Follow <a href="{{ site.baseurl }}/docs/en/{{ site.latest_version }}/guide/platforms/">platform specific guides</a> to install additional platform dependencies. Open a command prompt or Terminal, and type <code>npm install -g cordova</code>.</p>
         </div>
         <div class="col-md-4 col-xs-12">
             <div class="well_code">
@@ -153,16 +153,16 @@ permalink: /
             <h2>Common next steps</h2>
             <ul class="nav">
                 <li>
-                    <a href="{{ site.baseurl }}/docs/en/edge/guide/overview/">Read the docs</a>
+                    <a href="{{ site.baseurl }}/docs/en/{{ site.latest_version }}/guide/overview/">Read the docs</a>
                 </li>
                 <li>
-                    <a href="{{ site.baseurl }}/docs/en/edge/guide/cli/#link-add-plugin-features">Add a Plugin</a>
+                    <a href="{{ site.baseurl }}/docs/en/{{ site.latest_version }}/guide/cli/#link-add-plugin-features">Add a Plugin</a>
                 </li>
                 <li>
-                    <a href="{{ site.baseurl }}/docs/en/edge/config_ref/images.html">Add Icons and Splash Screen</a>
+                    <a href="{{ site.baseurl }}/docs/en/{{ site.latest_version }}/config_ref/images.html">Add Icons and Splash Screen</a>
                 </li>
                 <li>
-                    <a href="{{ site.baseurl }}/docs/en/edge/config_ref/">Configure Your App</a>
+                    <a href="{{ site.baseurl }}/docs/en/{{ site.latest_version }}/config_ref/">Configure Your App</a>
                 </li>
             </ul>
         </div>
@@ -179,7 +179,7 @@ permalink: /
             <div class="col-md-12 text-center">
                 <h1>Supported Platforms</h1>
                 <h2>See a list of
-                    <a href="{{ site.baseurl }}/docs/en/edge/guide/support/index.html">features supported</a> in each platform</h2>
+                    <a href="{{ site.baseurl }}/docs/en/{{ site.latest_version }}/guide/support/index.html">features supported</a> in each platform</h2>
                 <p>
                     Cordova wraps your HTML/JavaScript app into a native container which can access the device functions of several platforms.
                     These functions are exposed via a unified JavaScript API, allowing you to easily write one set of code to target nearly every

--- a/www/plugins/authors.md
+++ b/www/plugins/authors.md
@@ -40,7 +40,7 @@ Similar to `ecosystem:cordova`, platform support too uses keywords. Just add the
 
 ## Are there any additional documents to assist me with plugins?
 
-Yes there are. Please take a look at the [Plugin Development Guide]({{ site.baseurl }}/docs/en/edge/guide/hybrid/plugins/index.html) for a more detailed guide.
+Yes there are. Please take a look at the [Plugin Development Guide]({{ site.baseurl }}/docs/en/{{ site.latest_version }}/guide/hybrid/plugins/index.html) for a more detailed guide.
 
 ## I don't like X. How can I help improve the website?
 

--- a/www/plugins/faq.md
+++ b/www/plugins/faq.md
@@ -38,7 +38,7 @@ See Cordova [blog]({{ site.baseurl }}/announcements/2015/04/21/plugins-release-a
 
 ## Are there any additional documents to assist me with plugins?
 
-Yes there are. Please take a look at [Add Plugin Features]({{ site.baseurl }}/docs/en/edge/guide/cli/#link-add-plugin-features) for a more detailed guide.
+Yes there are. Please take a look at [Add Plugin Features]({{ site.baseurl }}/docs/en/{{ site.latest_version }}/guide/cli/#link-add-plugin-features) for a more detailed guide.
 
 ## I don't like X. How can I help improve the website?
 

--- a/www/static/plugins/pluginlist.jsx
+++ b/www/static/plugins/pluginlist.jsx
@@ -47,7 +47,7 @@ var PluginList = React.createClass({
             if (plugins.length === 0) {
                 return (
                     <div className="container plugins-results-container">
-                            No plugins found. Learn how to <a href="{{site.baseurl}}/docs/en/edge/guide/hybrid/plugins/index.html">create one</a>
+                            No plugins found. Learn how to <a href="{{site.baseurl}}/docs/en/{{site.latest_version}}/guide/hybrid/plugins/index.html">create one</a>
                     </div>
                 );
             } else {


### PR DESCRIPTION
- Adding docs root and language root redirects.
- Adding `site.latest_version` for that purpose, and for `not_latest_warning_text`.
- Changing all links to `docs/{lang}/edge` to `docs/{lang}/{latest_version}` because that is what they actually should be.