### PR TITLE
CB-10045: Made table elements in docs extend bootstrap table classes

### DIFF
--- a/www/static/css-src/_docs.scss
+++ b/www/static/css-src/_docs.scss
@@ -116,6 +116,11 @@
         color: gray !important;
     }
 
+    table {
+        @extend .table;
+        @extend .table-bordered;
+    }
+
     .keyword-index-list {
         list-style: none;
 


### PR DESCRIPTION
I'm adding a docs page and need table styles. This affects the platform support table FYI. @dblotsky please review.