### PR TITLE
Added page describing how to create issues

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -70,6 +70,8 @@ redcarpet:
         # not have a leading or trailing newline
         - lax_spacing
 
+        - tables
+
 kramdown:
     input: GFM
     hard_wrap: false

--- a/www/_includes/head.html
+++ b/www/_includes/head.html
@@ -23,7 +23,12 @@
 
     <!-- CSS -->
     <link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/static/css/main.css">
+
+    {% if page.no_code_highlight %}
+        <!-- The ! operator doesn't seem to work here -->
+    {% else %}
     <link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/static/js/lib/prettify/prettify.css">
+    {% endif %}
 
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>

--- a/www/_layouts/contribute-help.html
+++ b/www/_layouts/contribute-help.html
@@ -1,0 +1,9 @@
+---
+layout: cordova
+---
+
+<div class="container">
+    <div class="contribute-help">
+{{ content }}
+    </div>
+</div>

--- a/www/_layouts/contribute-help.html
+++ b/www/_layouts/contribute-help.html
@@ -1,5 +1,6 @@
 ---
 layout: cordova
+no_code_highlight: true
 ---
 
 <div class="container">

--- a/www/contribute/contribute_guidelines.md
+++ b/www/contribute/contribute_guidelines.md
@@ -21,7 +21,7 @@ Before contributing to Apache Cordova, please complete the following steps:
 Issues for Apache Cordova are hosted in the Apache JIRA. All code contributions made to Cordova should have a corresponding JIRA issue. When reporting issues, please follow [these guidelines](./issues.html).
 
 #### Claiming Issues
-If you find a JIRA issue that you would like to work on, you can ask to claim it; please leave a comment indicating your intention and a committer will assign it to you. Some issues in JIRA are auto-assigned to certain contributors. If it is clear that an issue is not being worked on, feel free to work on it yourself (but please comment first to let the asignee know). If you are looking for a place to start, try searching the [issues labelled easyfix](https://issues.apache.org/jira/browse/CB-9974?jql=project%20%3D%20CB%20AND%20resolution%20%3D%20Unresolved%20AND%20labels%20%3D%20%22easyfix%22%20ORDER%20BY%20createdDate%20DESC).
+If you find a JIRA issue that you would like to work on, you can ask to claim it; please leave a comment indicating your intention and a committer will assign it to you. Some issues in JIRA are auto-assigned to certain contributors. If it is clear that an issue is not being worked on, feel free to work on it yourself (but please comment first to let the asignee know). If you are looking for a place to start, try searching the [issues labelled easyfix](https://issues.apache.org/jira/issues?jql=project%20%3D%20CB%20AND%20resolution%20%3D%20Unresolved%20AND%20labels%20%3D%20%22easyfix%22%20ORDER%20BY%20createdDate%20DESC).
 
 
 ## Submitting Code
@@ -32,7 +32,23 @@ For all submitted code, there must be a corresponding issue in JIRA. If there is
 * Upload patches created with `git format-patch` to the JIRA issue
 * Paste a diff to JIRA (you won't get authorship if you do this)
 
-However you submit code, you should always call out a reviewer to look at and merge your code. A good place to find a reviewer is [the component list](https://issues.apache.org/jira/browse/CB/?selectedTab=com.atlassian.jira.jira-projects-plugin:components-panel) or you can send a mail out to the [dev mailing list](http://cordova.apache.org/contact).
+#### Making Pull requests
+
+The workflow for creating pull requests on Github generally follows these steps:
+
+1. [Open a JIRA issue](./issues.html) if one has not already been created
+2. [Create a local fork](https://help.github.com/articles/fork-a-repo/) of the appropriate Apache repository
+3. In your local fork, create a branch dedicated to the JIRA issue you are working on
+4. Push your commits to this branch
+5. [Squash](http://www.git-scm.com/book/en/v2/Git-Tools-Rewriting-History#Squashing-Commits) these commits into one single commit (see the section below regarding commit messages)
+6. [Create a pull request](https://help.github.com/articles/using-pull-requests/) on the Apache repository
+7. Ask for code review
+
+Please include the JIRA id in the title of any pull requests made to Github. The Apache Git bot will link the PR and the JIRA issue automatically. For more help on Git, see the [Git documentation](http://git-scm.com/doc)
+
+#### Code review
+
+However you submit code, you should always call out a reviewer to look at and merge your code. A good place to find a reviewer is [the component list](https://issues.apache.org/jira/browse/CB/?selectedTab=com.atlassian.jira.jira-projects-plugin:components-panel) or you can send a mail out to the [dev mailing list](http://cordova.apache.org/contact) with a link to the pull request.
 
 ## Testing your code
 
@@ -61,7 +77,6 @@ When contributing, please have your commit messages begin with the JIRA id and r
 CB-2345 android: Improved exec bridge by using strings instead of JSON
 CB-3456 all: Fixed plugin loading paths that start with /
 ```
-Please also include the JIRA id in the title of any pull requests made to Github. The Apache git bot will link the PR and the JIRA issue automatically.
 
 You are highly encouraged to describe your git commit with enough detail for someone else to understand it. In doing so, your commit message can consist of multiple lines. However, it also is highly encouraged that the first line of your commit message not exceed 50 characters. This is because some of the tooling that sits on top of git (such as the httpd apps that let you browse the repos) assumes that the first line is top-level summary that is 50 characters or less. Thus there will be highlighting and truncating of the commit message using these assumptions and it will look weird if these assumptions are not kept. There should also be a blank line between the summary and any further description. For example, here is a good commit message:
 

--- a/www/contribute/contribute_guidelines.md
+++ b/www/contribute/contribute_guidelines.md
@@ -1,0 +1,77 @@
+---
+layout: contribute-help
+title: Apache Cordova Contribute Guidelines
+---
+# Contributor Guidelines
+
+Thanks for helping to improve Cordova! This page provides a general guide on making contributions to Cordova. If you can't find something on this page, please feel free to contact the [dev mailing list](http://cordova.apache.org/contact) or ask questions on the Cordova Slack.
+
+## Prerequisites
+
+Before contributing to Apache Cordova, please complete the following steps:
+
+1. Sign the [Individual Contributor License Agreement (ICLA)](http://www.apache.org/licenses/#clas) and [submit it to the ASF](http://www.apache.org/licenses/#submitting).
+    * You should receive an email confirming you submission within a day or so and your name will appear in the [list of committers and non-committers](https://people.apache.org/committer-index.html)
+    * If you are submitting on behalf of a company, you may need to submit a CCLA as well
+2. Join the [mailing list](http://cordova.apache.org/contact/) and send a brief introduction of yourself
+3. Create an [Apache JIRA](https://issues.apache.org/jira/secure/Signup!default.jspa) account
+
+## Working with JIRA
+
+Issues for Apache Cordova are hosted in the Apache JIRA. All code contributions made to Cordova should have a corresponding JIRA issue. When reporting issues, please follow [these guidelines](./issues.html).
+
+#### Claiming Issues
+If you find a JIRA issue that you would like to work on, you can ask to claim it; please leave a comment indicating your intention and a committer will assign it to you. Some issues in JIRA are auto-assigned to certain contributors. If it is clear that an issue is not being worked on, feel free to work on it yourself (but please comment first to let the asignee know). If you are looking for a place to start, try searching the [issues labelled easyfix](https://issues.apache.org/jira/browse/CB-9974?jql=project%20%3D%20CB%20AND%20resolution%20%3D%20Unresolved%20AND%20labels%20%3D%20%22easyfix%22%20ORDER%20BY%20createdDate%20DESC).
+
+
+## Submitting Code
+
+For all submitted code, there must be a corresponding issue in JIRA. If there isn't an existing issue, please create one. You can submit code using one of the following methods:
+
+* Submit a pull request at one of the Apache Github mirrors at `github.com/apache/<repo name>` (**Strongly Preferred**)
+* Upload patches created with `git format-patch` to the JIRA issue
+* Paste a diff to JIRA (you won't get authorship if you do this)
+
+However you submit code, you should always call out a reviewer to look at and merge your code. A good place to find a reviewer is [the component list](https://issues.apache.org/jira/browse/CB/?selectedTab=com.atlassian.jira.jira-projects-plugin:components-panel) or you can send a mail out to the [dev mailing list](http://cordova.apache.org/contact).
+
+## Testing your code
+
+You are responsible for testing your changes and correcting any problems before submitting a pull request. Testing includes both verifying the functionality added/touched, and running the test suites to verify there are no regressions.
+
+When we say "run the test suites" this includes:
+* All automated tests in cordova-mobilespec
+* Manual tests in cordova-mobilespec that might be affected by the change
+* `npm test` for JS linting
+* Any platform-specific unit tests
+    * `cordova-android/test`
+    * `cordova-ios/CordovaLibTests`
+    * `cordova-js: jake test`
+    * `cordova-plugman: npm test`
+
+Please add a comment in Jira about what testing you did with your change so a committer can understand what testing was done before they merge it in.
+
+#### Adding tests
+
+If possible, please include tests that validate your changes and catch any future regressions. Most repositories have a `tests/` directory that includes the tests for that component.
+
+## Git Commit Messages
+
+When contributing, please have your commit messages begin with the JIRA id and relevant platform (if appropriate) followed by a description of the commit. Here are two examples:
+```
+CB-2345 android: Improved exec bridge by using strings instead of JSON
+CB-3456 all: Fixed plugin loading paths that start with /
+```
+Please also include the JIRA id in the title of any pull requests made to Github. The Apache git bot will link the PR and the JIRA issue automatically.
+
+You are highly encouraged to describe your git commit with enough detail for someone else to understand it. In doing so, your commit message can consist of multiple lines. However, it also is highly encouraged that the first line of your commit message not exceed 50 characters. This is because some of the tooling that sits on top of git (such as the httpd apps that let you browse the repos) assumes that the first line is top-level summary that is 50 characters or less. Thus there will be highlighting and truncating of the commit message using these assumptions and it will look weird if these assumptions are not kept. There should also be a blank line between the summary and any further description. For example, here is a good commit message:
+
+```
+CB-1234 Fixed the whizbang widget
+
+- added more sanity checking in the build script.
+- fixed the API to return the correct value in the scenario where there
+  aren't any whizbangs present.
+- corrected the documentation.
+```
+
+As an alternate to a bullet list, you could put long text here in paragraph form, with each line wrapped at 72 chars and blank lines between paragraphs.

--- a/www/contribute/index.html
+++ b/www/contribute/index.html
@@ -22,8 +22,9 @@ title: Apache Cordova Plugins
                 <li>Join the <a href="{{ site.baseurl }}/contact">Mailing List</a></li>
                 <li>Sign the <a href="http://www.apache.org/licenses/#clas">Individual Contributor License Agreement (ICLA)</a></li>
                 <li>Create an account in <a href="https://issues.apache.org/jira/secure/Dashboard.jspa">Apache Jira</a></li>
-                <li>Bookmark the official URL for <a href="https://issues.apache.org/jira/browse/CB/?selectedTab=com.atlassian.jira.jira-projects-plugin:issues-panel">Cordova Issues</a> (See also <a href="http://wiki.apache.org/cordova/IssueWorkflow">Issue Workflow</a>)</li>
+                <li>Bookmark the official URL for <a href="https://issues.apache.org/jira/browse/CB/?selectedTab=com.atlassian.jira.jira-projects-plugin:issues-panel">Cordova Issues</a></li>
                 <li>Send a brief introduction of yourself to <a href="mailto:dev@cordova.apache.org">dev@cordova.apache.org</a></li>
+                <li>Read the <a href="./contribute_guidelines.html">Contributor Guidelines</a></li>
             </ul>
         </div>
         <div class="col-sm-5">

--- a/www/contribute/index.html
+++ b/www/contribute/index.html
@@ -36,7 +36,7 @@ title: Apache Cordova Plugins
                     </div>
                     <ul class="nav">
                         <li><a href="https://issues.apache.org/jira/browse/CB/?selectedTab=com.atlassian.jira.jira-projects-plugin:issues-panel"><span class="glyphicon glyphicon-warning-sign"></span><i>&nbsp;</i>View All Issues</a></li>
-                        <li><a href="http://wiki.apache.org/cordova/ReportingBugs"><div class="report-bug-icon"></div><i>&nbsp;</i>Report a Bug</a></li>
+                        <li><a href="./issues.html"><div class="report-bug-icon"></div><i>&nbsp;</i>Report a Bug</a></li>
                         <li><a href="https://people.apache.org/committer-index.html"><span class="glyphicon glyphicon-user"></span><i>&nbsp;</i>View Committers / Non-Committers</a></li>
                     </ul>
             </div>

--- a/www/contribute/issues.md
+++ b/www/contribute/issues.md
@@ -1,0 +1,32 @@
+---
+layout: contribute-help
+title: Apache Cordova Reporting Issues
+---
+# Reporting Issues
+Thank you for helping to improve Cordova! Issues for Apache Cordova are hosted at the Apache [JIRA](https://issues.apache.org/jira/browse/CB). A JIRA account is required before you can submit issues (you can [create one here](https://issues.apache.org/jira/secure/Signup!default.jspa)). Before submitting an issue, please take a moment to search JIRA to see if an issue already exists. If it does, please consider commenting or voting for the issue to help raise its visibility.
+
+
+## Creating an issue in JIRA
+Once you have created an account and logged in, click the blue "Create" button at the top of the [Cordova JIRA](https://issues.apache.org/jira/browse/CB) page to create an issue. In the dialog that appears, please fill out the following fields to the best of your ability. All fields besides those listed here can be left blank
+
+Field           | Description
+----------------| -----
+Project         | Make sure that Apache Cordova is selected
+Issue Type      | Whether or not this is a bug or feature request
+Summary         | A one line description of the issue
+Component       | The [part of Cordova](https://issues.apache.org/jira/browse/CB/?selectedTab=com.atlassian.jira.jira-projects-plugin:components-panel) this issue pertains to. Please select only one component if possible (e.g. if you find a bug while using cordova-plugin-camera in Android, select the "Plugin Camera" component and not "Android")
+Affects Version | The version of the component that this issue pertains to
+Environment     | Some extra context about the environment in which a bug was found (e.g. the version of Android you are running, your version of the Cordova CLI, your development platform, etc.)
+Description     | A thorough description of the issue. For bugs, please provide code or steps for reproduction as well as any device logs or stack traces you might have.
+Labels          | Please label your issue with the platforms it affects (e.g. ios, windows, android, etc.) and nothing else
+Priority        | The impact of the issue. See below
+
+## Issue Priority
+
+We gauge issue priority on the following scale:
+* **Minor/Trivial:** The feature or bug is very specific or only affects a few people
+* **Major:** The feature or bug is important and impacts many people
+* **Critical:** Bugs (not features) that block the main function of a component and affect a large number of people (e.g. the camera plugin can't take pictures in iOS version x.x)
+* **Blocker:**  Catastrophic bugs that prevent projects from building or cause basic projects to crash immediately. It is very unlikely that a bug is a Blocker
+
+If you aren't sure about the priority, leave the default (major) selected. Please be aware that as our contributors triage issues, they may change the priority based on our criteria.

--- a/www/contribute/issues.md
+++ b/www/contribute/issues.md
@@ -7,7 +7,7 @@ Thank you for helping to improve Cordova! Issues for Apache Cordova are hosted a
 
 
 ## Creating an issue in JIRA
-Once you have created an account and logged in, click the blue "Create" button at the top of the [Cordova JIRA](https://issues.apache.org/jira/browse/CB) page to create an issue. In the dialog that appears, please fill out the following fields to the best of your ability. All fields besides those listed here can be left blank
+Once you have created an account and logged in, click the blue "Create" button at the top of the [Cordova JIRA](https://issues.apache.org/jira/browse/CB) page to create an issue. In the dialog that appears, please fill out the following fields to the best of your ability. All fields besides those listed here can be left blank.
 
 Field           | Description
 ----------------| -----

--- a/www/static/css-src/_contribute.scss
+++ b/www/static/css-src/_contribute.scss
@@ -128,3 +128,11 @@ a:hover .report-bug-icon {
         margin-bottom:.5em;
     }
 }
+
+// Issues and Contributing guides within contribute
+.contribute-help {
+    table {
+        @extend .table;
+        @extend .table-bordered;
+    }
+}


### PR DESCRIPTION
Replaces the [old wiki page](http://wiki.apache.org/cordova/ReportingBugs) with a new page based mostly on the [JIRA Triage docs](https://github.com/apache/cordova-coho/blob/master/docs/jira-triage.md)