### PR TITLE
CB-8976: Restoring documentation for android version code

### DIFF
--- a/www/docs/en/dev/config_ref/index.md
+++ b/www/docs/en/dev/config_ref/index.md
@@ -57,7 +57,7 @@ platform. See [Customize icons topic](images.html) for more information.
    ---------------- | ------------
    id(string) | *Required* <br/> Specifies the app's reverse-domain identifier, and the `version` its full version number expressed in major/minor/patch notation.
    version(string) | *Required* <br/> Full version number expressed in major/minor/patch notation.
-   android-versionCode(string) | ==Android== <br/> Alternative version for Android. Sets the [version code](http://developer.android.com/tools/publishing/versioning.html) for the application. See [the Android guide](../guide/platforms/android/index.html#setting-the-version-code) for information on how this code may be modified.
+   android-versionCode(string) | ==Android== <br/> Alternative version for Android. Sets the [version code](http://developer.android.com/tools/publishing/versioning.html) for the application. See [the Android guide](../guide/platforms/android/index.html#setting-the-version-code) for information on how this attribute may be modified.
    ios-CFBundleVersion(string) |  ==iOS== <br/> Alternative version for iOS. For further details, see [iOS versioning](https://developer.apple.com/library/ios/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-102364).
    osx-CFBundleVersion(string) |  ==OS X== <br/> Alternative version for OS X. For further details, see [OS X versioning](https://developer.apple.com/library/prerelease/mac/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-102364).
    packageVersion(string) |   ==Windows== <br/> Alternative version for Windows. For futher details, see [Windows versioning](https://msdn.microsoft.com/en-us/library/windows/apps/br211441.aspx)
@@ -71,7 +71,7 @@ platform. See [Customize icons topic](images.html) for more information.
     </widget>
 
     <!-- Android -->
-    <widget versionCode="0.1.3">
+    <widget android-versionCode="0.1.3">
     </widget>
 
     <!-- iOS -->

--- a/www/docs/en/dev/config_ref/index.md
+++ b/www/docs/en/dev/config_ref/index.md
@@ -57,7 +57,7 @@ platform. See [Customize icons topic](images.html) for more information.
    ---------------- | ------------
    id(string) | *Required* <br/> Specifies the app's reverse-domain identifier, and the `version` its full version number expressed in major/minor/patch notation.
    version(string) | *Required* <br/> Full version number expressed in major/minor/patch notation.
-   versionCode(string) | ==Android== <br/> Alternative version for Android. For further details, see [Android versioning](http://developer.android.com/tools/publishing/versioning.html)
+   android-versionCode(string) | ==Android== <br/> Alternative version for Android. Sets the [version code](http://developer.android.com/tools/publishing/versioning.html) for the application. See [the Android guide](../guide/platforms/android/index.html#setting-the-version-code) for information on how this code may be modified.
    ios-CFBundleVersion(string) |  ==iOS== <br/> Alternative version for iOS. For further details, see [iOS versioning](https://developer.apple.com/library/ios/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-102364).
    osx-CFBundleVersion(string) |  ==OS X== <br/> Alternative version for OS X. For further details, see [OS X versioning](https://developer.apple.com/library/prerelease/mac/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-102364).
    packageVersion(string) |   ==Windows== <br/> Alternative version for Windows. For futher details, see [Windows versioning](https://msdn.microsoft.com/en-us/library/windows/apps/br211441.aspx)
@@ -179,7 +179,7 @@ platform. See [Customize icons topic](images.html) for more information.
    Attributes(type) | Description
    ----------------- | ------------
    href(string) | *Required* <br/> Defines which URLs the app is allowed to ask the system to open.
-   See the cordova-plugin-whitelist [cordova-plugin-whitelist](../cordova-plugin-whitelist/index.html#intent-whitelist) for details.  
+   See the cordova-plugin-whitelist [cordova-plugin-whitelist](../cordova-plugin-whitelist/index.html#intent-whitelist) for details.
 
    Examples:
 
@@ -202,7 +202,7 @@ platform. See [Customize icons topic](images.html) for more information.
 
 ## preference
    Sets various options as pairs of name/value attributes. Each preference's name is case-insensitive. Many preferences are unique to specific platforms,
-   and will be indicated as such.  
+   and will be indicated as such.
 
    Attributes(type) | Description
    ----------------- | ------------
@@ -313,7 +313,7 @@ platform. See [Customize icons topic](images.html) for more information.
     <preference name="ChildBrowser" value="disable"/>
     <preference name="PopupBlocker" value="enable"/>
     <preference name="WebSecurity" value="disable"/>
-    
+
     <!-- OS X only preferences -->
     <preference name="HideMousePointer" value="5"/>
     <preference name="OSXLocalStoragePath" value="~/.myapp/database"/>
@@ -360,7 +360,7 @@ platform. See [Customize icons topic](images.html) for more information.
 
 
 ## platform
-   When using the CLI to build applications, it is sometimes necessary to specify preferences or other elements specific to a particular platform. Use the <platform> element to specify configuration that should only appear in a single platform-specific config.xml file.  
+   When using the CLI to build applications, it is sometimes necessary to specify preferences or other elements specific to a particular platform. Use the <platform> element to specify configuration that should only appear in a single platform-specific config.xml file.
 
    Attributes(type) | Description
    ----------------- | ------------

--- a/www/docs/en/dev/guide/platforms/android/index.md
+++ b/www/docs/en/dev/guide/platforms/android/index.md
@@ -252,6 +252,34 @@ Note that plugins can also include `build-extras.gradle` files via:
     <framework src="some.gradle" custom="true" type="gradleReference" />
 
 
+### Setting the Version Code
+
+To change the [version code](http://developer.android.com/tools/publishing/versioning.html) for your app's generated apk,
+set the `android-versionCode` attribute in the widget element of your application's
+[config.xml file](../../../config_ref/index.html). If the `android-versionCode` is not set, the
+version code will instead be determined using the `version` attribute. For example,
+if the version is `MAJOR.MINOR.PATCH`:
+
+```
+versionCode = MAJOR * 10000 + MINOR * 100 + PATCH
+```
+
+If your application has enabled the `cdvBuildMultipleApks` Gradle property (see
+[Setting Gradle Properties](#setting-gradle-properties)), the version code of your app
+will also be multiplied by 10 so that the last digit of the code can be used
+to indicate the architecture the apk was built for. This multiplication will happen
+regardless of whether the version code is taken from the `android-versionCode`
+attribute or generated using the `version`. Be aware that some plugins added to your
+project (including cordova-plugin-crosswalk-webview) may set this Gradle property
+automatically.
+
+**Please Note:** When updating the `android-versionCode` property, it is unwise to
+increment the version code taken from built apks. Instead, you should increment
+the code based off the value in your `config.xml` file's `android-versionCode`
+attribute. This is because the `cdvBuildMultipleApks` property causes the version code
+to be multiplied by 10 in the built apks and thus using that value will cause your next
+version code to be 100 times the original, etc.
+
 ## Signing an App
 
 First, you should read the [Android app signing requirements](http://developer.android.com/tools/publishing/app-signing.html).
@@ -371,7 +399,7 @@ for more details.
 
 cordova-android includes a number of scripts that allow the platform to be used
 without the full Cordova CLI. This development path may offer you a greater
-range of development options in certain situations than the cross-platform cordova CLI. 
+range of development options in certain situations than the cross-platform cordova CLI.
 For example, you need to use shell tools when deploying a custom
 Cordova WebView alongside native components. Before using this
 development path, you must still configure the Android SDK environment

--- a/www/docs/en/dev/guide/platforms/android/index.md
+++ b/www/docs/en/dev/guide/platforms/android/index.md
@@ -257,7 +257,7 @@ Note that plugins can also include `build-extras.gradle` files via:
 To change the [version code](http://developer.android.com/tools/publishing/versioning.html) for your app's generated apk,
 set the `android-versionCode` attribute in the widget element of your application's
 [config.xml file](../../../config_ref/index.html). If the `android-versionCode` is not set, the
-version code will instead be determined using the `version` attribute. For example,
+version code will be determined using the `version` attribute. For example,
 if the version is `MAJOR.MINOR.PATCH`:
 
 ```


### PR DESCRIPTION
The version code documentation was lost in the update to the config.xml reference. This restores that old information and moves it to the Android guide. I also tried to clarify how we modify the version code because there was some confusion over that in the [CB-8976](https://issues.apache.org/jira/browse/CB-8976) thread.