### PR TITLE
Removing prettify reference in index.js

### DIFF
--- a/www/static/js/index.js
+++ b/www/static/js/index.js
@@ -206,11 +206,4 @@ $(document).ready(function () {
             submitJiraSearchForm();
         }
     });
-
-    // add prettyprint class to code blocks for prettify.js
-    var all_code = $('pre');
-    all_code.attr('class', 'prettyprint');
-
-    // run syntax highlighter
-    prettyPrint();
 });


### PR DESCRIPTION
Forgot that we referenced a function from the Prettify script in another script that was included later in the page. Hurray web development!

@dblotsky check it out