### PR TITLE
Doc Anchor Fixes

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -66,11 +66,11 @@ redcarpet:
         # not have a leading or trailing newline
         - lax_spacing
 
+        # allows tables
         - tables
-        - highlight
 
-        # enables anchor links
-        - with_toc_data
+        # surrounds highlighted text with <mark>s
+        - highlight
 
 kramdown:
     input: GFM

--- a/www/docs/en/5.0.0/guide/platforms/amazonfireos/config.md
+++ b/www/docs/en/5.0.0/guide/platforms/amazonfireos/config.md
@@ -46,7 +46,7 @@ File](config_ref_index.md.html#The%20config.xml%20File) for information on globa
   page of an application. The title and message are separated by a comma
   in this value string, and that comma is removed before the dialog is
   displayed.
-  
+
         <preference name="LoadingDialog" value="Please wait, the app is loading"/>
 
 - `LoadingPageDialog` (string, defaults to `null`): The same as `LoadingDialog`,
@@ -70,7 +70,7 @@ File](config_ref_index.md.html#The%20config.xml%20File) for information on globa
   time the splash screen image displays.
 
         <preference name="SplashScreenDelay" value="10000"/>
-        
+
 - `ShowTitle` (boolean, defaults to `false`): Show the title at the top
   of the screen.
 
@@ -81,4 +81,3 @@ File](config_ref_index.md.html#The%20config.xml%20File) for information on globa
   values are `ERROR`, `WARN`, `INFO`, `DEBUG`, and `VERBOSE`.
 
         <preference name="LogLevel" value="VERBOSE"/>
-

--- a/www/docs/en/dev/cordova/events/events.md
+++ b/www/docs/en/dev/cordova/events/events.md
@@ -71,9 +71,7 @@ The application code could add listeners for these events. For example:
 
     // Add similar event handlers for other events
 
-**Note**: Applications typically should use `document.addEventListener` to
-attach an event listener once the [deviceready](#link-deviceready)
-event fires.
+**Note**: Applications typically should use `document.addEventListener` to attach an event listener once the [deviceready](#deviceready)
 
 The following table lists the cordova events and the supported platforms:
 
@@ -92,9 +90,9 @@ The following table lists the cordova events and the supported platforms:
     </tr>
 </thead>
 
-<tbody>    
+<tbody>
     <tr>
-        <th><a href="#link-deviceready">deviceready</a></th>
+        <th><a href="#deviceready">deviceready</a></th>
         <td data-col="android"    class="y"></td>
         <td data-col="blackberry10" class="y"></td>
         <td data-col="ios"        class="y"></td>
@@ -103,7 +101,7 @@ The following table lists the cordova events and the supported platforms:
     </tr>
 
     <tr>
-        <th><a href="#link-pause">pause</a></th>
+        <th><a href="#pause">pause</a></th>
         <td data-col="android"    class="y"></td>
         <td data-col="blackberry10" class="y"></td>
         <td data-col="ios"        class="y"></td>
@@ -112,7 +110,7 @@ The following table lists the cordova events and the supported platforms:
     </tr>
 
     <tr>
-        <th><a href="#link-resume">resume</a></th>
+        <th><a href="#resume">resume</a></th>
         <td data-col="android"    class="y"></td>
         <td data-col="blackberry10" class="y"></td>
         <td data-col="ios"        class="y"></td>
@@ -121,7 +119,7 @@ The following table lists the cordova events and the supported platforms:
     </tr>
 
     <tr>
-        <th><a href="#link-backbutton">backbutton</a></th>
+        <th><a href="#backbutton">backbutton</a></th>
         <td data-col="android"    class="y"></td>
         <td data-col="blackberry10" class="y"></td>
         <td data-col="ios"        class="n"></td>
@@ -130,7 +128,7 @@ The following table lists the cordova events and the supported platforms:
     </tr>
 
     <tr>
-        <th><a href="#link-menubutton">menubutton</a></th>
+        <th><a href="#menubutton">menubutton</a></th>
         <td data-col="android"    class="y"></td>
         <td data-col="blackberry10" class="y"></td>
         <td data-col="ios"        class="n"></td>
@@ -139,7 +137,7 @@ The following table lists the cordova events and the supported platforms:
     </tr>
 
     <tr>
-        <th><a href="#link-searchbutton">searchbutton</a></th>
+        <th><a href="#searchbutton">searchbutton</a></th>
         <td data-col="android"    class="y"></td>
         <td data-col="blackberry10" class="n"></td>
         <td data-col="ios"        class="n"></td>
@@ -148,7 +146,7 @@ The following table lists the cordova events and the supported platforms:
     </tr>
 
     <tr>
-        <th><a href="#link-startcallbutton">startcallbutton</a></th>
+        <th><a href="#startcallbutton">startcallbutton</a></th>
         <td data-col="android"    class="n"></td>
         <td data-col="blackberry10" class="y"></td>
         <td data-col="ios"        class="n"></td>
@@ -157,7 +155,7 @@ The following table lists the cordova events and the supported platforms:
     </tr>
 
     <tr>
-        <th><a href="#link-endcallbutton">endcallbutton</a></th>
+        <th><a href="#endcallbutton">endcallbutton</a></th>
         <td data-col="android"    class="n"></td>
         <td data-col="blackberry10" class="y"></td>
         <td data-col="ios"        class="n"></td>
@@ -166,7 +164,7 @@ The following table lists the cordova events and the supported platforms:
     </tr>
 
     <tr>
-        <th><a href="#link-volumedownbutton">volumedownbutton</a></th>
+        <th><a href="#volumedownbutton">volumedownbutton</a></th>
         <td data-col="android"    class="y"></td>
         <td data-col="blackberry10" class="y"></td>
         <td data-col="ios"        class="n"></td>
@@ -175,13 +173,13 @@ The following table lists the cordova events and the supported platforms:
     </tr>
 
     <tr>
-        <th><a href="#link-volumeupbutton">volumeupbutton</a></th>
+        <th><a href="#volumeupbutton">volumeupbutton</a></th>
         <td data-col="android"    class="y"></td>
         <td data-col="blackberry10" class="y"></td>
         <td data-col="ios"        class="n"></td>
         <td data-col="winphone8"  class="n"></td>
         <td data-col="win"       class="n"></td>
-    </tr>    
+    </tr>
 </tbody>
 </table>
 
@@ -261,7 +259,7 @@ The `resume` event fires when the native platform pulls the application out from
 
 ### iOS Quirks
 
-Any interactive functions called from a [pause](#link-pause) event handler execute
+Any interactive functions called from a [pause](#pause) event handler execute
 later when the app resumes, as signaled by the `resume` event. These
 include alerts, `console.log()`, and any calls from plugins or the
 Cordova API, which go through Objective-C.

--- a/www/docs/en/dev/guide/cli/index.md
+++ b/www/docs/en/dev/guide/cli/index.md
@@ -558,5 +558,5 @@ you're building:
         $ cordova platform update ios
         ...etc.
 
-[DeviceReadyEvent]: ../../cordova/events/events.html#link-deviceready
-[BackButtonEvent]: ../../cordova/events/events.html#link-backbutton
+[DeviceReadyEvent]: ../../cordova/events/events.html#deviceready
+[BackButtonEvent]: ../../cordova/events/events.html#backbutton

--- a/www/docs/en/dev/guide/next/index.md
+++ b/www/docs/en/dev/guide/next/index.md
@@ -216,4 +216,4 @@ This Google Group was the old support forum when Cordova was still called PhoneG
 Consider finding a local Cordova/PhoneGap meetup group
 
 
-[DeviceReadyEvent]: ../../cordova/events/events.html#link-deviceready
+[DeviceReadyEvent]: ../../cordova/events/events.html#deviceready

--- a/www/docs/en/dev/guide/platforms/android/config.md
+++ b/www/docs/en/dev/guide/platforms/android/config.md
@@ -123,4 +123,4 @@ File](config_ref_index.md.html#The%20config.xml%20File) for information on globa
         <preference name="AppendUserAgent" value="My Browser" />
 
 
-[PauseEvent]: ../../../cordova/events/events.html#link-pause
+[PauseEvent]: ../../../cordova/events/events.html#pause

--- a/www/docs/en/dev/guide/platforms/android/plugin.md
+++ b/www/docs/en/dev/guide/platforms/android/plugin.md
@@ -463,5 +463,5 @@ on your device or emulator to simulate low memory scenarios. If your plugin
 launches external activities, you should always do some testing with this
 setting enabled to ensure that you are properly handling low memory scenarios.
 
-[PauseEvent]: ../../../cordova/events/events.html#link-pause
-[ResumeEvent]: ../../../cordova/events/events.html#link-resume
+[PauseEvent]: ../../../cordova/events/events.html#pause
+[ResumeEvent]: ../../../cordova/events/events.html#resume

--- a/www/docs/en/dev/guide/platforms/ios/plugin.md
+++ b/www/docs/en/dev/guide/platforms/ios/plugin.md
@@ -249,5 +249,5 @@ can attach Safari 8.0 to the app running within the iOS 8 Simulator.
 [CDVCommandDelegate.h]: https://github.com/apache/cordova-ios/blob/master/CordovaLib/Classes/Public/CDVCommandDelegate.h
 [CDVPlugin.h]: https://github.com/apache/cordova-ios/blob/master/CordovaLib/Classes/Public/CDVPlugin.h
 [CDVPlugin.m]: https://github.com/apache/cordova-ios/blob/master/CordovaLib/Classes/Public/CDVPlugin.m
-[ResumeEvent]: ../../../cordova/events/events.html#link-resume
-[PauseEvent]: ../../../cordova/events/events.html#link-pause
+[ResumeEvent]: ../../../cordova/events/events.html#resume
+[PauseEvent]: ../../../cordova/events/events.html#pause

--- a/www/docs/en/dev/guide/platforms/wp8/plugin.md
+++ b/www/docs/en/dev/guide/platforms/wp8/plugin.md
@@ -23,7 +23,7 @@ title: Windows Phone 8 Plugins
 # Windows Phone 8 Plugins
 
 This section provides details for how to implement native plugin code
-on the Windows Phone platform. Before reading this, see [Plugin Development Guide](../../hybrid/plugins/index.html) 
+on the Windows Phone platform. Before reading this, see [Plugin Development Guide](../../hybrid/plugins/index.html)
 for an overview of the plugin's structure and its common
 JavaScript interface. This section continues to demonstrate the sample
 _echo_ plugin that communicates from the Cordova webview to the native
@@ -237,5 +237,5 @@ yourself of errors.
   unnecessary functionality from the plugin's various native
   implementations.
 
-[PauseEvent]: ../../../cordova/events/events.html#link-pause
-[ResumeEvent]: ../../../cordova/events/events.html#link-resume
+[PauseEvent]: ../../../cordova/events/events.html#pause
+[ResumeEvent]: ../../../cordova/events/events.html#resume

--- a/www/index.html
+++ b/www/index.html
@@ -157,7 +157,7 @@ change_frequency: monthly
                     <a href="{{ site.baseurl }}/docs/en/{{ site.default_linked_docs_version }}/guide/overview/">Read the docs</a>
                 </li>
                 <li>
-                    <a href="{{ site.baseurl }}/docs/en/{{ site.default_linked_docs_version }}/guide/cli/#link-add-plugin-features">Add a Plugin</a>
+                    <a href="{{ site.baseurl }}/docs/en/{{ site.default_linked_docs_version }}/guide/cli/#add-plugin-features">Add a Plugin</a>
                 </li>
                 <li>
                     <a href="{{ site.baseurl }}/docs/en/{{ site.default_linked_docs_version }}/config_ref/images.html">Add Icons and Splash Screen</a>

--- a/www/plugins/faq.md
+++ b/www/plugins/faq.md
@@ -38,7 +38,7 @@ See Cordova [blog]({{ site.baseurl }}/announcements/2015/04/21/plugins-release-a
 
 ## Are there any additional documents to assist me with plugins?
 
-Yes there are. Please take a look at [Add Plugin Features]({{ site.baseurl }}/docs/en/{{ site.default_linked_docs_version }}/guide/cli/#link-add-plugin-features) for a more detailed guide.
+Yes there are. Please take a look at [Add Plugin Features]({{ site.baseurl }}/docs/en/{{ site.default_linked_docs_version }}/guide/cli/#add-plugin-features) for a more detailed guide.
 
 ## I don't like X. How can I help improve the website?
 

--- a/www/static/css-src/_docs.scss
+++ b/www/static/css-src/_docs.scss
@@ -21,13 +21,14 @@
     * Anchor links on documentation headers
     */
     .header-link {
-      position: relative;
-      left: 0.5em;
-      opacity: 0;
+        position: relative;
+        left: 0.5em;
+        opacity: 0;
+        font-size: 0.7em;
 
-      -webkit-transition: opacity 0.2s ease-in-out 0.1s;
-      -moz-transition: opacity 0.2s ease-in-out 0.1s;
-      -ms-transition: opacity 0.2s ease-in-out 0.1s;
+        -webkit-transition: opacity 0.2s ease-in-out 0.1s;
+        -moz-transition: opacity 0.2s ease-in-out 0.1s;
+        -ms-transition: opacity 0.2s ease-in-out 0.1s;
     }
 
     h2:hover .header-link,
@@ -35,7 +36,7 @@
     h4:hover .header-link,
     h5:hover .header-link,
     h6:hover .header-link {
-      opacity: 1;
+        opacity: 1;
     }
 
     pre {
@@ -261,6 +262,12 @@
             width: 240px;
             height: 120px;
         }
+    }
+}
+
+@media (max-width: $screen-sm-max) {
+    .header-link {
+        opacity: 1 !important;
     }
 }
 

--- a/www/static/css-src/main.scss
+++ b/www/static/css-src/main.scss
@@ -40,8 +40,7 @@ $screen-xs-max: $screen-sm-min - 1;
 $screen-md-min: 992px;
 $screen-sm-max: $screen-md-min - 1;
 $screen-lg-min: 1200px;
-$screen-lg: (min-width: $screen-lg-min);
-$screen-md-max: $screen-lg - 1;
+$screen-md-max: $screen-lg-min - 1;
 
 
 /* Mixin that prefixes any CSS rule */

--- a/www/static/js/docs.js
+++ b/www/static/js/docs.js
@@ -17,49 +17,82 @@
 
 $(document).ready(function () {
 
-    function getAnchorName(i, heading, prefix) {
-        var name = prefix;
-        if (heading.id) {
-            name += heading.id;
-        } else if (heading.name) {
-            name += heading.name;
-        } else {
-            name += i;
-        }
-        return name;
+    function slugify(text) {
+        text = text.toLowerCase();
+
+        // replace unaccepted characters with spaces
+        // NOTE:
+        //      a better regex would have been /[^\d\s\w]/ug, but the 'u' flag
+        //      (Unicode) is not supported in some browsers, and we support
+        //      many languages that use Unicode characters
+        text = text.replace(/[\[\]\(\)\=\+\?]/g, ' ');
+
+        // trim whitespace and replace runs of whitespace with single dashes
+        text = text.trim().replace(/ +/g, '-');
+
+        return text;
     }
 
-    var anchorLink = function (id) {
-        var anchor = document.createElement("a");
+    function getIdForHeading(heading) {
+        if (heading.id) {
+            return heading.id;
+        } else if (heading.name) {
+            return heading.name;
+        } else {
+            return slugify(heading.innerText);
+        }
+    }
+
+    function permalinkTo(id) {
+        var anchor       = document.createElement("a");
         anchor.className = "header-link";
         anchor.href      = "#" + id;
         anchor.innerHTML = "<i class=\"glyphicon glyphicon-link\"></i>";
         return anchor;
     }
 
+    function anchorFor(id) {
+        var anchor       = document.createElement("a");
+        anchor.className = "fragment-anchor";
+        anchor.id        = id;
+        return anchor;
+    }
+
+    // go through all headings in the content and add some links
+    $('#page-toc-source h1, #page-toc-source h2, #page-toc-source h3, #page-toc-source h4, #page-toc-source h5, #page-toc-source h6')
+    .each(function (i, heading) {
+
+        headingId = getIdForHeading(heading);
+
+        // add an anchor for linking to the heading
+        // NOTE:
+        //      we could have set the ID on the heading itself but we didn't
+        //      because the <a> has some extra CSS that floats it above the
+        //      heading and makes it easier to see when linked
+        $(heading).before(anchorFor(headingId))
+
+        // add a permalink to all but the first heading
+        if (i > 0) {
+            $(heading).append(permalinkTo(headingId));
+        }
+    });
+
     // Table of Contents
     $('#page-toc').toc({
         'selectors':         'h1,h2', // elements to use as headings
         'container':         '#page-toc-source', // element to find all selectors in
-        'prefix':            'link-', // prefix for anchor tags and class names
+        'prefix':            '', // prefix for anchor tags and class names
         'onHighlight':       function(el) {}, // called when a new section is highlighted
         'highlightOnScroll': true, // add class to heading that is currently in focus
         'highlightOffset':   100, // offset to trigger the next headline
         'anchorName':        function(i, heading, prefix) { // custom function for anchor name
-            return getAnchorName(i, heading, prefix);
+            return getIdForHeading(heading);
         },
         'headerText': function(i, heading, $heading) { // custom function building the header-item text
             return $heading.text();
         },
         'itemClass': function(i, heading, $heading, prefix) { // custom function for item class
-            // the first link is the H1 header of the page - exclude it
-            if (i > 0) {
-                // add a special class to the anchor for this toc entry
-                var anchorName = getAnchorName(i, heading, prefix);
-                $('#' + anchorName).addClass('fragment-anchor');
 
-                $heading.append(anchorLink(anchorName));
-            }
             // don't assign any special classes to the toc entry itself
             return '';
         }


### PR DESCRIPTION
- Moving anchor creation out of ToC logic. 
- Moving ID creation into JS because RedCarpet doesn't support Unicode headings. 
- Making permalink icons a bit smaller and making them always show on small and medium screens.