### PR TITLE
CB-10836 Improving "Edit" links

### DIFF
--- a/conf/_config.yml
+++ b/conf/_config.yml
@@ -27,6 +27,9 @@ latest_docs_version: dev
 # the docs version that is shown by default when clicking on docs links on the site
 default_linked_docs_version: latest
 
+# the language that serves as the source for the translations
+src_language: en
+
 # NOTE:
 #      this value _might_ get overwritten on some pages;
 #      see _defaults.yml, which is a generated file

--- a/tools/bin/gen_defaults.js
+++ b/tools/bin/gen_defaults.js
@@ -88,9 +88,14 @@ function main () {
             if (versionName === latestVersionName) {
                 changeFrequency = LATEST_CHANGE_FREQUENCY;
                 pagePriority    = LATEST_PAGE_PRIORITY;
-            } else if (versionName == DEV_VERSION_NAME) {
+            } else if (versionName === DEV_VERSION_NAME) {
                 changeFrequency = DEV_CHANGE_FREQUENCY;
                 pagePriority    = DEV_PAGE_PRIORITY;
+            }
+
+            var current = false;
+            if (versionName === latestVersionName || versionName === DEV_VERSION_NAME) {
+                current = true;
             }
 
             var versionDefaults = {
@@ -103,6 +108,7 @@ function main () {
                     generated_toc:    generatedToc.replace(".yml", ""),
                     change_frequency: changeFrequency,
                     priority:         pagePriority,
+                    current:          current
                 }
             };
 

--- a/www/_layouts/docs-de.html
+++ b/www/_layouts/docs-de.html
@@ -7,6 +7,9 @@ toc_text: "Inhaltsverzeichnis"
 latest_text: "Letzte"
 visit_github_text: "Other versions are on GitHub."
 plugin_version_text: "This documentation describes this plugin at version"
+edit_text: "Edit"
+edit_source_text: "Edit Source on GitHub"
+edit_translation_text: "Edit Translation on Crowdin"
 ---
 
 {{ content }}

--- a/www/_layouts/docs-en.html
+++ b/www/_layouts/docs-en.html
@@ -7,6 +7,9 @@ toc_text: "Table of Contents"
 latest_text: "Latest"
 visit_github_text: "Other versions are on GitHub."
 plugin_version_text: "This documentation describes this plugin at version"
+edit_text: "Edit"
+edit_source_text: "Edit Source on GitHub"
+edit_translation_text: "Edit Translation on Crowdin"
 ---
 
 {{ content }}

--- a/www/_layouts/docs-es.html
+++ b/www/_layouts/docs-es.html
@@ -7,6 +7,9 @@ toc_text: "Tabla de Contenidos"
 latest_text: "Ultima"
 visit_github_text: "Other versions are on GitHub."
 plugin_version_text: "This documentation describes this plugin at version"
+edit_text: "Edit"
+edit_source_text: "Edit Source on GitHub"
+edit_translation_text: "Edit Translation on Crowdin"
 ---
 
 {{ content }}

--- a/www/_layouts/docs-fr.html
+++ b/www/_layouts/docs-fr.html
@@ -7,6 +7,9 @@ toc_text: "Table des Matières"
 latest_text: "Dernière"
 visit_github_text: "L'autres versions sont sur Github."
 plugin_version_text: "Ce document décrit ce plugin à la version"
+edit_text: "Modifier"
+edit_source_text: "Modifier la Source sur GitHub"
+edit_translation_text: "Modifier la Traduction sur Crowdin"
 ---
 
 {{ content }}

--- a/www/_layouts/docs-it.html
+++ b/www/_layouts/docs-it.html
@@ -7,6 +7,9 @@ toc_text: "Sommario"
 latest_text: "Latest"
 visit_github_text: "Other versions are on GitHub."
 plugin_version_text: "This documentation describes this plugin at version"
+edit_text: "Edit"
+edit_source_text: "Edit Source on GitHub"
+edit_translation_text: "Edit Translation on Crowdin"
 ---
 
 {{ content }}

--- a/www/_layouts/docs-ja.html
+++ b/www/_layouts/docs-ja.html
@@ -7,6 +7,9 @@ toc_text: "目次"
 latest_text: "Latest"
 visit_github_text: "Other versions are on GitHub."
 plugin_version_text: "This documentation describes this plugin at version"
+edit_text: "Edit"
+edit_source_text: "Edit Source on GitHub"
+edit_translation_text: "Edit Translation on Crowdin"
 ---
 
 {{ content }}

--- a/www/_layouts/docs-ko.html
+++ b/www/_layouts/docs-ko.html
@@ -7,6 +7,9 @@ toc_text: "차례"
 latest_text: "Latest"
 visit_github_text: "Other versions are on GitHub."
 plugin_version_text: "This documentation describes this plugin at version"
+edit_text: "Edit"
+edit_source_text: "Edit Source on GitHub"
+edit_translation_text: "Edit Translation on Crowdin"
 ---
 
 {{ content }}

--- a/www/_layouts/docs-pl.html
+++ b/www/_layouts/docs-pl.html
@@ -7,6 +7,9 @@ toc_text: "Spis treści"
 latest_text: "Latest"
 visit_github_text: "Other versions are on GitHub."
 plugin_version_text: "This documentation describes this plugin at version"
+edit_text: "Edit"
+edit_source_text: "Edit Source on GitHub"
+edit_translation_text: "Edit Translation on Crowdin"
 ---
 
 {{ content }}

--- a/www/_layouts/docs-ru.html
+++ b/www/_layouts/docs-ru.html
@@ -7,6 +7,9 @@ toc_text: "Содержание"
 latest_text: "Последняя"
 visit_github_text: "Другие версии на GitHub."
 plugin_version_text: "Эта документация описывает этот плагин версии"
+edit_text: "Править"
+edit_source_text: "Править Исток на GitHub"
+edit_translation_text: "Править Перевод на Crowdin"
 ---
 
 <style type="text/css">

--- a/www/_layouts/docs-sl.html
+++ b/www/_layouts/docs-sl.html
@@ -7,6 +7,9 @@ toc_text: "Kazalo"
 latest_text: "Latest"
 visit_github_text: "Other versions are on GitHub."
 plugin_version_text: "This documentation describes this plugin at version"
+edit_text: "Edit"
+edit_source_text: "Edit Source on GitHub"
+edit_translation_text: "Edit Translation on Crowdin"
 ---
 
 {{ content }}

--- a/www/_layouts/docs-zh.html
+++ b/www/_layouts/docs-zh.html
@@ -7,6 +7,9 @@ toc_text: "目录"
 latest_text: "Latest"
 visit_github_text: "Other versions are on GitHub."
 plugin_version_text: "This documentation describes this plugin at version"
+edit_text: "Edit"
+edit_source_text: "Edit Source on GitHub"
+edit_translation_text: "Edit Translation on Crowdin"
 ---
 
 {{ content }}

--- a/www/_layouts/docs.html
+++ b/www/_layouts/docs.html
@@ -50,9 +50,61 @@ analytics_id: UA-64283057-1
 
         <div class="content-header">
 
-            <a class="edit" href="{% if page.edit_link %}{{ page.edit_link }}{% else %}{{ site.repo.uri }}/tree/{{ site.repo.branch }}/www/{{ page.path }}{% endif %}">
-                <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span> Edit
-            </a>
+            {% comment %}
+            Show a simple edit link if the page has a specific edit link.
+            {% endcomment %}
+            {% if page.edit_link %}
+                <a class="edit" href="{{ page.edit_link }}"><span class="glyphicon glyphicon-pencil" aria-hidden="true"></span> {{ page.edit_text }}</a>
+
+            {% comment %}
+            Otherwise, have a dropdown of editing options.
+            {% endcomment %}
+            {% else %}
+
+                {% capture edit_link %}{{ site.repo.uri }}/tree/{{ site.repo.branch }}/www/{{ page.path }}{% endcapture %}
+                {% capture version_string %}/{{ page.version }}/{% endcapture %}
+                {% capture language_string %}/{{ page.language }}/{% endcapture %}
+                {% capture src_language_string %}/{{ site.src_language }}/{% endcapture %}
+
+                {% comment %}
+                Compute related edit links (i.e. source language edit link and /dev/ edit link).
+                {% endcomment %}
+                {% assign dev_edit_link     = edit_link | replace:version_string,"/dev/" %}
+                {% assign src_dev_edit_link = dev_edit_link | replace:language_string,src_language_string %}
+
+                <!-- Edit dropdown -->
+                <div class="dropdown">
+                    <button class="btn btn-default dropdown-toggle" type="button" id="editDropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+                        {{ page.edit_text }}
+                        <span class="caret"></span>
+                    </button>
+
+                    <!-- List edit options -->
+                    <ul class="dropdown-menu" aria-labelledby="editDropdown">
+                        {% if page.language != site.src_language and page.current %}
+
+                            {% capture page_path_prefix %}docs/{{ page.language }}/{{ page.version }}{% endcapture %}
+                            {% assign page_path_end = page.path | split:"/" | last %}
+                            {% assign page_path     = page.path | replace:page_path_prefix,"docs/en/dev" | replace:page_path_end,"" %}
+                            {% capture crowdin_link %}https://crowdin.com/project/cordova/{{ page.language }}#/cordova-docs/{{ page_path }}{% endcapture %}
+
+                            <li>
+                                <a href="{{ src_dev_edit_link }}">{{ page.edit_source_text }}</a>
+                            </li>
+                            <li>
+                                <a href="{{ crowdin_link }}">{{ page.edit_translation_text }}</a>
+                            </li>
+                        {% else %}
+                            {% if page.version == site.latest_docs_version %}
+                                {% assign edit_link = dev_edit_link %}
+                            {% endif %}
+                            <li>
+                                <a href="{{ edit_link }}">{{ page.edit_source_text }}</a>
+                            </li>
+                        {% endif %}
+                    </ul>
+                </div>
+            {% endif %}
 
             <!-- Language dropdown -->
             <div class="dropdown">


### PR DESCRIPTION
# Changes

- Added links to Crowdin translation on appropriate pages
- Changed "Edit" links for translated content to point to English sources
- Changed "Edit" links for current content to point to /dev/ sources
- Changed all other "Edit" links point to their respective files

# Examples (link at each example's top)

### DEV ENGLISH

<img width="500" alt="1" src="https://cloud.githubusercontent.com/assets/405489/13669630/a6fe0446-e679-11e5-83c7-eb7f7d28d28b.png">

### LATEST ENGLISH

<img width="500" alt="2" src="https://cloud.githubusercontent.com/assets/405489/13669640/ac9c2b9e-e679-11e5-9d78-502c43f898a3.png">

### OLD ENGLISH

<img width="500" alt="3" src="https://cloud.githubusercontent.com/assets/405489/13669642/b08e2db0-e679-11e5-9690-a447006e3843.png">

### DEV FRENCH SOURCE

<img width="500" alt="4" src="https://cloud.githubusercontent.com/assets/405489/13669649/b7e62a18-e679-11e5-97a2-fadf5006ec39.png">

### DEV FRENCH TRANSLATION

<img width="500" alt="5" src="https://cloud.githubusercontent.com/assets/405489/13669651/ba4bcefc-e679-11e5-8361-6300e931e066.png">

### LATEST FRENCH SOURCE

<img width="500" alt="6" src="https://cloud.githubusercontent.com/assets/405489/13669655/be5548ac-e679-11e5-8a32-fc372e130335.png">

### LATEST FRENCH TRANSLATION

<img width="500" alt="7" src="https://cloud.githubusercontent.com/assets/405489/13669659/c17f6cf6-e679-11e5-8e1a-be5338e44eef.png">

### OLD FRENCH

<img width="500" alt="8" src="https://cloud.githubusercontent.com/assets/405489/13669662/c41645de-e679-11e5-86e8-a59d35160841.png">
