### PR TITLE
CB-10178 Fix a number of documentation issues

### DIFF
--- a/www/_data/toc/de-dev-manual.yml
+++ b/www/_data/toc/de-dev-manual.yml
@@ -30,7 +30,7 @@
             url: "platform_plugin_versioning_ref/index.html"
         -   name: "Debug and test"
             url:
-        -   name: "Use icons"
+        -   name: "Customize icons"
             url: "config_ref/images.html"
         -   name: "Automate Tasks"
             url:

--- a/www/_data/toc/en-dev-manual.yml
+++ b/www/_data/toc/en-dev-manual.yml
@@ -30,7 +30,7 @@
             url: "platform_plugin_versioning_ref/index.html"
         -   name: "Debug and test"
             url:
-        -   name: "Use icons"
+        -   name: "Customize icons"
             url: "config_ref/images.html"
         -   name: "Automate Tasks"
             url:

--- a/www/_data/toc/es-dev-manual.yml
+++ b/www/_data/toc/es-dev-manual.yml
@@ -30,7 +30,7 @@
             url: "platform_plugin_versioning_ref/index.html"
         -   name: "Debug and test"
             url:
-        -   name: "Use icons"
+        -   name: "Customize icons"
             url: "config_ref/images.html"
         -   name: "Automate Tasks"
             url:

--- a/www/_data/toc/fr-dev-manual.yml
+++ b/www/_data/toc/fr-dev-manual.yml
@@ -30,7 +30,7 @@
             url: "platform_plugin_versioning_ref/index.html"
         -   name: "Debug and test"
             url:
-        -   name: "Use icons"
+        -   name: "Customize icons"
             url: "config_ref/images.html"
         -   name: "Automate Tasks"
             url:

--- a/www/_data/toc/it-dev-manual.yml
+++ b/www/_data/toc/it-dev-manual.yml
@@ -30,7 +30,7 @@
             url: "platform_plugin_versioning_ref/index.html"
         -   name: "Debug and test"
             url:
-        -   name: "Use icons"
+        -   name: "Customize icons"
             url: "config_ref/images.html"
         -   name: "Automate Tasks"
             url:

--- a/www/_data/toc/ja-dev-manual.yml
+++ b/www/_data/toc/ja-dev-manual.yml
@@ -30,7 +30,7 @@
             url: "platform_plugin_versioning_ref/index.html"
         -   name: "Debug and test"
             url:
-        -   name: "Use icons"
+        -   name: "Customize icons"
             url: "config_ref/images.html"
         -   name: "Automate Tasks"
             url:

--- a/www/_data/toc/ko-dev-manual.yml
+++ b/www/_data/toc/ko-dev-manual.yml
@@ -30,7 +30,7 @@
             url: "platform_plugin_versioning_ref/index.html"
         -   name: "Debug and test"
             url:
-        -   name: "Use icons"
+        -   name: "Customize icons"
             url: "config_ref/images.html"
         -   name: "Automate Tasks"
             url:

--- a/www/_data/toc/pl-dev-manual.yml
+++ b/www/_data/toc/pl-dev-manual.yml
@@ -30,7 +30,7 @@
             url: "platform_plugin_versioning_ref/index.html"
         -   name: "Debug and test"
             url:
-        -   name: "Use icons"
+        -   name: "Customize icons"
             url: "config_ref/images.html"
         -   name: "Automate Tasks"
             url:

--- a/www/_data/toc/ru-dev-manual.yml
+++ b/www/_data/toc/ru-dev-manual.yml
@@ -30,7 +30,7 @@
             url: "platform_plugin_versioning_ref/index.html"
         -   name: "Debug and test"
             url:
-        -   name: "Use icons"
+        -   name: "Customize icons"
             url: "config_ref/images.html"
         -   name: "Automate Tasks"
             url:

--- a/www/_data/toc/sl-dev-manual.yml
+++ b/www/_data/toc/sl-dev-manual.yml
@@ -30,7 +30,7 @@
             url: "platform_plugin_versioning_ref/index.html"
         -   name: "Debug and test"
             url:
-        -   name: "Use icons"
+        -   name: "Customize icons"
             url: "config_ref/images.html"
         -   name: "Automate Tasks"
             url:

--- a/www/_data/toc/zh-dev-manual.yml
+++ b/www/_data/toc/zh-dev-manual.yml
@@ -30,7 +30,7 @@
             url: "platform_plugin_versioning_ref/index.html"
         -   name: "Debug and test"
             url:
-        -   name: "Use icons"
+        -   name: "Customize icons"
             url: "config_ref/images.html"
         -   name: "Automate Tasks"
             url:

--- a/www/docs/en/dev/config_ref/images.md
+++ b/www/docs/en/dev/config_ref/images.md
@@ -17,19 +17,22 @@ license: >
     specific language governing permissions and limitations
     under the License.
 
-title: Icons
+title: Customize app icons
+description: Learn how to customize icons for your Cordova app
 ---
 
-# Icons
+# Customize Icons
 
-This section shows how to configure an app's icon for various platforms.
+This section shows how to configure an app's icon for various platforms. Support for splash screen has moved to a Cordova plugin of its own. The configuration options can be found in the [Splashscreen plugin docs][splashscreen_plugin].
 
 ## Configuring Icons in the CLI
 
 When working in the CLI you can define app icon(s) via `<icon>` element (`config.xml`).
 If you do not specify an icon then the Apache Cordova logo is used.
 
-        <icon src="res/ios/icon.png" platform="ios" width="57" height="57" density="mdpi" />
+```xml
+    <icon src="res/ios/icon.png" platform="ios" width="57" height="57" density="mdpi" />
+```
 
 Attributes    | Description
 --------------|--------------------------------------------------------------------------------
@@ -42,79 +45,107 @@ density       | *Optional* <br/> Specified icon density (Android Specific)
 
 The following configuration can be used to define single default icon
 which will be used for all platforms.
-
-        <icon src="res/icon.png" />
-
+```xml
+    <icon src="res/icon.png" />
+```
 For each platform you can also define a pixel-perfect icons set to fit
 different screen resolutions.
 
 ##Android
-
-         <platform name="android">
-                  <icon src="res/android/ldpi.png" density="ldpi" />
-                  <icon src="res/android/mdpi.png" density="mdpi" />
-                  <icon src="res/android/hdpi.png" density="hdpi" />
-                  <icon src="res/android/xhdpi.png" density="xhdpi" />
-         </platform>
+```xml
+    <platform name="android">
+        <!-- 
+            ldpi    : 36x36 px
+            mdpi    : 48x48 px
+            hdpi    : 72x72 px
+            xhdpi   : 96x96 px
+            xxhdpi  : 144x144 px
+            xxxhdpi : 192x192 px
+        -->
+        <icon src="res/android/ldpi.png" density="ldpi" />
+        <icon src="res/android/mdpi.png" density="mdpi" />
+        <icon src="res/android/hdpi.png" density="hdpi" />
+        <icon src="res/android/xhdpi.png" density="xhdpi" />
+        <icon src="res/android/xxhdpi.png" density="xxhdpi" />
+        <icon src="res/android/xxxhdpi.png" density="xxxhdpi" />
+    </platform>
+```
+###See Also
+- [Android icon guide](https://www.google.com/design/spec/style/icons.html)
+- [Android - Supporting multiple screens](http://developer.android.com/guide/practices/screens_support.html)
 
 ##BlackBerry10
-
-         <platform name="blackberry10">
-                  <icon src="res/bb10/icon-86.png" />
-                  <icon src="res/bb10/icon-150.png" />
-         </platform>
-
-See [BlackBerry's documentation][blackberry_icon] for targeting multiple sizes and locales.
+```xml
+    <platform name="blackberry10">
+        <icon src="res/bb10/icon-86.png" />
+        <icon src="res/bb10/icon-150.png" />
+    </platform>
+```
+###See Also
+- [BlackBerry's documentation][blackberry_icon] for targeting multiple sizes and locales.
 
 ##iOS
-
-         <platform name="ios">
-                  <!-- iOS 8.0+ -->
-                  <!-- iPhone 6 Plus  -->
-                  <icon src="res/ios/icon-60@3x.png" width="180" height="180" />
-                  <!-- iOS 7.0+ -->
-                  <!-- iPhone / iPod Touch  -->
-                  <icon src="res/ios/icon-60.png" width="60" height="60" />
-                  <icon src="res/ios/icon-60@2x.png" width="120" height="120" />
-                  <!-- iPad -->
-                  <icon src="res/ios/icon-76.png" width="76" height="76" />
-                  <icon src="res/ios/icon-76@2x.png" width="152" height="152" />
-                  <!-- iOS 6.1 -->
-                  <!-- Spotlight Icon -->
-                  <icon src="res/ios/icon-40.png" width="40" height="40" />
-                  <icon src="res/ios/icon-40@2x.png" width="80" height="80" />
-                  <!-- iPhone / iPod Touch -->
-                  <icon src="res/ios/icon.png" width="57" height="57" />
-                  <icon src="res/ios/icon@2x.png" width="114" height="114" />
-                  <!-- iPad -->
-                  <icon src="res/ios/icon-72.png" width="72" height="72" />
-                  <icon src="res/ios/icon-72@2x.png" width="144" height="144" />
-                  <!-- iPhone Spotlight and Settings Icon -->
-                  <icon src="res/ios/icon-small.png" width="29" height="29" />
-                  <icon src="res/ios/icon-small@2x.png" width="58" height="58" />
-                  <!-- iPad Spotlight and Settings Icon -->
-                  <icon src="res/ios/icon-50.png" width="50" height="50" />
-                  <icon src="res/ios/icon-50@2x.png" width="100" height="100" />
-         </platform>
-
-##Windows Phone8
-
-         <platform name="wp8">
-                  <icon src="res/wp/ApplicationIcon.png" width="99" height="99" />
-                  <!-- tile image -->
-                  <icon src="res/wp/Background.png" width="159" height="159" />
-         </platform>
+```xml
+    <platform name="ios">
+        <!-- iOS 8.0+ -->
+        <!-- iPhone 6 Plus  -->
+        <icon src="res/ios/icon-60@3x.png" width="180" height="180" />
+        <!-- iOS 7.0+ -->
+        <!-- iPhone / iPod Touch  -->
+        <icon src="res/ios/icon-60.png" width="60" height="60" />
+        <icon src="res/ios/icon-60@2x.png" width="120" height="120" />
+        <!-- iPad -->
+        <icon src="res/ios/icon-76.png" width="76" height="76" />
+        <icon src="res/ios/icon-76@2x.png" width="152" height="152" />
+        <!-- iOS 6.1 -->
+        <!-- Spotlight Icon -->
+        <icon src="res/ios/icon-40.png" width="40" height="40" />
+        <icon src="res/ios/icon-40@2x.png" width="80" height="80" />
+        <!-- iPhone / iPod Touch -->
+        <icon src="res/ios/icon.png" width="57" height="57" />
+        <icon src="res/ios/icon@2x.png" width="114" height="114" />
+        <!-- iPad -->
+        <icon src="res/ios/icon-72.png" width="72" height="72" />
+        <icon src="res/ios/icon-72@2x.png" width="144" height="144" />
+        <!-- iPhone Spotlight and Settings Icon -->
+        <icon src="res/ios/icon-small.png" width="29" height="29" />
+        <icon src="res/ios/icon-small@2x.png" width="58" height="58" />
+        <!-- iPad Spotlight and Settings Icon -->
+        <icon src="res/ios/icon-50.png" width="50" height="50" />
+        <icon src="res/ios/icon-50@2x.png" width="100" height="100" />
+    </platform>
+```
+###See Also
+- [App icon and image size guidelines](https://developer.apple.com/library/ios/documentation/UserExperience/Conceptual/MobileHIG/IconMatrix.html)
 
 ##Windows
+```xml
+    <platform name="windows">
+        <icon src="res/windows/logo.png" width="150" height="150" />
+        <icon src="res/windows/smalllogo.png" width="30" height="30" />
+        <icon src="res/windows/storelogo.png" width="50" height="50" />
+        <icon src="res/Windows/Square44x44Logo.scale-100.png" width="44" height="44" />
+        <icon src="res/Windows/Square44x44Logo.scale-240.png" width="106" height="106" />
+        <icon src="res/Windows/Square70x70Logo.scale-100.png" width="70" height="70" />
+        <icon src="res/Windows/Square71x71Logo.scale-100.png" width="71" height="71" />
+        <icon src="res/Windows/Square71x71Logo.scale-240.png" width="170" height="170" />
+        <icon src="res/Windows/Square150x150Logo.scale-240.png" width="360" height="360" />
+        <icon src="res/Windows/Square310x310Logo.scale-100.png" width="310" height="310" />
+        <icon src="res/Windows/Wide310x150Logo.scale-100.png" width="310" height="150" />
+        <icon src="res/Windows/Wide310x150Logo.scale-240.png" width="744" height="360" />
+    </platform>
+```
+###See Also:
+- [Windows platform guidelines for icons](https://msdn.microsoft.com/en-us/library/windows/apps/mt412102.aspx).
 
-         <platform name="windows">
-                  <icon src="res/windows/logo.png" width="150" height="150" />
-                  <icon src="res/windows/smalllogo.png" width="30" height="30" />
-                  <icon src="res/windows/storelogo.png" width="50" height="50" />
-         </platform>
-
-
-The splash screen configuration options can be found in the [Splashscreen plugin docs][splashscreen_plugin].
+##Windows Phone 8 (WP8 Platform)
+```xml
+    <platform name="wp8">
+        <icon src="res/wp/ApplicationIcon.png" width="99" height="99" />
+        <!-- tile image -->
+        <icon src="res/wp/Background.png" width="159" height="159" />
+    </platform>
+```
 
 [blackberry_icon]: http://developer.blackberry.com/html5/documentation/icon_element.html
-[splashscreen_plugin]: ../gen/cordova-plugin-splashscreen/
+[splashscreen_plugin]: ../cordova-plugin-splashscreen/

--- a/www/docs/en/dev/config_ref/index.md
+++ b/www/docs/en/dev/config_ref/index.md
@@ -48,7 +48,7 @@ For example:
 
 In addition to the various configuration options detailed below, you
 can also configure an application's core set of images for each target
-platform. See [Icons and Splash Screens](images.html) for more information.
+platform. See [Customize icons topic](images.html) for more information.
 
 # widget
    Root element of the config.xml document.
@@ -163,7 +163,7 @@ platform. See [Icons and Splash Screens](images.html) for more information.
    Attributes(type) | Description
    ----------------- | ------------
    href(string) | *Required* <br/> Defines the set of external domains the WebView is allowed to navigate to.
-   See the cordova-plugin-whitelist [cordova-plugin-whitelist](https://github.com/apache/cordova-plugin-whitelist#navigation-whitelist) for details.
+   See the cordova-plugin-whitelist [cordova-plugin-whitelist](../cordova-plugin-whitelist/index.html#navigation-whitelist) for details.
 
    Examples:
 
@@ -179,7 +179,7 @@ platform. See [Icons and Splash Screens](images.html) for more information.
    Attributes(type) | Description
    ----------------- | ------------
    href(string) | *Required* <br/> Defines which URLs the app is allowed to ask the system to open.
-   See the cordova-plugin-whitelist [cordova-plugin-whitelist](https://github.com/apache/cordova-plugin-whitelist#intent-whitelist) for details.  
+   See the cordova-plugin-whitelist [cordova-plugin-whitelist](../cordova-plugin-whitelist/index.html#intent-whitelist) for details.  
 
    Examples:
 
@@ -213,7 +213,7 @@ platform. See [Icons and Splash Screens](images.html) for more information.
    android-targetSdkVersion(integer) | *Default: Dependent on cordova-android Version* <br/> ==Android== <br/> Sets the `targetSdkVersion` attribute of the `<uses-sdk>` tag in the project's `AndroidManifest.xml` (see [here][uses-sdk]).
    AppendUserAgent(string) | ==Android== <br/> If set, the value will append to the end of old UserAgent of webview. When using with OverrideUserAgent, this value will be ignored.
    AppendUserAgent(string) | ==iOS== <br/> If set, the value will append to the end of old UserAgent of webview. When using with OverrideUserAgent, this value will be ignored.
-   BackgroundColor(string) | ==Android== ==BlackBerry== <br/> Supports a four-byte hex value, with the first byte representing the alpha channel, and standard RGB values for the following three bytes.
+   BackgroundColor(string) | ==Android== ==BlackBerry== ==Windows== <br/> Supports a four-byte hex value, with the first byte representing the alpha channel, and standard RGB values for the following three bytes.
    BackupWebStorage(string) | *Default: cloud* <br/> Allowed values: none, local, cloud. <br/> ==iOS== <br/>  Set to cloud to allow web storage data to backup via iCloud. Set to local to allow only local backups via iTunes sync. Set to none prevent web storage backups.
    ChildBrowser(string) | *Default: enable* <br/> ==BlackBerry== <br/> Disables child browser windows. By default, apps launch a secondary browser window to display resources accessed via window.open() or by specifying a _blank anchor target. Specify disable to override this default behavior.
    CordovaWebViewEngine(string) | *Default: CDVUIWebViewEngine* <br/> ==iOS== <br/> This sets the WebView engine plugin to be used to render the host app. The plugin must conform to the CDVWebViewEngineProtocol protocol. The 'value' here should match the 'feature' name of the WebView engine plugin that is installed. This preference usually would be set by the WebView engine plugin that is installed, automatically.
@@ -245,8 +245,6 @@ platform. See [Icons and Splash Screens](images.html) for more information.
    PopupBlocker(string) | *Default: enable* <br/> ==BlackBerry== <br/> Enables the popup blocker, which prevents calls to window.open(). By default, popups display in a child browser window. Setting the preference to enable prevents it from displaying at all.
    SetFullscreen(boolean) | *Default: false* <br/> ==Android== <br/> Same as the Fullscreen parameter in the global configuration of this xml file. This Android-specific element is deprecated in favor of the global Fullscreen element, and will be removed in a future version.
    ShowTitle(boolean) | *Default: false* <br/> ==Android== <br/> Show the title at the top of the screen.
-   SplashScreen(string) | *Default: splash* <br/> ==Android== <br/> The name of the file minus its extension in the ```res/drawable``` directory. Various assets must share this common name in various subdirectories.
-   SplashScreenDelay(number in milliseconds) | *Default: 3000, 3 seconds* <br/> ==Android== <br/> The amount of time the splash screen image displays.
    Suppresses3DTouchGesture(boolean) | *Default: false* <br/> ==iOS== <br/> Set to true to avoid 3D Touch capable iOS devices rendering a magnifying glass widget when the user applies force while longpressing the webview. Test your app thoroughly since this disables onclick handlers, but plays nice with ontouchend. If this setting is true, SuppressesLongPressGesture will effectively be true as well.
    SuppressesIncrementalRendering(boolean) | *Default: false* <br/> ==iOS== <br/> Set to true to wait until all content has been received before it renders to the screen.
    SuppressesLongPressGesture(boolean) | *Default: false* <br/> ==iOS== <br/> Set to true to avoid iOS9+ rendering a magnifying glass widget when the user longpresses the webview. Test your app thoroughly since this may interfere with text selection capabilities.
@@ -293,7 +291,6 @@ platform. See [Icons and Splash Screens](images.html) for more information.
     <!-- Android only preferences -->
     <preference name="KeepRunning" value="false"/>
     <preference name="LoadUrlTimeoutValue" value="10000"/>
-    <preference name="SplashScreen" value="mySplash"/>
     <preference name="InAppBrowserStorageEnabled" value="true"/>
     <preference name="LoadingDialog" value="My Title,My Message"/>
     <preference name="ErrorUrl" value="myErrorPage.html"/>

--- a/www/docs/en/dev/guide/appdev/whitelist/index.md
+++ b/www/docs/en/dev/guide/appdev/whitelist/index.md
@@ -139,7 +139,7 @@ ways:
 The whitelisting rules for Windows Phone 8 are found in the
 app's `config.xml` file.
 
-[wlp]: https://github.com/apache/cordova-plugin-whitelist
+[wlp]: ../../../cordova-plugin-whitelist/
 [1]: http://www.w3.org/TR/widgets-access/
 [2]: http://google.com
 [3]: https://google.com

--- a/www/docs/en/dev/guide/hybrid/plugins/index.md
+++ b/www/docs/en/dev/guide/hybrid/plugins/index.md
@@ -25,11 +25,11 @@ title: Plugin Development Guide
 A _plugin_ is a package of injected code that allows the Cordova webview within
 which the app renders to communicate with the native platform on
 which it runs.  Plugins provide access to device and platform
-functionality that is ordinarily unavailable to web-based apps.  All
+functionality that is ordinarily unavailable to web-based apps. All
 the main Cordova API features are implemented as plugins, and many
 others are available that enable features such as bar code scanners,
-NFC communication, or to tailor calendar interfaces. There is a
-[registry](http://plugins.cordova.io) of available plugins.
+NFC communication, or to tailor calendar interfaces. You can search for available plugins
+on [Cordova Plugin Search page](/plugins/).
 
 Plugins comprise a single JavaScript interface along with
 corresponding native code libraries for each supported platform.  In essence
@@ -45,43 +45,45 @@ this section.
 
 In addition to these instructions, when preparing to write a plugin it
 is best to look over
-[existing plugins](http://cordova.apache.org/#contribute)
+[existing plugins](http://cordova.apache.org/contribute)
 for guidance.
 
 ## Building a Plugin
 
-Application developers use the CLI's `plugin add` command (discussed
-in The Command-Line Interface) to apply a plugin to a project. The
+Application developers use the CLI's [plugin add command](../../../cordova-cli/index.html#cordova-plugin-add-command) to add a plugin to a project. The
 argument to that command is the URL for a _git_ repository containing
 the plugin code.  This example implements Cordova's Device API:
 
-        $ cordova plugin add https://git-wip-us.apache.org/repos/asf/cordova-plugin-device.git
+```bash
+    $ cordova plugin add https://git-wip-us.apache.org/repos/asf/cordova-plugin-device.git
+```
 
 The plugin repository must feature a top-level `plugin.xml` manifest
 file. There are many ways to configure this file, details for which
-are available in the [Plugin Specification](../../../plugin_ref/spec.html). This abbreviated version of
-the `Device` plugin provides a simple example to use as a model:
+are available in the [Plugin Specification](../../../plugin_ref/spec.html). This abbreviated version of the `Device` plugin provides a simple example to use as a model:
 
-        <?xml version="1.0" encoding="UTF-8"?>
-        <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
-                id="cordova-plugin-device" version="0.2.3">
-            <name>Device</name>
-            <description>Cordova Device Plugin</description>
-            <license>Apache 2.0</license>
-            <keywords>cordova,device</keywords>
-            <js-module src="www/device.js" name="device">
-                <clobbers target="device" />
-            </js-module>
-            <platform name="ios">
-                <config-file target="config.xml" parent="/*">
-                    <feature name="Device">
-                        <param name="ios-package" value="CDVDevice"/>
-                    </feature>
-                </config-file>
-                <header-file src="src/ios/CDVDevice.h" />
-                <source-file src="src/ios/CDVDevice.m" />
-            </platform>
-        </plugin>
+```xml
+    <?xml version="1.0" encoding="UTF-8"?>
+    <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
+            id="cordova-plugin-device" version="0.2.3">
+        <name>Device</name>
+        <description>Cordova Device Plugin</description>
+        <license>Apache 2.0</license>
+        <keywords>cordova,device</keywords>
+        <js-module src="www/device.js" name="device">
+            <clobbers target="device" />
+        </js-module>
+        <platform name="ios">
+            <config-file target="config.xml" parent="/*">
+                <feature name="Device">
+                    <param name="ios-package" value="CDVDevice"/>
+                </feature>
+            </config-file>
+            <header-file src="src/ios/CDVDevice.h" />
+            <source-file src="src/ios/CDVDevice.m" />
+        </platform>
+    </plugin>
+```
 
 The top-level `plugin` tag's `id` attribute uses the same
 reverse-domain format to identify the plugin package as the apps to
@@ -93,30 +95,28 @@ the platform-specific `config.xml` file to make the platform aware of
 the additional code library.  The `header-file` and `source-file` tags
 specify the path to the library's component files.
 
-## Validating a Plugin
+## Validating a Plugin using Plugman
 
 You can use the `plugman` utility to check whether the plugin installs
 correctly for each platform.  Install `plugman` with the following
 [node](http://nodejs.org/) command:
 
-        $ npm install -g plugman
+```bash
+    $ npm install -g plugman
+```
 
 You need an valid app source directory, such as the top-level `www`
 directory included in a default CLI-generated project as described in
-[The Command-Line Interface](../../cli/index.html).  Make sure the app's `index.html` home
-page reference the name of the plugin's JavaScript interface, as if it
-were in the same source directory:
-
-        <script src="myplugin.js"></script>
+[Create your first app guide](../../cli/index.html).  
 
 Then run a command such as the following to test whether iOS
 dependencies load properly:
 
-         $ plugman install --platform ios --project /path/to/my/project/www --plugin /path/to/my/plugin
+```bash
+    $ plugman install --platform ios --project /path/to/my/project/www --plugin /path/to/my/plugin
+```
 
-For details on `plugman` options, see [Using Plugman to Manage Plugins](../../../plugin_ref/plugman.html).
-For information on how to actually _debug_ plugins, see each
-platform's native interface listed at the bottom of this page.
+For details on `plugman` options, see [Using Plugman to Manage Plugins](../../../plugin_ref/plugman.html). For information on how to actually _debug_ plugins, see each platform's native interface listed at the bottom of this page.
 
 ## The JavaScript Interface
 
@@ -126,11 +126,13 @@ plugin's JavaScript however you like, but you need to call
 `cordova.exec` to communicate with the native platform, using the
 following syntax:
 
-        cordova.exec(function(winParam) {},
-                     function(error) {},
-                     "service",
-                     "action",
-                     ["firstArgument", "secondArgument", 42, false]);
+```js
+    cordova.exec(function(winParam) {},
+                 function(error) {},
+                 "service",
+                 "action",
+                 ["firstArgument", "secondArgument", 42, false]);
+```
 
 Here is how each parameter works:
 

--- a/www/docs/en/dev/guide/overview/index.md
+++ b/www/docs/en/dev/guide/overview/index.md
@@ -17,15 +17,14 @@ license: >
     specific language governing permissions and limitations
     under the License.
 
-title: Overview
+title: Architectural overview of Cordova platform
 ---
 
 # Overview
 
 Apache Cordova is an open-source mobile development framework. It allows you
-to use standard web technologies such as HTML5, CSS3, and JavaScript
-for cross-platform development, avoiding each mobile platform's native
-development language.  Applications execute within wrappers targeted
+to use standard web technologies - HTML5, CSS3, and JavaScript
+for cross-platform development. Applications execute within wrappers targeted
 to each platform, and rely on standards-compliant API bindings to
 access each device's capabilities such as sensors, data, network status, etc. 
 
@@ -62,7 +61,7 @@ application components.
 
 This is the part where your application code resides. The application itself is 
 implemented as a web page, by default a local file named _index.html_, that 
-references whatever CSS, JavaScript, images, media files, or other resources 
+references CSS, JavaScript, images, media files, or other resources 
 are necessary for it to run. The app executes in a _WebView_ within the native 
 application wrapper, which you distribute to app stores.
 
@@ -78,14 +77,13 @@ other and bindings to standard device APIs. This enables you to invoke native
 code from JavaScript. 
 
 Apache Cordova project maintains a set of plugins called the 
-[core plugins](../../cordova/plugins/pluginapis.html). These core 
+[Core Plugins](../guide/support/index.html#core-plugin-apis). These core 
 plugins provide your application to access device capabilities such as 
 battery, camera, contacts, etc.
 
 In addition to the core plugins, there are several third-party plugins which 
 provide additional bindings to features not necessarily available on all 
-platforms. You can search for Cordova plugins using [plugin search](http://plugins.cordova.io)  
-or [npm](https://www.npmjs.com/search?q=ecosystem%3Acordova). You can also 
+platforms. You can search for Cordova plugins using [plugin search](/plugins/) or [npm](https://www.npmjs.com/search?q=ecosystem%3Acordova). You can also 
 develop your own plugins, as described in the 
 [Plugin Development Guide](../hybrid/plugins/index.html). Plugins may be 
 necessary, for example, to communicate between Cordova and custom native 
@@ -98,7 +96,7 @@ desire, even the core plugins, must be explicitly added.
 Cordova does not provide any UI widgets or MV* frameworks. Cordova provides
 only the runtime in which those can execute. If you wish to use UI widgets
 and/or an MV* framework, you will need to select those and include them in
-your application yourself as third-party material.
+your application.
 
 ## Development Paths
 
@@ -108,17 +106,15 @@ task, they each offer advantages:
 
 - __Cross-platform (CLI) workflow__: Use this workflow if you want your app
   to run on as many different mobile operating systems as possible,
-  with little need for platform-specific development.  This workflow
-  centers around the `cordova` utility, otherwise known as the Cordova
-  _CLI_. The CLI is a high-level tool that allows you to build projects 
+  with little need for platform-specific development. This workflow
+  centers around the `cordova` CLI. The CLI is a high-level tool that allows you to build projects 
   for many platforms at once, abstracting away much of the functionality of 
   lower-level shell scripts. The CLI copies a common set of web assets into
   subdirectories for each mobile platform, makes any necessary
   configuration changes for each, runs build scripts to generate
   application binaries. The CLI also provides a common interface to
-  apply plugins to your app. For more details on the CLI, see The
-  Command-Line Interface. Unless you have a need for the platform-centered
-  workflow, the cross-platform workflow is recommended.
+  apply plugins to your app. To get started follow the steps in the 
+  [Create your first app tutorial](../cli/index.html). Unless you have a need for the platform-centered workflow, the cross-platform workflow is recommended.
 
 - __Platform-centered workflow__: Use this workflow if you want to
   focus on building an app for a single platform and need to be able
@@ -129,27 +125,20 @@ task, they each offer advantages:
   this workflow if you need to modify the project within the SDK. This 
   workflow relies on a set of lower-level shell scripts that are tailored for 
   each supported platform, and a separate Plugman utility that allows you to 
-  apply plugins.  While you can use this workflow to build cross-platform
+  apply plugins. While you can use this workflow to build cross-platform
   apps, it is generally more difficult because the lack of a
   higher-level tool means separate build cycles and plugin
-  modifications for each platform. Still, this workflow allows you
-  greater access to development options provided by each SDK, and is
-  essential for complex hybrid apps.
+  modifications for each platform. 
 
 When first starting out, it may be easiest to use the cross-platform
-workflow to create an app, as described in [The Command-Line Interface](../cli/index.html).
+workflow to create an app, as described in [Create your first app tutorial](../cli/index.html).
 You then have the option to switch to a platform-centered workflow if
-you need the greater control the SDK provides.  Lower-level shell
-utilities are available at
-[cordova.apache.org](http://cordova.apache.org) in a separate
-distribution than the CLI. For projects initially generated by the
-CLI, these shell tools are also available in the project's various
-`platforms/*/cordova` directories.
+you need the greater control the SDK provides.  
 
-__NOTE__: Once you switch from the CLI-based workflow to one centered
+> __NOTE__: Once you switch from the CLI-based workflow to one centered
 around the platform-specific SDKs and shell tools, you can't go back.
 The CLI maintains a common set of cross-platform source code, which on
-each build it uses to write over platform-specific source code.  To
+each build it uses to write over platform-specific source code. To
 preserve any modifications you make to the platform-specific assets,
 you need to switch to the platform-centered shell tools, which ignore
 the cross-platform source code, and instead relies on the
@@ -160,13 +149,12 @@ platform-specific source code.
 The installation of Cordova will differ depending on the workflow above
 you choose:
 
-  * Cross-platform workflow: see [The Command-Line Interface](../cli/index.html).
+  * Cross-platform workflow: See [Create your first app tutorial](../cli/index.html).
 
   * Platform-centered workflow.
 
 After installing Cordova, it is recommended that you review the 
-```Develop for platforms``` section for the mobile platforms that you 
+```Develop for Platforms``` section for the mobile platforms that you 
 will be developing for. It is also recommended that you also review the 
 [Privacy Guide](../appdev/privacy/index.html) and 
-[Security Guide](../appdev/security/index.html). And refer to the other 
-included guides as necessary.
+[Security Guide](../appdev/security/index.html).

--- a/www/docs/en/dev/guide/support/index.md
+++ b/www/docs/en/dev/guide/support/index.md
@@ -17,7 +17,7 @@ license: >
     specific language governing permissions and limitations
     under the License.
 
-title: Platform Support
+title: Corodva support by platform
 ---
 
 # Platform Support
@@ -78,11 +78,11 @@ CLI's shorthand names.
 
     <tr>
         <th></th>
-        <th colspan="20"><h2>Core plugin APIs</h2></th>
+        <th colspan="20"><h2>Core Plugin APIs</h2></th>
     </tr>
 
     <tr>
-        <th><a href="https://www.npmjs.com/package/cordova-plugin-device-motion">Accelerometer</a></th>
+        <th><a href="../../cordova-plugin-device-motion/">Accelerometer</a></th>
         <td data-col="android"    class="y"></td>
         <td data-col="blackberry10" class="y"></td>
         <td data-col="ios"        class="y"></td>
@@ -92,7 +92,7 @@ CLI's shorthand names.
     </tr>
 
     <tr>
-        <th><a href="https://www.npmjs.com/package/cordova-plugin-battery-status">BatteryStatus</a></th>
+        <th><a href="../../cordova-plugin-battery-status/">BatteryStatus</a></th>
         <td data-col="android"    class="y"></td>
         <td data-col="blackberry10" class="y"></td>
         <td data-col="ios"        class="y"></td>
@@ -102,7 +102,7 @@ CLI's shorthand names.
     </tr>
 
     <tr>
-        <th><a href="https://www.npmjs.com/package/cordova-plugin-camera">Camera</a></th>
+        <th><a href="../../cordova-plugin-camera/">Camera</a></th>
         <td data-col="android"    class="y"></td>
         <td data-col="blackberry10" class="y"></td>
         <td data-col="ios"        class="y"></td>
@@ -112,7 +112,7 @@ CLI's shorthand names.
     </tr>
 
     <tr>
-        <th><a href="https://www.npmjs.com/package/cordova-plugin-media-capture">Capture</a></th>
+        <th><a href="../../cordova-plugin-media-capture/">Capture</a></th>
         <td data-col="android"    class="y"></td>
         <td data-col="blackberry10" class="y"></td>
         <td data-col="ios"        class="y"></td>
@@ -122,7 +122,7 @@ CLI's shorthand names.
     </tr>
 
     <tr>
-        <th><a href="https://www.npmjs.com/package/cordova-plugin-device-orientation">Compass</a></th>
+        <th><a href="../../cordova-plugin-device-orientation/">Compass</a></th>
         <td data-col="android"    class="y"></td>
         <td data-col="blackberry10" class="y"></td>
         <td data-col="ios"        class="y">(3GS+)</td>
@@ -132,7 +132,7 @@ CLI's shorthand names.
     </tr>
 
     <tr>
-        <th><a href="https://www.npmjs.com/package/cordova-plugin-network-information">Connection</a></th>
+        <th><a href="../../cordova-plugin-network-information/">Connection</a></th>
         <td data-col="android"    class="y"></td>
         <td data-col="blackberry10" class="y"></td>
         <td data-col="ios"        class="y"></td>
@@ -142,7 +142,7 @@ CLI's shorthand names.
     </tr>
 
     <tr>
-        <th><a href="https://www.npmjs.com/package/cordova-plugin-contacts">Contacts</a></th>
+        <th><a href="../../cordova-plugin-contacts/">Contacts</a></th>
         <td data-col="android"    class="y"></td>
         <td data-col="blackberry10" class="y"></td>
         <td data-col="ios"        class="y"></td>
@@ -152,7 +152,7 @@ CLI's shorthand names.
     </tr>
 
     <tr>
-        <th><a href="https://www.npmjs.com/package/cordova-plugin-device">Device</a></th>
+        <th><a href="../../cordova-plugin-device/">Device</a></th>
         <td data-col="android"    class="y"></td>
         <td data-col="blackberry10" class="y"></td>
         <td data-col="ios"        class="y"></td>
@@ -172,7 +172,7 @@ CLI's shorthand names.
     </tr>
 
     <tr>
-        <th><a href="https://www.npmjs.com/package/cordova-plugin-file">File</a></th>
+        <th><a href="../../cordova-plugin-file">File</a></th>
         <td data-col="android"    class="y"></td>
         <td data-col="blackberry10" class="y"></td>
         <td data-col="ios"        class="y"></td>
@@ -182,7 +182,7 @@ CLI's shorthand names.
     </tr>
 
     <tr>
-        <th><a href="https://www.npmjs.com/package/cordova-plugin-file-transfer">File Transfer</a></th>
+        <th><a href="../../cordova-plugin-file-transfer/">File Transfer</a></th>
         <td data-col="android"    class="y"></td>
         <td data-col="blackberry10" class="y">* Do not support onprogress nor abort</td>
         <td data-col="ios"        class="y"></td>
@@ -192,7 +192,7 @@ CLI's shorthand names.
     </tr>
 
     <tr>
-        <th><a href="https://www.npmjs.com/package/cordova-plugin-geolocation">Geolocation</a></th>
+        <th><a href="../../cordova-plugin-geolocation/">Geolocation</a></th>
         <td data-col="android"    class="y"></td>
         <td data-col="blackberry10" class="y"></td>
         <td data-col="ios"        class="y"></td>
@@ -202,7 +202,7 @@ CLI's shorthand names.
     </tr>
 
     <tr>
-        <th><a href="https://www.npmjs.com/package/cordova-plugin-globalization">Globalization</a></th>
+        <th><a href="../../cordova-plugin-globalization/">Globalization</a></th>
         <td data-col="android"    class="y"></td>
         <td data-col="blackberry10" class="y"></td>
         <td data-col="ios"        class="y"></td>
@@ -212,7 +212,7 @@ CLI's shorthand names.
     </tr>
 
     <tr>
-        <th><a href="https://www.npmjs.com/package/cordova-plugin-inappbrowser">InAppBrowser</a></th>
+        <th><a href="../../cordova-plugin-inappbrowser/">InAppBrowser</a></th>
         <td data-col="android"    class="y"></td>
         <td data-col="blackberry10" class="y"></td>
         <td data-col="ios"        class="y"></td>
@@ -222,7 +222,7 @@ CLI's shorthand names.
     </tr>
 
     <tr>
-        <th><a href="https://www.npmjs.com/package/cordova-plugin-media">Media</a></th>
+        <th><a href="../../cordova-plugin-media/">Media</a></th>
         <td data-col="android"    class="y"></td>
         <td data-col="blackberry10" class="y"></td>
         <td data-col="ios"        class="y"></td>
@@ -232,7 +232,7 @@ CLI's shorthand names.
     </tr>
 
     <tr>
-        <th><a href="https://www.npmjs.com/package/cordova-plugin-dialogs">Notification</a></th>
+        <th><a href="../../cordova-plugin-dialogs/">Notification</a></th>
         <td data-col="android"    class="y"></td>
         <td data-col="blackberry10" class="y"></td>
         <td data-col="ios"        class="y"></td>
@@ -242,7 +242,7 @@ CLI's shorthand names.
     </tr>
 
     <tr>
-        <th><a href="https://www.npmjs.com/package/cordova-plugin-splashscreen">Splashscreen</a></th>
+        <th><a href="../../cordova-plugin-splashscreen/">Splashscreen</a></th>
         <td data-col="android"    class="y"></td>
         <td data-col="blackberry10" class="y"></td>
         <td data-col="ios"        class="y"></td>
@@ -252,7 +252,7 @@ CLI's shorthand names.
     </tr>
 
     <tr>
-        <th><a href="https://www.npmjs.com/package/cordova-plugin-statusbar">Status Bar</a></th>
+        <th><a href="../../cordova-plugin-statusbar/">Status Bar</a></th>
         <td data-col="android"    class="y"></td>
         <td data-col="blackberry10" class="n"></td>
         <td data-col="ios"        class="y"></td>
@@ -272,7 +272,7 @@ CLI's shorthand names.
     </tr>
 
     <tr>
-        <th><a href="https://www.npmjs.com/package/cordova-plugin-vibration">Vibration</a></th>
+        <th><a href="../../cordova-plugin-vibration/">Vibration</a></th>
         <td data-col="android"    class="y"></td>
         <td data-col="blackberry10" class="y"></td>
         <td data-col="ios"        class="y"></td>

--- a/www/docs/en/dev/plugin_ref/spec.md
+++ b/www/docs/en/dev/plugin_ref/spec.md
@@ -17,7 +17,7 @@ license: >
     specific language governing permissions and limitations
     under the License.
 
-title: Plugin.xml
+title: Plugin.xml reference documentation
 ---
 
 # Plugin.xml

--- a/www/index.html
+++ b/www/index.html
@@ -154,10 +154,10 @@ change_frequency: monthly
                     <a href="{{ site.baseurl }}/docs/en/{{ site.default_linked_docs_version }}/guide/overview/">Read the docs</a>
                 </li>
                 <li>
-                    <a href="{{ site.baseurl }}/docs/en/{{ site.default_linked_docs_version }}/guide/cli/#add-plugin-features">Add a Plugin</a>
+                    <a href="{{ site.baseurl }}/docs/en/{{ site.default_linked_docs_version }}/guide/cli/#add-plugins">Add a Plugin</a>
                 </li>
                 <li>
-                    <a href="{{ site.baseurl }}/docs/en/{{ site.default_linked_docs_version }}/config_ref/images.html">Add Icons and Splash Screen</a>
+                    <a href="{{ site.baseurl }}/docs/en/{{ site.default_linked_docs_version }}/config_ref/images.html">Customize app icons</a>
                 </li>
                 <li>
                     <a href="{{ site.baseurl }}/docs/en/{{ site.default_linked_docs_version }}/config_ref/">Configure Your App</a>


### PR DESCRIPTION
Here are the list of fixes
- Add more examples for icons for Windows and link to platform SDK docs.
- Ensure all references to CLI guide - now reference to notion of "creating your first app"
- Update all links for plugins to point to internal docs as opposed to npm/GitHub.