### PR TITLE
Improving 404 for Missing Versions

### DIFF
--- a/www/http/404.html
+++ b/www/http/404.html
@@ -9,7 +9,10 @@ permalink: 404.html
         <h1>404: Not Found</h1>
     </div>
     <div id="not-found-redirect-alert" class="not-found-redirect">
-        <div class="alert alert-warning" role="alert">It looks like the content has moved <a id="redirect-link">here</a>.</div>
+        <div class="alert alert-warning" role="alert">It looks like the content has moved <a id="new-redirect-link">here</a>.</div>
+    </div>
+    <div id="no-version-redirect-alert" class="not-found-redirect">
+        <div class="alert alert-warning" role="alert">It looks like this version isn't translated. The in-development version is <a id="edge-redirect-link">here</a>.</div>
     </div>
 </div>
 <script type="text/javascript" src="{{ site.baseurl }}/static/js/404.js" defer></script>

--- a/www/static/js/404.js
+++ b/www/static/js/404.js
@@ -1,30 +1,99 @@
+(function () {
+    var DOCS_VERSION_PATTERN = /(docs\/..\/[\d\.edge]+)/;
 
-var splitUrl =  window.location.href.split(/(docs\/..\/[\d\.edge]+)/);
+    function transformOldURL(oldURL) {
+        var splitURL = oldURL.split(DOCS_VERSION_PATTERN);
 
-if(splitUrl.length > 2) {
-    var baseUrl = splitUrl[0];
-    var versionString = splitUrl[1];
-    var pageExtension = splitUrl.slice(2).join("");
+        var baseURL       = splitURL[0];
+        var versionString = splitURL[1];
+        var pageExtension = splitURL.slice(2).join("");
 
-    pageExtension = pageExtension.split("#")[0];
-    pageExtension = pageExtension.replace(".md", "");
-    pageExtension = pageExtension.replace(/_/g, "/");
-    pageExtension = pageExtension.replace("config/ref", "config_ref");
-    pageExtension = pageExtension.replace("plugin/ref", "plugin_ref");
-    pageExtension = pageExtension.replace("display/name", "display_name");
-    pageExtension = pageExtension.replace("platform/plugin/versioning/ref", "platform_plugin_versioning_ref");
+        // get rid of the fragment and replace underscores with slashes
+        // also remove the ".md" extension
+        pageExtension = pageExtension.split("#")[0];
+        pageExtension = pageExtension.replace(".md", "");
+        pageExtension = pageExtension.replace(/_/g, "/");
 
-    var newUrl = baseUrl + versionString + pageExtension;
+        // undo special cases of paths that really do contain underscores
+        // NOTE:
+        //      this list is complete; in the pre-migration docs, no other
+        //      directories or files contained underscores
+        pageExtension = pageExtension.replace("config/ref", "config_ref");
+        pageExtension = pageExtension.replace("plugin/ref", "plugin_ref");
+        pageExtension = pageExtension.replace("display/name", "display_name");
+        pageExtension = pageExtension.replace("platform/plugin/versioning/ref", "platform_plugin_versioning_ref");
 
-    // Try the new URL to see if it exists
-    $.ajax({
-        url: newUrl,
-        statusCode: {
-            200: function() {
-                // If it does, show it to the user
-                $("#redirect-link").attr("href", newUrl);
-                $("#not-found-redirect-alert").css("display", "block");
-            }
+        return baseURL + versionString + pageExtension;
+    }
+
+    function getEdgeURL(url) {
+        return url.replace(/docs\/(..)\/([\d\.edge]+)/, 'docs/$1/edge');
+    }
+
+    function getRootURL(url) {
+        var splitURL      = url.split(DOCS_VERSION_PATTERN);
+        var baseURL       = splitURL[0];
+        var versionString = splitURL[1];
+
+        return baseURL + versionString;
+    }
+
+    function isDocsURL(url) {
+        return DOCS_VERSION_PATTERN.test(url);
+    }
+
+    function tryURL(url, responseMap) {
+        $.ajax({url: url, statusCode: responseMap});
+    }
+
+    function showNewRedirect(url) {
+        $("#new-redirect-link").attr("href", url);
+        $("#not-found-redirect-alert").css("display", "block");
+    }
+
+    function showEdgeRedirect(url) {
+        $("#edge-redirect-link").attr("href", url);
+        $("#no-version-redirect-alert").css("display", "block");
+    }
+
+    function main() {
+
+        var url = window.location.href;
+
+        if (!isDocsURL(url)) {
+            return;
         }
-    });
-}
+
+        // get related URLs
+        var rootURL = getRootURL(url);
+        var edgeURL = getEdgeURL(rootURL);
+        var newURL  = transformOldURL(url);
+
+        // try the root URL
+        $.ajax({
+            url: rootURL,
+            statusCode: {
+
+                // if the root exists, before offering the new
+                // URL, also check if it exists
+                200: function () {
+                    $.ajax({
+                        url: newURL,
+                        statusCode: {
+                            200: function () {
+                                showNewRedirect(newURL)
+                            }
+                        }
+                    });
+                },
+
+                // if it doesn't exist, assume that the version is invalid
+                404: function () {
+                    showEdgeRedirect(edgeURL)
+                }
+            }
+        });
+    }
+
+    main();
+}());


### PR DESCRIPTION
- Now displaying a message for missing docs versions, linking to "edge."
- Still showing "moved here" message for 404s on existing versions.