### PR TITLE
Set proper name in iOS config documentation

### DIFF
--- a/www/docs/ru/5.1.1/guide/platforms/ios/config.md
+++ b/www/docs/ru/5.1.1/guide/platforms/ios/config.md
@@ -88,4 +88,4 @@ title: Конфигурация iOS
         
 *   `AppendUserAgent` (строка, не задан по умолчанию): Если параметр установлен, значение будет добавляться в конец старого значения UserAgent для webview. При использовании с OverrideUserAgent, это значение будет игнорироваться.
     
-        <preference name="OverrideUserAgent" value="My Browser" />
+        <preference name="AppendUserAgent" value="My Browser" />


### PR DESCRIPTION
Correct property name in example is wrong