### PR TITLE
Do not escape markdown code for relative links

### DIFF
--- a/www/docs/en/6.0.0/guide/platforms/android/plugin.md
+++ b/www/docs/en/6.0.0/guide/platforms/android/plugin.md
@@ -35,7 +35,7 @@ Android WebView with hooks attached to it.  Plugins are represented as
 class mappings in the `config.xml` file.  A plugin consists of at
 least one Java class that extends the `CordovaPlugin` class,
 overriding one of its `execute` methods. As best practice, the plugin
-should also handle `[pause](../../../cordova/events/events.pause.html)` and `[resume](../../../cordova/events/events.resume.html)` events, along with any message
+should also handle [`pause`](../../../cordova/events/events.pause.html) and [`resume`](../../../cordova/events/events.resume.html) events, along with any message
 passing between plugins.  Plugins with long-running requests,
 background activity such as media playback, listeners, or internal
 state should implement the `onReset()` method as well. It executes


### PR DESCRIPTION
The links were not clickable. The markdown code was just shown in plaintext.