### PR TITLE
Fixed a typo in a title

### DIFF
--- a/www/docs/en/dev/guide/support/index.md
+++ b/www/docs/en/dev/guide/support/index.md
@@ -17,7 +17,7 @@ license: >
     specific language governing permissions and limitations
     under the License.
 
-title: Corodva support by platform
+title: Cordova support by platform
 ---
 
 # Platform Support


### PR DESCRIPTION
In /www/docs/en/dev/guide/support/index.md :
"Corodva" -> "Cordova"