### PR TITLE
Update to plugin.md regarding Cordova-Android 5.0.x changes

### DIFF
--- a/www/_posts/2015-11-05-cordova-android-5.0.0.md
+++ b/www/_posts/2015-11-05-cordova-android-5.0.0.md
@@ -7,13 +7,13 @@ title:  "Apache Cordova 5.0.0"
 categories: announcements
 tags: news releases
 ---
-We are happy to announce that Cordova Android 5.0.0` has been released.
+We are happy to announce that `Cordova Android 5.0.0` has been released.
 
 With this release, there is now support for Android Marshmallow permission checking in plugins.  Due to the nature of the recent Android changes, the
 major version has been incremented to reflect the new API changes.  Only plugins that use certain permissions as defined by Google are affected
 by this change.
 
-Information on how to use the new Android Permission APIs can be found in the Cordova documentation, which can be found here.
+Information on how to use the new Android Permission APIs can be found in the Cordova documentation, which can be found [here](https://http://cordova.apache.org/docs/en/latest/guide/platforms/android/plugin.html).
 
 To upgrade:
 

--- a/www/_posts/2015-11-05-cordova-android-5.0.0.md
+++ b/www/_posts/2015-11-05-cordova-android-5.0.0.md
@@ -1,0 +1,57 @@
+---
+layout: post
+author:
+    name:Joe Bowser
+    url: https://twitter.com/infil00p
+title:  "Apache Cordova 5.0.0"
+categories: announcements
+tags: news releases
+---
+We are happy to announce that Cordova Android 5.0.0` has been released.
+
+With this release, there is now support for Android Marshmallow permission checking in plugins.  Due to the nature of the recent Android changes, the
+major version has been incremented to reflect the new API changes.  Only plugins that use certain permissions as defined by Google are affected
+by this change.
+
+Information on how to use the new Android Permission APIs can be found in the Cordova documentation, which can be found here.
+
+To upgrade:
+
+    npm install -g cordova
+    cd my_project
+    cordova platform update android@5.0.0
+
+To add it explicitly:
+
+    cordova platform add android@5.0.0
+
+<!--more-->
+## What's new in Android platform
+* [CB-9909](https://issues.apache.org/jira/browse/CB-9909) Shouldn't escape spaces in paths on Windows.
+* [CB-9870](https://issues.apache.org/jira/browse/CB-9870) updated hello world template
+* [CB-9880](https://issues.apache.org/jira/browse/CB-9880) Fixes platform update failure when upgrading from android@<4.1.0
+* [CB-9844](https://issues.apache.org/jira/browse/CB-9844) Remove old .java after renaming activity
+* [CB-9800](https://issues.apache.org/jira/browse/CB-9800)  Fixing contribute link.
+* [CB-9782](https://issues.apache.org/jira/browse/CB-9782)  Check in `cordova-common` dependency
+* [CB-9835](https://issues.apache.org/jira/browse/CB-9909) Downgrade `properties-parser` to prevent failures in Node < 4.x
+* [CB-9782](https://issues.apache.org/jira/browse/CB-9782)  Implements PlatformApi contract for Android platform.
+* [CB-9826](https://issues.apache.org/jira/browse/CB-9826)  Fixed `test-build` script on windows. 
+* Refactor of the Cordova Plugin/Permissions API
+* Bump up to API level 23
+* Commiting code to handle permissions, and the special case of the Geolocation Plugin
+* [CB-9608](https://issues.apache.org/jira/browse/CB-9608) cordova-android no longer builds on Node 0.10 or below
+* [CB-9080](https://issues.apache.org/jira/browse/CB-9080)  Cordova CLI run for Android versions 4.1.1 and lower throws error
+* [CB-9557](https://issues.apache.org/jira/browse/CB-9557) Fixes apk install failure when switching from debug to release build
+* [CB-9496](https://issues.apache.org/jira/browse/CB-9496)  removed permissions added for crosswalk
+* [CB-9402](https://issues.apache.org/jira/browse/CB-9402)  Allow to set gradle distubutionUrl via env variable CORDOVA_ANDROID_GRADLE_DISTRIBUTION_URL
+* [CB-9428](https://issues.apache.org/jira/browse/CB-9428)  update script now bumps up minSdkVersion to 14 if it is less than that.
+* [CB-9430](https://issues.apache.org/jira/browse/CB-9430)  Fixes check_reqs failure when javac returns an extra line
+* [CB-9172](https://issues.apache.org/jira/browse/CB-9172)  Improved emulator deploy stability. This closes #188.
+* [CB-9404](https://issues.apache.org/jira/browse/CB-9409)  Fixed an exception when path contained -debug or -release
+* [CB-8320](https://issues.apache.org/jira/browse/CB-8320)  Setting up gradle so we can use CordovaLib as a standard Android Library
+* [CB-9185](https://issues.apache.org/jira/browse/CB-9185)  Fixed an issue when unsigned apks couldn't be found. 
+* [CB-9397](https://issues.apache.org/jira/browse/CB-9397)  Fixes minor issues with `cordova requirements android`
+* [CB-9389](https://issues.apache.org/jira/browse/CB-9389)  Fixes build/check_reqs hang
+
+
+

--- a/www/docs/en/edge/guide/platforms/android/plugin.md
+++ b/www/docs/en/edge/guide/platforms/android/plugin.md
@@ -259,9 +259,89 @@ As of Cordova 2.0, Plugins can no longer directly access the
 methods exist on the `Context`, so both `getContext()` and
 `getActivity()` can return the required object.
 
+## Android Permissions
+
+Android permissions until recently have been handled at install-time instead
+of runtime.  These permissions are required to be declared on an application that uses
+the permissions, and these permissions need to be added to the Android Manifest.  This can be
+accomplished by using the config.xml to inject these permissions in the AndroidManifest.xml file.
+The example below uses the Contacts permission.
+
+        <config-file target="AndroidManifest.xml" parent="/*">
+            <uses-permission android:name="android.permission.READ_CONTACTS" />
+        </config-file>
+
+## Android Permissions (Cordova-Android 5.0.x and greater)
+
+Android 6.0 "Marshmallow" introduced a new permissions model where
+the user can turn on and off permissions as necessary.  This means that
+applications must handle these permission changes to be future-proof, which
+was the focus of the Cordova-Android 5.0 release.
+
+The permissions that need to be handled at runtime can be found in the Android Developer
+documentation here.
+
+As far as a plugin is concerned, the permission can be requested by calling the ermission method, which signature is as follows:
+
+        cordova.reqquestPermission(CordovaPlugin plugin, int requestCode, String permission);
+
+To cut down on verbosity, it's standard practice to assign this to a local static variable:
+
+    public static final String READ = Manifest.permission.READ_CONTACTS;
+
+
+Then, in the exec method, the permission should be checked:
+
+            if(cordova.hasPermission(READ)) {
+                search(executeArgs);
+            }
+            else
+            {
+                getReadPermission(SEARCH_REQ_CODE);
+            }
+
+In this case, we just call requestPermission:
+
+    protected void getReadPermission(int requestCode)
+    {
+        cordova.requestPermission(this, requestCode, READ);
+    }
+
+This will call the activity and cause a prompt to appear asking for the permission.  Once the user has the permission, the result must be handled with the onRequestPermissionResult method, which
+every plugin should override.  An example of this can be found below:
+
+    public void onRequestPermissionResult(int requestCode, String[] permissions,
+                                             int[] grantResults) throws JSONException
+    {
+        for(int r:grantResults)
+        {
+            if(r == PackageManager.PERMISSION_DENIED)
+            {
+                this.callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.ERROR, PERMISSION_DENIED_ERROR));
+                return;
+            }
+        }
+        switch(requestCode)
+        {
+            case SEARCH_REQ_CODE:
+                search(executeArgs);
+                break;
+            case SAVE_REQ_CODE:
+                save(executeArgs);
+                break;
+            case REMOVE_REQ_CODE:
+                remove(executeArgs);
+                break;
+        }
+    }
+
+
+The switch statement above would return from the prompt and depending on the requestCode that was passed in, it would call the method.  It should be noted that permission prompts may stack if the execution is not handled correctly, and that this should be avoided.
+
 ## Debugging Android Plugins
 
-Eclipse allows you to debug plugins as Java source included in the
-project.  Only the latest version of the Android Developer Tools
-allows you to attach source code to _JAR_ dependencies, so this
-feature is not yet fully supported.
+Android debugging can be done with either Eclipse or Android Studio, although Android
+studio is recommended.  Since Cordova-Android is currently used as a library project,
+and plugins are supported as source code, it is possible to debug the Java code inside 
+a Cordova application just like a native Android application.
+

--- a/www/docs/en/edge/guide/platforms/android/plugin.md
+++ b/www/docs/en/edge/guide/platforms/android/plugin.md
@@ -289,6 +289,9 @@ To cut down on verbosity, it's standard practice to assign this to a local stati
 
     public static final String READ = Manifest.permission.READ_CONTACTS;
 
+It is also standard practice to define the requestCode as follows:
+
+    public static final int SEARCH_REQ_CODE = 0;
 
 Then, in the exec method, the permission should be checked:
 

--- a/www/docs/en/edge/guide/platforms/android/plugin.md
+++ b/www/docs/en/edge/guide/platforms/android/plugin.md
@@ -279,7 +279,7 @@ applications must handle these permission changes to be future-proof, which
 was the focus of the Cordova-Android 5.0 release.
 
 The permissions that need to be handled at runtime can be found in the Android Developer
-documentation here.
+documentation [here](http://developer.android.com/guide/topics/security/permissions.html#perm-groups).
 
 As far as a plugin is concerned, the permission can be requested by calling the permission method, which signature is as follows:
 

--- a/www/docs/en/edge/guide/platforms/android/plugin.md
+++ b/www/docs/en/edge/guide/platforms/android/plugin.md
@@ -281,7 +281,7 @@ was the focus of the Cordova-Android 5.0 release.
 The permissions that need to be handled at runtime can be found in the Android Developer
 documentation here.
 
-As far as a plugin is concerned, the permission can be requested by calling the ermission method, which signature is as follows:
+As far as a plugin is concerned, the permission can be requested by calling the permission method, which signature is as follows:
 
         cordova.reqquestPermission(CordovaPlugin plugin, int requestCode, String permission);
 
@@ -337,6 +337,17 @@ every plugin should override.  An example of this can be found below:
 
 
 The switch statement above would return from the prompt and depending on the requestCode that was passed in, it would call the method.  It should be noted that permission prompts may stack if the execution is not handled correctly, and that this should be avoided.
+
+In addition to asking for permission for a single permission, it is also possible to request permissions for an entire group by defining the permissions array, as what is done with the Geolocation plugin:
+
+    String [] permissions = { Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION };
+
+Then when requesting the permission, all that needs to be done is the following:
+    
+    cordova.requestPermissions(this, 0, permissions);
+
+This requests the permissions specified in the array.  It's a good idea to provide a publicly accessible permissions array since this can be used by plugins that use your plugin as a 
+dependency, although this is not required.
 
 ## Debugging Android Plugins
 


### PR DESCRIPTION
Also changed out-of-date debugging information.  Also, the Android Permissions information was completely missing from the plugin documentation.  