### PR TITLE
CB-11127 Improving internal linking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ conf/_defaults.yml
 conf/_version.yml
 
 www/_data/docs-versions.yml
+www/_data/all-pages.yml
 www/_data/toc/*-gen.yml
 www/static/css
 www/static/js/plugins.js

--- a/conf/_config.yml
+++ b/conf/_config.yml
@@ -15,9 +15,6 @@ description: >
     developer to access native device function from JavaScript.
 
 excerpt_separator: <!--more-->
-repo:
-    uri:    https://github.com/apache/cordova-docs
-    branch: master
 
 # the version to which /latest/ points
 # NOTE:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -55,10 +55,12 @@ var NODOCS_CONFIG_FILE   = path.join(CONFIG_DIR, "_nodocs.yml");
 
 var VERSION_FILE      = "VERSION";
 var DOCS_VERSION_FILE = path.join(DATA_DIR, "docs-versions.yml");
+var ALL_PAGES_FILE    = path.join(DATA_DIR, "all-pages.yml");
+var FETCH_CONFIG      = path.join(DATA_DIR, "fetched-files.yml");
+var REDIRECTS_FILE    = path.join(DATA_DIR, "redirects.yml");
 var PLUGINS_FILE_NAME = "plugins.js";
 var PLUGINS_FILE      = path.join(JS_DIR, PLUGINS_FILE_NAME);
 var PLUGINS_SRC_FILE  = path.join(PLUGINS_SRC_DIR, "app.js");
-var FETCH_CONFIG      = path.join(DATA_DIR, "fetched-files.yml");
 
 var BASE_CONFIGS = [CONFIG_FILE, DEFAULTS_CONFIG_FILE, VERSION_CONFIG_FILE];
 var DEV_CONFIGS  = [DEV_CONFIG_FILE];
@@ -217,6 +219,7 @@ gulp.task("help", function () {
     gutil.log("");
     gutil.log("    data          run all the below tasks");
     gutil.log("    docs-versions create " + DOCS_VERSION_FILE);
+    gutil.log("    pages-dict    create " + ALL_PAGES_FILE);
     gutil.log("    toc           create all generated ToC files in " + TOC_DIR);
     gutil.log("    fetch         download docs specified in " + FETCH_CONFIG);
     gutil.log("");
@@ -237,7 +240,7 @@ gulp.task("help", function () {
     gutil.log("");
 });
 
-gulp.task("data", ["toc", "docs-versions"])
+gulp.task("data", ["toc", "docs-versions", "pages-dict"])
 gulp.task("configs", ["defaults", "version"]);
 gulp.task("styles", ["less", "css", "sass"]);
 
@@ -326,6 +329,18 @@ gulp.task("reload", function () {
 gulp.task("docs-versions", function () {
     return execPiped("node", [bin("gen_versions.js"), DOCS_DIR], DOCS_VERSION_FILE)
         .pipe(gulp.dest(ROOT_DIR));
+});
+
+gulp.task("pages-dict", function () {
+    var args = [
+        bin("gen_pages_dict.js"),
+        '--siteRoot', SOURCE_DIR,
+        '--redirectsFile', REDIRECTS_FILE,
+        '--latestVersion', LATEST_DOCS_VERSION,
+        '--languages', LANGUAGES.join(","),
+    ];
+
+    return execPiped("node", args, ALL_PAGES_FILE).pipe(gulp.dest(ROOT_DIR));
 });
 
 gulp.task("version", function () {
@@ -473,6 +488,7 @@ gulp.task("clean", function () {
     remove(CSS_OUT_DIR);
     remove(PLUGINS_FILE);
     remove(DOCS_VERSION_FILE);
+    remove(ALL_PAGES_FILE);
     remove(DEFAULTS_CONFIG_FILE);
     remove(VERSION_CONFIG_FILE);
 });

--- a/package.json
+++ b/package.json
@@ -54,9 +54,10 @@
   "devDependencies": {
     "colors": "^1.0.3",
     "diff": "^1.2.0",
+    "glob": "^7.0.3",
+    "gulp-htmllint": "^0.0.5",
     "jshint": "^2.5.8",
     "mocha": "^1.21.4",
-    "gulp-htmllint": "^0.0.5",
     "simplecrawler": "^0.5.2"
   },
   "repository": {

--- a/tools/bin/gen_pages_dict.js
+++ b/tools/bin/gen_pages_dict.js
@@ -1,0 +1,120 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+"use strict";
+
+var fs       = require("fs");
+var path     = require("path");
+var yaml     = require("js-yaml");
+var walk     = require("walk");
+var glob     = require("glob");
+var Q        = require("q");
+var optimist = require("optimist");
+
+var util = require("./util");
+
+// constants
+var LATEST_ALIAS_URI = "/latest/";
+
+// helpers
+function pathToURI(filePath, rootPath) {
+    return filePath
+        .replace(new RegExp("^" + rootPath), "")
+        .replace(new RegExp("\\.md$"), ".html");
+}
+
+function pagesFromRedirects(redirects, languages) {
+    var pages = {};
+
+    // add docs redirects
+    if (typeof redirects.docs !== "undefined") {
+        for (var redirectSource in redirects.docs) {
+
+            // add an entry for the redirect's source, once for each language
+            for (var i = 0; i < languages.length; i++) {
+                var language = languages[i];
+                var pagePath = "/docs/" + language + "/" + redirectSource;
+
+                pages[pagePath] = true;
+            }
+        }
+    }
+
+    return pages;
+}
+
+function isInLatestDocs(uri, latestVersion) {
+    return uri.indexOf("/" + latestVersion + "/") !== (-1);
+}
+
+// main
+function main () {
+
+    // get args
+    var argv = optimist
+        .usage("Usage: $0 [options]")
+        .demand("languages").describe("languages", "comma-separated list of docs languages")
+        .demand("latestVersion").describe("latestVersion", "the current latest docs version")
+        .demand("siteRoot").describe("siteRoot", "the source ToC for the given directory")
+        .string("redirectsFile").describe("redirectsFile", "file containing redirects for the website").default("redirectsFile", null)
+        .argv;
+
+    var siteRootPath      = argv.siteRoot;
+    var redirectsFilePath = argv.redirectsFile;
+    var latestVersion     = argv.latestVersion;
+    var languages         = argv.languages.split(",");
+
+    // pages to return
+    var pages = {};
+
+    // add pages for redirects if a redirects file was passed
+    if (redirectsFilePath !== null) {
+
+        var redirectsString = fs.readFileSync(redirectsFilePath);
+        var redirects       = yaml.load(redirectsString);
+        var redirectsPages  = pagesFromRedirects(redirects, languages);
+
+        pages = redirectsPages;
+    }
+
+    // add entries for all Markdown files in the site root
+    var allMarkdownFiles = path.join(siteRootPath, "**/*.md");
+    glob(allMarkdownFiles, function (error, filePaths) {
+        for (var i = 0; i < filePaths.length; i++) {
+            var filePath = filePaths[i];
+            var fileURI  = pathToURI(filePath, siteRootPath);
+
+            // add the page
+            pages[fileURI] = true;
+
+            // also add /latest/ version for pages in latest docs
+            if (isInLatestDocs(fileURI, latestVersion)) {
+                var latestURI = fileURI.replace("/" + latestVersion + "/", LATEST_ALIAS_URI);
+
+                pages[latestURI] = true;
+            }
+        }
+
+        // print output
+        console.log(util.generatedBy(__filename));
+        console.log(yaml.dump(pages));
+    });
+}
+
+if (require.main === module) {
+    main();
+}

--- a/www/.htaccess
+++ b/www/.htaccess
@@ -41,7 +41,9 @@ RewriteEngine on
 #      (?:\d+\.(?:\d+\.\d+|x))|dev|latest - regex for versions
 #
 # NOTE:
-#      L  - terminal rule
+#      Meanings of some of the flags at the ends of rules:
+#
+#      L  - terminal rule; if it applies, no more rules are checked
 #      R  - redirect (followed by code)
 #      NE - no escaping special characters
 
@@ -61,14 +63,14 @@ RewriteRule ^.*docs/(\w\w(?:-\w\w)?)/latest$ {{site.baseurl}}/docs/$1/latest/ [R
 #
 #     docs/*/XX/* -> docs/*/YY/*
 #
-{% for redirect in site.data.redirects.version-renames %}RewriteRule ^.*docs/(\w\w(?:-\w\w)?)/{{redirect.old}}/(.*)$ {{site.baseurl}}/docs/$1/{{redirect.new}}/$2 [R=302,L]
+{% for redirect in site.data.redirects.version-renames %}RewriteRule ^.*docs/(\w\w(?:-\w\w)?)/{{redirect[0]}}/(.*)$ {{site.baseurl}}/docs/$1/{{redirect[1]}}/$2 [R=302,L]
 {% endfor %}
 
 # 302 (temporary):
 #
 #     docs/XX/* -> docs/YY/*
 #
-{% for redirect in site.data.redirects.language-renames %}RewriteRule ^.*docs/{{redirect.old}}/((?:\d+\.(?:\d+\.\d+|x))|dev|latest)/(.*)$ {{site.baseurl}}/docs/{{redirect.new}}/$1/$2 [R=302,L]
+{% for redirect in site.data.redirects.language-renames %}RewriteRule ^.*docs/{{redirect[0]}}/((?:\d+\.(?:\d+\.\d+|x))|dev|latest)/(.*)$ {{site.baseurl}}/docs/{{redirect[1]}}/$1/$2 [R=302,L]
 {% endfor %}
 
 # 301 (PERMANENT):
@@ -80,21 +82,21 @@ RewriteRule ^.*docs/(\w\w(?:-\w\w)?)/latest$ {{site.baseurl}}/docs/$1/latest/ [R
 #       by site.baseurl. It is thrown away because there is no RewriteCond to
 #       control whether the rewrite happens to a URI or a local file path
 #       (when Apache is locating the local file to serve).
-{% for redirect in site.data.redirects.docs-global %}RewriteRule ^.*docs/(\w\w(?:-\w\w)?)/((?:\d+\.(?:\d+\.\d+|x))|dev|latest)/{{redirect.old}}$ {{site.baseurl}}/docs/$1/$2/{{redirect.new}} [NE,R=301,L]
+{% for redirect in site.data.redirects.docs-global %}RewriteRule ^.*docs/(\w\w(?:-\w\w)?)/((?:\d+\.(?:\d+\.\d+|x))|dev|latest)/{{redirect[0]}}$ {{site.baseurl}}/docs/$1/$2/{{redirect[1]}} [NE,R=301,L]
 {% endfor %}
 
 # 301 (PERMANENT):
 #
 #     old docs pages -> new docs pages (version-specific)
 #
-{% for redirect in site.data.redirects.docs %}RewriteRule ^.*docs/(\w\w(?:-\w\w)?)/{{redirect.old}}$ {{site.baseurl}}/docs/$1/{{redirect.new}} [NE,R=301,L]
+{% for redirect in site.data.redirects.docs %}RewriteRule ^.*docs/(\w\w(?:-\w\w)?)/{{redirect[0]}}$ {{site.baseurl}}/docs/$1/{{redirect[1]}} [NE,R=301,L]
 {% endfor %}
 
 # 301 (PERMANENT):
 #
 #     old pages -> new pages
 #
-{% for redirect in site.data.redirects.general %}RewriteRule ^.*/{{redirect.old}}$ {{site.baseurl}}/{{redirect.new}} [NE,R=301,L]
+{% for redirect in site.data.redirects.general %}RewriteRule ^.*/{{redirect[0]}}$ {{site.baseurl}}/{{redirect[1]}} [NE,R=301,L]
 {% endfor %}
 
 # rewrite only:
@@ -105,6 +107,7 @@ RewriteRule ^.*docs/(\w\w(?:-\w\w)?)/latest$ {{site.baseurl}}/docs/$1/latest/ [R
 #       This does NOT return a redirect. It returns the resource *as if* the
 #       redirected URI was requested. That is, both URIs return the same
 #       resource, but the browser won't change the URI (no redirects followed).
+#
 # NOTE:
 #       This needs to be *after* the docs redirects because they might need the
 #       "/latest/" to be in the URI in order to activate. Placing this rule

--- a/www/_data/redirects.yml
+++ b/www/_data/redirects.yml
@@ -3,224 +3,224 @@
 
 # 302 (temporary) renames of versions
 version-renames:
-    - {old: "edge", new: "dev"}
-    - {old: "6.0.0", new: "6.x"}
+    "edge": "dev"
+    "6.0.0": "6.x"
 
 # 302 (temporary) renames of languages
 language-renames:
-    - {old: "zh", new: "zh-tw"}
+    "zh": "zh-tw"
 
 # 301 (PERMANENT) redirect paths relative to /
 general:
-    - {old: "plugins/authors.html", new: "docs/en/latest/guide/hybrid/plugins/index.html#publishing-plugins"}
+    "plugins/authors.html": "docs/en/latest/guide/hybrid/plugins/index.html#publishing-plugins"
 
 # 301 (PERMANENT) redirect paths relative to /docs/XX/
 docs:
-    - {old: "dev/guide/platforms/android/tools.html", new: "dev/guide/platforms/android/index.html"}
-    - {old: "latest/guide/platforms/android/tools.html", new: "latest/guide/platforms/android/index.html"}
+    "dev/guide/platforms/android/tools.html": "dev/guide/platforms/android/index.html"
+    "latest/guide/platforms/android/tools.html": "latest/guide/platforms/android/index.html"
 
-    - {old: "dev/guide/platforms/android/lifecycle.html", new: "dev/guide/platforms/android/index.html#lifecycle-guide"}
-    - {old: "latest/guide/platforms/android/lifecycle.html", new: "latest/guide/platforms/android/index.html#lifecycle-guide"}
+    "dev/guide/platforms/android/lifecycle.html": "dev/guide/platforms/android/index.html#lifecycle-guide"
+    "latest/guide/platforms/android/lifecycle.html": "latest/guide/platforms/android/index.html#lifecycle-guide"
 
-    - {old: "dev/guide/platforms/android/config.html", new: "dev/config_ref/index.html"}
-    - {old: "latest/guide/platforms/android/config.html", new: "latest/config_ref/index.html"}
+    "dev/guide/platforms/android/config.html": "dev/config_ref/index.html"
+    "latest/guide/platforms/android/config.html": "latest/config_ref/index.html"
 
-    - {old: "dev/guide/platforms/ios/tools.html", new: "dev/guide/platforms/ios/index.html"}
-    - {old: "latest/guide/platforms/ios/tools.html", new: "latest/guide/platforms/ios/index.html"}
+    "dev/guide/platforms/ios/tools.html": "dev/guide/platforms/ios/index.html"
+    "latest/guide/platforms/ios/tools.html": "latest/guide/platforms/ios/index.html"
 
-    - {old: "dev/guide/platforms/ios/config.html", new: "dev/config_ref/index.html"}
-    - {old: "latest/guide/platforms/ios/config.html", new: "latest/config_ref/index.html"}
+    "dev/guide/platforms/ios/config.html": "dev/config_ref/index.html"
+    "latest/guide/platforms/ios/config.html": "latest/config_ref/index.html"
 
-    - {old: "dev/guide/platforms/win8/packaging.html", new: "dev/guide/platforms/win8/index.html#signing-an-app"}
-    - {old: "latest/guide/platforms/win8/packaging.html", new: "latest/guide/platforms/win8/index.html#signing-an-app"}
+    "dev/guide/platforms/win8/packaging.html": "dev/guide/platforms/win8/index.html#signing-an-app"
+    "latest/guide/platforms/win8/packaging.html": "latest/guide/platforms/win8/index.html#signing-an-app"
 
-    - {old: "dev/guide/platforms/win8/win10-support.html", new: "dev/guide/platforms/win8/index.html"}
-    - {old: "latest/guide/platforms/win8/win10-support.html", new: "latest/guide/platforms/win8/index.html"}
+    "dev/guide/platforms/win8/win10-support.html": "dev/guide/platforms/win8/index.html"
+    "latest/guide/platforms/win8/win10-support.html": "latest/guide/platforms/win8/index.html"
 
-    - {old: "dev/cordova/plugins/pluginapis.html", new: "deprecated.html"}
-    - {old: "latest/cordova/plugins/pluginapis.html", new: "deprecated.html"}
+    "dev/cordova/plugins/pluginapis.html": "deprecated.html"
+    "latest/cordova/plugins/pluginapis.html": "deprecated.html"
 
     # NOTE:
     #      these only need to be done for /latest, since they only existed in /latest and they don't exist anywhere anymore
-    - {old: "latest/cordova-cli/index.html", new: "latest/reference/cordova-cli/index.html"}
-    - {old: "latest/cordova-plugin-battery-status/index.html", new: "latest/reference/cordova-plugin-battery-status/index.html"}
-    - {old: "latest/cordova-plugin-camera/index.html", new: "latest/reference/cordova-plugin-camera/index.html"}
-    - {old: "latest/cordova-plugin-console/index.html", new: "latest/reference/cordova-plugin-console/index.html"}
-    - {old: "latest/cordova-plugin-contacts/index.html", new: "latest/reference/cordova-plugin-contacts/index.html"}
-    - {old: "latest/cordova-plugin-device/index.html", new: "latest/reference/cordova-plugin-device/index.html"}
-    - {old: "latest/cordova-plugin-device-motion/index.html", new: "latest/reference/cordova-plugin-device-motion/index.html"}
-    - {old: "latest/cordova-plugin-device-orientation/index.html", new: "latest/reference/cordova-plugin-device-orientation/index.html"}
-    - {old: "latest/cordova-plugin-dialogs/index.html", new: "latest/reference/cordova-plugin-dialogs/index.html"}
-    - {old: "latest/cordova-plugin-file/index.html", new: "latest/reference/cordova-plugin-file/index.html"}
-    - {old: "latest/cordova-plugin-file-transfer/index.html", new: "latest/reference/cordova-plugin-file-transfer/index.html"}
-    - {old: "latest/cordova-plugin-geolocation/index.html", new: "latest/reference/cordova-plugin-geolocation/index.html"}
-    - {old: "latest/cordova-plugin-globalization/index.html", new: "latest/reference/cordova-plugin-globalization/index.html"}
-    - {old: "latest/cordova-plugin-inappbrowser/index.html", new: "latest/reference/cordova-plugin-inappbrowser/index.html"}
-    - {old: "latest/cordova-plugin-media/index.html", new: "latest/reference/cordova-plugin-media/index.html"}
-    - {old: "latest/cordova-plugin-media-capture/index.html", new: "latest/reference/cordova-plugin-media-capture/index.html"}
-    - {old: "latest/cordova-plugin-network-information/index.html", new: "latest/reference/cordova-plugin-network-information/index.html"}
-    - {old: "latest/cordova-plugin-splashscreen/index.html", new: "latest/reference/cordova-plugin-splashscreen/index.html"}
-    - {old: "latest/cordova-plugin-vibration/index.html", new: "latest/reference/cordova-plugin-vibration/index.html"}
-    - {old: "latest/cordova-plugin-statusbar/index.html", new: "latest/reference/cordova-plugin-statusbar/index.html"}
-    - {old: "latest/cordova-plugin-whitelist/index.html", new: "latest/reference/cordova-plugin-whitelist/index.html"}
-    - {old: "latest/cordova-plugin-legacy-whitelist/index.html", new: "latest/reference/cordova-plugin-legacy-whitelist/index.html"}
+    "latest/cordova-cli/index.html": "latest/reference/cordova-cli/index.html"
+    "latest/cordova-plugin-battery-status/index.html": "latest/reference/cordova-plugin-battery-status/index.html"
+    "latest/cordova-plugin-camera/index.html": "latest/reference/cordova-plugin-camera/index.html"
+    "latest/cordova-plugin-console/index.html": "latest/reference/cordova-plugin-console/index.html"
+    "latest/cordova-plugin-contacts/index.html": "latest/reference/cordova-plugin-contacts/index.html"
+    "latest/cordova-plugin-device/index.html": "latest/reference/cordova-plugin-device/index.html"
+    "latest/cordova-plugin-device-motion/index.html": "latest/reference/cordova-plugin-device-motion/index.html"
+    "latest/cordova-plugin-device-orientation/index.html": "latest/reference/cordova-plugin-device-orientation/index.html"
+    "latest/cordova-plugin-dialogs/index.html": "latest/reference/cordova-plugin-dialogs/index.html"
+    "latest/cordova-plugin-file/index.html": "latest/reference/cordova-plugin-file/index.html"
+    "latest/cordova-plugin-file-transfer/index.html": "latest/reference/cordova-plugin-file-transfer/index.html"
+    "latest/cordova-plugin-geolocation/index.html": "latest/reference/cordova-plugin-geolocation/index.html"
+    "latest/cordova-plugin-globalization/index.html": "latest/reference/cordova-plugin-globalization/index.html"
+    "latest/cordova-plugin-inappbrowser/index.html": "latest/reference/cordova-plugin-inappbrowser/index.html"
+    "latest/cordova-plugin-media/index.html": "latest/reference/cordova-plugin-media/index.html"
+    "latest/cordova-plugin-media-capture/index.html": "latest/reference/cordova-plugin-media-capture/index.html"
+    "latest/cordova-plugin-network-information/index.html": "latest/reference/cordova-plugin-network-information/index.html"
+    "latest/cordova-plugin-splashscreen/index.html": "latest/reference/cordova-plugin-splashscreen/index.html"
+    "latest/cordova-plugin-vibration/index.html": "latest/reference/cordova-plugin-vibration/index.html"
+    "latest/cordova-plugin-statusbar/index.html": "latest/reference/cordova-plugin-statusbar/index.html"
+    "latest/cordova-plugin-whitelist/index.html": "latest/reference/cordova-plugin-whitelist/index.html"
+    "latest/cordova-plugin-legacy-whitelist/index.html": "latest/reference/cordova-plugin-legacy-whitelist/index.html"
 
 # 301 (PERMANENT) redirect paths relative to /docs/XX/YYY/
 docs-global:
-    - {old: "config_ref_images.md.html", new: "config_ref/images.html"}
-    - {old: "config_ref_index.md.html", new: "config_ref/index.html"}
-    - {old: "cordova_accelerometer_accelerometer.md.html", new: "cordova/accelerometer/accelerometer.html"}
-    - {old: "cordova_camera_camera.cleanup.md.html", new: "cordova/camera/camera.cleanup.html"}
-    - {old: "cordova_camera_camera.md.html", new: "cordova/camera/camera.html"}
-    - {old: "cordova_compass_compass.md.html", new: "cordova/compass/compass.html"}
-    - {old: "cordova_connection_connection.md.html", new: "cordova/connection/connection.html"}
-    - {old: "cordova_contacts_contacts.md.html", new: "cordova/contacts/contacts.html"}
-    - {old: "cordova_device_device.md.html", new: "cordova/device/device.html"}
-    - {old: "cordova_device_device.model.md.html", new: "cordova/device/device.model.html"}
-    - {old: "cordova_events_events.md.html", new: "cordova/events/events.html"}
-    - {old: "cordova_file_file.md.html", new: "cordova/file/file.html"}
-    - {old: "cordova_geolocation_geolocation.md.html", new: "cordova/geolocation/geolocation.html"}
-    - {old: "cordova_globalization_globalization.md.html", new: "cordova/globalization/globalization.html"}
-    - {old: "cordova_inappbrowser_inappbrowser.md.html", new: "cordova/inappbrowser/inappbrowser.html"}
-    - {old: "cordova_media_capture_capture.md.html", new: "cordova/media/capture/capture.html"}
-    - {old: "cordova_media_media.md.html", new: "cordova/media/media.html"}
-    - {old: "cordova_notification_notification.md.html", new: "cordova/notification/notification.html"}
-    - {old: "cordova_splashscreen_splashscreen.md.html", new: "cordova/splashscreen/splashscreen.html"}
-    - {old: "cordova_storage_storage.md.html", new: "cordova/storage/storage.html"}
-    - {old: "guide_appdev_privacy_index.md.html", new: "guide/appdev/privacy/index.html"}
-    - {old: "guide_appdev_whitelist_index.md.html", new: "guide/appdev/whitelist/index.html"}
-    - {old: "guide_cli_index.md.html", new: "guide/cli/index.html"}
-    - {old: "guide_hybrid_plugins_index.md.html", new: "guide/hybrid/plugins/index.html"}
-    - {old: "guide_hybrid_webviews_index.md.html", new: "guide/hybrid/webviews/index.html"}
-    - {old: "guide_overview_index.md.html", new: "guide/overview/index.html"}
-    - {old: "guide_platforms_android_config.md.html", new: "guide/platforms/android/config.html"}
-    - {old: "guide_platforms_android_index.md.html", new: "guide/platforms/android/index.html"}
-    - {old: "guide_platforms_android_plugin.md.html", new: "guide/platforms/android/plugin.html"}
-    - {old: "guide_platforms_android_tools.md.html", new: "guide/platforms/android/tools.html"}
-    - {old: "guide_platforms_android_upgrading.md.html", new: "guide/platforms/android/upgrading.html"}
-    - {old: "guide_platforms_android_webview.md.html", new: "guide/platforms/android/webview.html"}
-    - {old: "guide_platforms_blackberry10_config.md.html", new: "guide/platforms/blackberry10/config.html"}
-    - {old: "guide_platforms_blackberry10_index.md.html", new: "guide/platforms/blackberry10/index.html"}
-    - {old: "guide_platforms_blackberry10_plugin.md.html", new: "guide/platforms/blackberry10/plugin.html"}
-    - {old: "guide_platforms_blackberry10_tools.md.html", new: "guide/platforms/blackberry10/tools.html"}
-    - {old: "guide_platforms_blackberry10_upgrading.md.html", new: "guide/platforms/blackberry10/upgrading.html"}
-    - {old: "guide_platforms_blackberry_config.md.html", new: "guide/platforms/blackberry/config.html"}
-    - {old: "guide_platforms_blackberry_index.md.html", new: "guide/platforms/blackberry/index.html"}
-    - {old: "guide_platforms_blackberry_plugin.md.html", new: "guide/platforms/blackberry/plugin.html"}
-    - {old: "guide_platforms_blackberry_tools.md.html", new: "guide/platforms/blackberry/tools.html"}
-    - {old: "guide_platforms_blackberry_upgrading.md.html", new: "guide/platforms/blackberry/upgrading.html"}
-    - {old: "guide_platforms_firefoxos_config.md.html", new: "guide/platforms/firefoxos/config.html"}
-    - {old: "guide_platforms_index.md.html", new: "guide/platforms/index.html"}
-    - {old: "guide_platforms_ios_config.md.html", new: "guide/platforms/ios/config.html"}
-    - {old: "guide_platforms_ios_index.md.html", new: "guide/platforms/ios/index.html"}
-    - {old: "guide_platforms_ios_plugin.md.html", new: "guide/platforms/ios/plugin.html"}
-    - {old: "guide_platforms_ios_tools.md.html", new: "guide/platforms/ios/tools.html"}
-    - {old: "guide_platforms_ios_upgrading.md.html", new: "guide/platforms/ios/upgrading.html"}
-    - {old: "guide_platforms_ios_webview.md.html", new: "guide/platforms/ios/webview.html"}
-    - {old: "guide_platforms_tizen_index.md.html", new: "guide/platforms/tizen/index.html"}
-    - {old: "guide_platforms_win8_index.md.html", new: "guide/platforms/win8/index.html"}
-    - {old: "guide_platforms_win8_tools.md.html", new: "guide/platforms/win8/tools.html"}
-    - {old: "guide_platforms_win8_upgrading.md.html", new: "guide/platforms/win8/upgrading.html"}
-    - {old: "guide_platforms_wp7_index.md.html", new: "guide/platforms/wp7/index.html"}
-    - {old: "guide_platforms_wp8_index.md.html", new: "guide/platforms/wp8/index.html"}
-    - {old: "guide_platforms_wp8_plugin.md.html", new: "guide/platforms/wp8/plugin.html"}
-    - {old: "guide_platforms_wp8_tools.md.html", new: "guide/platforms/wp8/tools.html"}
-    - {old: "guide_platforms_wp8_upgrading.md.html", new: "guide/platforms/wp8/upgrading.html"}
-    - {old: "plugin_ref_plugman.md.html", new: "plugin_ref/plugman.html"}
-    - {old: "plugin_ref_spec.md.html", new: "plugin_ref/spec.html"}
-    - {old: "cordova_plugins_pluginapis.md.html", new: "cordova/plugins/pluginapis.html"}
-    - {old: "cordova_storage_database_database.md.html", new: "cordova/storage/database/database.html"}
-    - {old: "cordova_storage_localstorage_localstorage.md.html", new: "cordova/storage/localstorage/localstorage.html"}
-    - {old: "cordova_storage_parameters_display_name.md.html", new: "cordova/storage/parameters/display_name.html"}
-    - {old: "cordova_storage_parameters_name.md.html", new: "cordova/storage/parameters/name.html"}
-    - {old: "cordova_storage_parameters_size.md.html", new: "cordova/storage/parameters/size.html"}
-    - {old: "cordova_storage_parameters_version.md.html", new: "cordova/storage/parameters/version.html"}
-    - {old: "cordova_storage_sqlerror_sqlerror.md.html", new: "cordova/storage/sqlerror/sqlerror.html"}
-    - {old: "cordova_storage_sqlresultset_sqlresultset.md.html", new: "cordova/storage/sqlresultset/sqlresultset.html"}
-    - {old: "cordova_storage_sqlresultsetrowlist_sqlresultsetrowlist.md.html", new: "cordova/storage/sqlresultsetrowlist/sqlresultsetrowlist.html"}
-    - {old: "cordova_storage_sqltransaction_sqltransaction.md.html", new: "cordova/storage/sqltransaction/sqltransaction.html"}
-    - {old: "cordova_storage_storage.opendatabase.md.html", new: "cordova/storage/storage.opendatabase.html"}
-    - {old: "guide_platforms_amazonfireos_config.md.html", new: "guide/platforms/amazonfireos/config.html"}
-    - {old: "guide_platforms_amazonfireos_index.md.html", new: "guide/platforms/amazonfireos/index.html"}
-    - {old: "guide_platforms_amazonfireos_plugin.md.html", new: "guide/platforms/amazonfireos/plugin.html"}
-    - {old: "guide_platforms_amazonfireos_webview.md.html", new: "guide/platforms/amazonfireos/webview.html"}
-    - {old: "guide_platforms_ubuntu_index.md.html", new: "guide/platforms/ubuntu/index.html"}
-    - {old: "guide_support_index.md.html", new: "guide/support/index.html"}
-    - {old: "guide_appdev_hooks_index.md.html", new: "guide/appdev/hooks/index.html"}
-    - {old: "guide_appdev_security_index.md.html", new: "guide/appdev/security/index.html"}
-    - {old: "guide_next_index.md.html", new: "guide/next/index.html"}
-    - {old: "guide_platforms_android_upgrade.md.html", new: "guide/platforms/android/upgrade.html"}
-    - {old: "guide_platforms_blackberry10_upgrade.md.html", new: "guide/platforms/blackberry10/upgrade.html"}
-    - {old: "guide_platforms_blackberry_upgrade.md.html", new: "guide/platforms/blackberry/upgrade.html"}
-    - {old: "guide_platforms_firefoxos_index.md.html", new: "guide/platforms/firefoxos/index.html"}
-    - {old: "guide_platforms_ios_upgrade.md.html", new: "guide/platforms/ios/upgrade.html"}
-    - {old: "guide_platforms_win8_packaging.md.html", new: "guide/platforms/win8/packaging.html"}
-    - {old: "guide_platforms_win8_plugin.md.html", new: "guide/platforms/win8/plugin.html"}
-    - {old: "guide_platforms_win8_upgrade.md.html", new: "guide/platforms/win8/upgrade.html"}
-    - {old: "guide_platforms_win8_win10-support.md.html", new: "guide/platforms/win8/win10-support.html"}
-    - {old: "guide_platforms_wp8_parallels.md.html", new: "guide/platforms/wp8/parallels.html"}
-    - {old: "guide_platforms_wp8_upgrade.md.html", new: "guide/platforms/wp8/upgrade.html"}
-    - {old: "guide_platforms_wp8_vmware.md.html", new: "guide/platforms/wp8/vmware.html"}
-    - {old: "guide_platforms_wp8_webview.md.html", new: "guide/platforms/wp8/webview.html"}
-    - {old: "platform_plugin_versioning_ref_index.md.html", new: "platform_plugin_versioning_ref/index.html"}
-    - {old: "guide_getting-started_android_index.md.html", new: "guide/getting-started/android/index.html"}
-    - {old: "guide_getting-started_blackberry_index.md.html", new: "guide/getting-started/blackberry/index.html"}
-    - {old: "guide_getting-started_index.md.html", new: "guide/getting-started/index.html"}
-    - {old: "guide_getting-started_ios_index.md.html", new: "guide/getting-started/ios/index.html"}
-    - {old: "guide_getting-started_symbian_index.md.html", new: "guide/getting-started/symbian/index.html"}
-    - {old: "guide_getting-started_webos_index.md.html", new: "guide/getting-started/webos/index.html"}
-    - {old: "guide_getting-started_windows-phone_index.md.html", new: "guide/getting-started/windows-phone/index.html"}
-    - {old: "guide_upgrading_blackberry_index.md.html", new: "guide/upgrading/blackberry/index.html"}
-    - {old: "guide_upgrading_webos_index.md.html", new: "guide/upgrading/webos/index.html"}
-    - {old: "phonegap_accelerometer_accelerometer.md.html", new: "phonegap/accelerometer/accelerometer.html"}
-    - {old: "phonegap_camera_camera.md.html", new: "phonegap/camera/camera.html"}
-    - {old: "phonegap_compass_compass.md.html", new: "phonegap/compass/compass.html"}
-    - {old: "phonegap_connection_connection.md.html", new: "phonegap/connection/connection.html"}
-    - {old: "phonegap_contacts_contacts.md.html", new: "phonegap/contacts/contacts.html"}
-    - {old: "phonegap_device_device.md.html", new: "phonegap/device/device.html"}
-    - {old: "phonegap_events_events.md.html", new: "phonegap/events/events.html"}
-    - {old: "phonegap_file_file.md.html", new: "phonegap/file/file.html"}
-    - {old: "phonegap_geolocation_geolocation.md.html", new: "phonegap/geolocation/geolocation.html"}
-    - {old: "phonegap_media_capture_capture.md.html", new: "phonegap/media/capture/capture.html"}
-    - {old: "phonegap_media_media.md.html", new: "phonegap/media/media.html"}
-    - {old: "phonegap_notification_notification.md.html", new: "phonegap/notification/notification.html"}
-    - {old: "phonegap_storage_storage.md.html", new: "phonegap/storage/storage.html"}
-    - {old: "guide_getting-started_bada_index.md.html", new: "guide/getting-started/bada/index.html"}
-    - {old: "guide_upgrading_android_index.md.html", new: "guide/upgrading/android/index.html"}
-    - {old: "guide_upgrading_bada_index.md.html", new: "guide/upgrading/bada/index.html"}
-    - {old: "guide_upgrading_index.md.html", new: "guide/upgrading/index.html"}
-    - {old: "guide_upgrading_ios_index.md.html", new: "guide/upgrading/ios/index.html"}
-    - {old: "guide_upgrading_symbian_index.md.html", new: "guide/upgrading/symbian/index.html"}
-    - {old: "guide_upgrading_windows-phone_index.md.html", new: "guide/upgrading/windows-phone/index.html"}
-    - {old: "guide_whitelist_index.md.html", new: "guide/whitelist/index.html"}
-    - {old: "guide_command-line_index.md.html", new: "guide/command-line/index.html"}
-    - {old: "guide_cordova-webview_android.md.html", new: "guide/cordova-webview/android.html"}
-    - {old: "guide_cordova-webview_index.md.html", new: "guide/cordova-webview/index.html"}
-    - {old: "guide_cordova-webview_ios.md.html", new: "guide/cordova-webview/ios.html"}
-    - {old: "guide_plugin-development_android_index.md.html", new: "guide/plugin-development/android/index.html"}
-    - {old: "guide_plugin-development_bada_index.md.html", new: "guide/plugin-development/bada/index.html"}
-    - {old: "guide_plugin-development_blackberry_index.md.html", new: "guide/plugin-development/blackberry/index.html"}
-    - {old: "guide_plugin-development_index.md.html", new: "guide/plugin-development/index.html"}
-    - {old: "guide_plugin-development_ios_index.md.html", new: "guide/plugin-development/ios/index.html"}
-    - {old: "guide_plugin-development_webos_index.md.html", new: "guide/plugin-development/webos/index.html"}
-    - {old: "guide_plugin-development_windows-phone_index.md.html", new: "guide/plugin-development/windows-phone/index.html"}
-    - {old: "guide_getting-started_tizen_index.md.html", new: "guide/getting-started/tizen/index.html"}
-    - {old: "guide_plugin-development_tizen_index.md.html", new: "guide/plugin-development/tizen/index.html"}
-    - {old: "guide_upgrading_tizen_index.md.html", new: "guide/upgrading/tizen/index.html"}
-    - {old: "guide_getting-started_windows-8_index.md.html", new: "guide/getting-started/windows-8/index.html"}
-    - {old: "guide_project-settings_index.md.html", new: "guide/project-settings/index.html"}
-    - {old: "guide_project-settings_ios_index.md.html", new: "guide/project-settings/ios/index.html"}
-    - {old: "guide_getting-started_windows-phone-7_index.md.html", new: "guide/getting-started/windows-phone-7/index.html"}
-    - {old: "guide_getting-started_windows-phone-8_index.md.html", new: "guide/getting-started/windows-phone-8/index.html"}
-    - {old: "guide_project-settings_android_index.md.html", new: "guide/project-settings/android/index.html"}
-    - {old: "guide_project-settings_bada_index.md.html", new: "guide/project-settings/bada/index.html"}
-    - {old: "guide_project-settings_blackberry_index.md.html", new: "guide/project-settings/blackberry/index.html"}
-    - {old: "guide_project-settings_firefoxos_index.md.html", new: "guide/project-settings/firefoxos/index.html"}
-    - {old: "guide_project-settings_webos_index.md.html", new: "guide/project-settings/webos/index.html"}
-    - {old: "guide_project-settings_windows8_index.md.html", new: "guide/project-settings/windows8/index.html"}
-    - {old: "guide_project-settings_wp7_index.md.html", new: "guide/project-settings/wp7/index.html"}
-    - {old: "guide_project-settings_wp8_index.md.html", new: "guide/project-settings/wp8/index.html"}
-    - {old: "guide_getting-started_blackberry10_index.md.html", new: "guide/getting-started/blackberry10/index.html"}
-    - {old: "guide_plugin-development_blackberry10_index.md.html", new: "guide/plugin-development/blackberry10/index.html"}
-    - {old: "guide_privacy_index.md.html", new: "guide/privacy/index.html"}
-    - {old: "guide_upgrading_windows-8_index.md.html", new: "guide/upgrading/windows-8/index.html"}
+    "config_ref_images.md.html": "config_ref/images.html"
+    "config_ref_index.md.html": "config_ref/index.html"
+    "cordova_accelerometer_accelerometer.md.html": "cordova/accelerometer/accelerometer.html"
+    "cordova_camera_camera.cleanup.md.html": "cordova/camera/camera.cleanup.html"
+    "cordova_camera_camera.md.html": "cordova/camera/camera.html"
+    "cordova_compass_compass.md.html": "cordova/compass/compass.html"
+    "cordova_connection_connection.md.html": "cordova/connection/connection.html"
+    "cordova_contacts_contacts.md.html": "cordova/contacts/contacts.html"
+    "cordova_device_device.md.html": "cordova/device/device.html"
+    "cordova_device_device.model.md.html": "cordova/device/device.model.html"
+    "cordova_events_events.md.html": "cordova/events/events.html"
+    "cordova_file_file.md.html": "cordova/file/file.html"
+    "cordova_geolocation_geolocation.md.html": "cordova/geolocation/geolocation.html"
+    "cordova_globalization_globalization.md.html": "cordova/globalization/globalization.html"
+    "cordova_inappbrowser_inappbrowser.md.html": "cordova/inappbrowser/inappbrowser.html"
+    "cordova_media_capture_capture.md.html": "cordova/media/capture/capture.html"
+    "cordova_media_media.md.html": "cordova/media/media.html"
+    "cordova_notification_notification.md.html": "cordova/notification/notification.html"
+    "cordova_splashscreen_splashscreen.md.html": "cordova/splashscreen/splashscreen.html"
+    "cordova_storage_storage.md.html": "cordova/storage/storage.html"
+    "guide_appdev_privacy_index.md.html": "guide/appdev/privacy/index.html"
+    "guide_appdev_whitelist_index.md.html": "guide/appdev/whitelist/index.html"
+    "guide_cli_index.md.html": "guide/cli/index.html"
+    "guide_hybrid_plugins_index.md.html": "guide/hybrid/plugins/index.html"
+    "guide_hybrid_webviews_index.md.html": "guide/hybrid/webviews/index.html"
+    "guide_overview_index.md.html": "guide/overview/index.html"
+    "guide_platforms_android_config.md.html": "guide/platforms/android/config.html"
+    "guide_platforms_android_index.md.html": "guide/platforms/android/index.html"
+    "guide_platforms_android_plugin.md.html": "guide/platforms/android/plugin.html"
+    "guide_platforms_android_tools.md.html": "guide/platforms/android/tools.html"
+    "guide_platforms_android_upgrading.md.html": "guide/platforms/android/upgrading.html"
+    "guide_platforms_android_webview.md.html": "guide/platforms/android/webview.html"
+    "guide_platforms_blackberry10_config.md.html": "guide/platforms/blackberry10/config.html"
+    "guide_platforms_blackberry10_index.md.html": "guide/platforms/blackberry10/index.html"
+    "guide_platforms_blackberry10_plugin.md.html": "guide/platforms/blackberry10/plugin.html"
+    "guide_platforms_blackberry10_tools.md.html": "guide/platforms/blackberry10/tools.html"
+    "guide_platforms_blackberry10_upgrading.md.html": "guide/platforms/blackberry10/upgrading.html"
+    "guide_platforms_blackberry_config.md.html": "guide/platforms/blackberry/config.html"
+    "guide_platforms_blackberry_index.md.html": "guide/platforms/blackberry/index.html"
+    "guide_platforms_blackberry_plugin.md.html": "guide/platforms/blackberry/plugin.html"
+    "guide_platforms_blackberry_tools.md.html": "guide/platforms/blackberry/tools.html"
+    "guide_platforms_blackberry_upgrading.md.html": "guide/platforms/blackberry/upgrading.html"
+    "guide_platforms_firefoxos_config.md.html": "guide/platforms/firefoxos/config.html"
+    "guide_platforms_index.md.html": "guide/platforms/index.html"
+    "guide_platforms_ios_config.md.html": "guide/platforms/ios/config.html"
+    "guide_platforms_ios_index.md.html": "guide/platforms/ios/index.html"
+    "guide_platforms_ios_plugin.md.html": "guide/platforms/ios/plugin.html"
+    "guide_platforms_ios_tools.md.html": "guide/platforms/ios/tools.html"
+    "guide_platforms_ios_upgrading.md.html": "guide/platforms/ios/upgrading.html"
+    "guide_platforms_ios_webview.md.html": "guide/platforms/ios/webview.html"
+    "guide_platforms_tizen_index.md.html": "guide/platforms/tizen/index.html"
+    "guide_platforms_win8_index.md.html": "guide/platforms/win8/index.html"
+    "guide_platforms_win8_tools.md.html": "guide/platforms/win8/tools.html"
+    "guide_platforms_win8_upgrading.md.html": "guide/platforms/win8/upgrading.html"
+    "guide_platforms_wp7_index.md.html": "guide/platforms/wp7/index.html"
+    "guide_platforms_wp8_index.md.html": "guide/platforms/wp8/index.html"
+    "guide_platforms_wp8_plugin.md.html": "guide/platforms/wp8/plugin.html"
+    "guide_platforms_wp8_tools.md.html": "guide/platforms/wp8/tools.html"
+    "guide_platforms_wp8_upgrading.md.html": "guide/platforms/wp8/upgrading.html"
+    "plugin_ref_plugman.md.html": "plugin_ref/plugman.html"
+    "plugin_ref_spec.md.html": "plugin_ref/spec.html"
+    "cordova_plugins_pluginapis.md.html": "cordova/plugins/pluginapis.html"
+    "cordova_storage_database_database.md.html": "cordova/storage/database/database.html"
+    "cordova_storage_localstorage_localstorage.md.html": "cordova/storage/localstorage/localstorage.html"
+    "cordova_storage_parameters_display_name.md.html": "cordova/storage/parameters/display_name.html"
+    "cordova_storage_parameters_name.md.html": "cordova/storage/parameters/name.html"
+    "cordova_storage_parameters_size.md.html": "cordova/storage/parameters/size.html"
+    "cordova_storage_parameters_version.md.html": "cordova/storage/parameters/version.html"
+    "cordova_storage_sqlerror_sqlerror.md.html": "cordova/storage/sqlerror/sqlerror.html"
+    "cordova_storage_sqlresultset_sqlresultset.md.html": "cordova/storage/sqlresultset/sqlresultset.html"
+    "cordova_storage_sqlresultsetrowlist_sqlresultsetrowlist.md.html": "cordova/storage/sqlresultsetrowlist/sqlresultsetrowlist.html"
+    "cordova_storage_sqltransaction_sqltransaction.md.html": "cordova/storage/sqltransaction/sqltransaction.html"
+    "cordova_storage_storage.opendatabase.md.html": "cordova/storage/storage.opendatabase.html"
+    "guide_platforms_amazonfireos_config.md.html": "guide/platforms/amazonfireos/config.html"
+    "guide_platforms_amazonfireos_index.md.html": "guide/platforms/amazonfireos/index.html"
+    "guide_platforms_amazonfireos_plugin.md.html": "guide/platforms/amazonfireos/plugin.html"
+    "guide_platforms_amazonfireos_webview.md.html": "guide/platforms/amazonfireos/webview.html"
+    "guide_platforms_ubuntu_index.md.html": "guide/platforms/ubuntu/index.html"
+    "guide_support_index.md.html": "guide/support/index.html"
+    "guide_appdev_hooks_index.md.html": "guide/appdev/hooks/index.html"
+    "guide_appdev_security_index.md.html": "guide/appdev/security/index.html"
+    "guide_next_index.md.html": "guide/next/index.html"
+    "guide_platforms_android_upgrade.md.html": "guide/platforms/android/upgrade.html"
+    "guide_platforms_blackberry10_upgrade.md.html": "guide/platforms/blackberry10/upgrade.html"
+    "guide_platforms_blackberry_upgrade.md.html": "guide/platforms/blackberry/upgrade.html"
+    "guide_platforms_firefoxos_index.md.html": "guide/platforms/firefoxos/index.html"
+    "guide_platforms_ios_upgrade.md.html": "guide/platforms/ios/upgrade.html"
+    "guide_platforms_win8_packaging.md.html": "guide/platforms/win8/packaging.html"
+    "guide_platforms_win8_plugin.md.html": "guide/platforms/win8/plugin.html"
+    "guide_platforms_win8_upgrade.md.html": "guide/platforms/win8/upgrade.html"
+    "guide_platforms_win8_win10-support.md.html": "guide/platforms/win8/win10-support.html"
+    "guide_platforms_wp8_parallels.md.html": "guide/platforms/wp8/parallels.html"
+    "guide_platforms_wp8_upgrade.md.html": "guide/platforms/wp8/upgrade.html"
+    "guide_platforms_wp8_vmware.md.html": "guide/platforms/wp8/vmware.html"
+    "guide_platforms_wp8_webview.md.html": "guide/platforms/wp8/webview.html"
+    "platform_plugin_versioning_ref_index.md.html": "platform_plugin_versioning_ref/index.html"
+    "guide_getting-started_android_index.md.html": "guide/getting-started/android/index.html"
+    "guide_getting-started_blackberry_index.md.html": "guide/getting-started/blackberry/index.html"
+    "guide_getting-started_index.md.html": "guide/getting-started/index.html"
+    "guide_getting-started_ios_index.md.html": "guide/getting-started/ios/index.html"
+    "guide_getting-started_symbian_index.md.html": "guide/getting-started/symbian/index.html"
+    "guide_getting-started_webos_index.md.html": "guide/getting-started/webos/index.html"
+    "guide_getting-started_windows-phone_index.md.html": "guide/getting-started/windows-phone/index.html"
+    "guide_upgrading_blackberry_index.md.html": "guide/upgrading/blackberry/index.html"
+    "guide_upgrading_webos_index.md.html": "guide/upgrading/webos/index.html"
+    "phonegap_accelerometer_accelerometer.md.html": "phonegap/accelerometer/accelerometer.html"
+    "phonegap_camera_camera.md.html": "phonegap/camera/camera.html"
+    "phonegap_compass_compass.md.html": "phonegap/compass/compass.html"
+    "phonegap_connection_connection.md.html": "phonegap/connection/connection.html"
+    "phonegap_contacts_contacts.md.html": "phonegap/contacts/contacts.html"
+    "phonegap_device_device.md.html": "phonegap/device/device.html"
+    "phonegap_events_events.md.html": "phonegap/events/events.html"
+    "phonegap_file_file.md.html": "phonegap/file/file.html"
+    "phonegap_geolocation_geolocation.md.html": "phonegap/geolocation/geolocation.html"
+    "phonegap_media_capture_capture.md.html": "phonegap/media/capture/capture.html"
+    "phonegap_media_media.md.html": "phonegap/media/media.html"
+    "phonegap_notification_notification.md.html": "phonegap/notification/notification.html"
+    "phonegap_storage_storage.md.html": "phonegap/storage/storage.html"
+    "guide_getting-started_bada_index.md.html": "guide/getting-started/bada/index.html"
+    "guide_upgrading_android_index.md.html": "guide/upgrading/android/index.html"
+    "guide_upgrading_bada_index.md.html": "guide/upgrading/bada/index.html"
+    "guide_upgrading_index.md.html": "guide/upgrading/index.html"
+    "guide_upgrading_ios_index.md.html": "guide/upgrading/ios/index.html"
+    "guide_upgrading_symbian_index.md.html": "guide/upgrading/symbian/index.html"
+    "guide_upgrading_windows-phone_index.md.html": "guide/upgrading/windows-phone/index.html"
+    "guide_whitelist_index.md.html": "guide/whitelist/index.html"
+    "guide_command-line_index.md.html": "guide/command-line/index.html"
+    "guide_cordova-webview_android.md.html": "guide/cordova-webview/android.html"
+    "guide_cordova-webview_index.md.html": "guide/cordova-webview/index.html"
+    "guide_cordova-webview_ios.md.html": "guide/cordova-webview/ios.html"
+    "guide_plugin-development_android_index.md.html": "guide/plugin-development/android/index.html"
+    "guide_plugin-development_bada_index.md.html": "guide/plugin-development/bada/index.html"
+    "guide_plugin-development_blackberry_index.md.html": "guide/plugin-development/blackberry/index.html"
+    "guide_plugin-development_index.md.html": "guide/plugin-development/index.html"
+    "guide_plugin-development_ios_index.md.html": "guide/plugin-development/ios/index.html"
+    "guide_plugin-development_webos_index.md.html": "guide/plugin-development/webos/index.html"
+    "guide_plugin-development_windows-phone_index.md.html": "guide/plugin-development/windows-phone/index.html"
+    "guide_getting-started_tizen_index.md.html": "guide/getting-started/tizen/index.html"
+    "guide_plugin-development_tizen_index.md.html": "guide/plugin-development/tizen/index.html"
+    "guide_upgrading_tizen_index.md.html": "guide/upgrading/tizen/index.html"
+    "guide_getting-started_windows-8_index.md.html": "guide/getting-started/windows-8/index.html"
+    "guide_project-settings_index.md.html": "guide/project-settings/index.html"
+    "guide_project-settings_ios_index.md.html": "guide/project-settings/ios/index.html"
+    "guide_getting-started_windows-phone-7_index.md.html": "guide/getting-started/windows-phone-7/index.html"
+    "guide_getting-started_windows-phone-8_index.md.html": "guide/getting-started/windows-phone-8/index.html"
+    "guide_project-settings_android_index.md.html": "guide/project-settings/android/index.html"
+    "guide_project-settings_bada_index.md.html": "guide/project-settings/bada/index.html"
+    "guide_project-settings_blackberry_index.md.html": "guide/project-settings/blackberry/index.html"
+    "guide_project-settings_firefoxos_index.md.html": "guide/project-settings/firefoxos/index.html"
+    "guide_project-settings_webos_index.md.html": "guide/project-settings/webos/index.html"
+    "guide_project-settings_windows8_index.md.html": "guide/project-settings/windows8/index.html"
+    "guide_project-settings_wp7_index.md.html": "guide/project-settings/wp7/index.html"
+    "guide_project-settings_wp8_index.md.html": "guide/project-settings/wp8/index.html"
+    "guide_getting-started_blackberry10_index.md.html": "guide/getting-started/blackberry10/index.html"
+    "guide_plugin-development_blackberry10_index.md.html": "guide/plugin-development/blackberry10/index.html"
+    "guide_privacy_index.md.html": "guide/privacy/index.html"
+    "guide_upgrading_windows-8_index.md.html": "guide/upgrading/windows-8/index.html"

--- a/www/_layouts/docs.html
+++ b/www/_layouts/docs.html
@@ -6,27 +6,30 @@ analytics_id: UA-64283057-1
 
 {% include header.html %}
 
-<!-- Use the manual ToC, and if it doesn't exist, use the generated one -->
-{% assign toc_dir = site.data.toc %}
-{% assign tocfile = toc_dir.[page.tocfile] %}
+{% comment %}
+set some constants
+{% endcomment %}
+{% assign ALL_PAGES = site.data.all-pages %}
+{% assign TOCFILE   = site.data.toc[page.tocfile] %}
 
-{% capture version_prefix %}/docs/{{ page.language }}/{{ page.version }}/{% endcapture %}
-{% assign my_entry = page.url | replace: version_prefix,"" %}
-{% assign my_entry_parts = my_entry | split: "/" %}
+{% capture VERSION_ROOT %}/docs/{{ page.language }}/{{ page.version }}/{% endcapture %}
+{% capture LANGUAGE_ROOT %}/docs/{{ page.language }}/{% endcapture %}
+
+{% assign MY_ENTRY = page.url | replace: VERSION_ROOT,"" %}
+{% assign my_entry_parts = MY_ENTRY | split: "/" %}
 
 {% comment %}
-    path_to_root: path from here to version root, replacing all parts except the last one with '../'
-
-    NOTE:
-         the capture is a single line because extraneous whitespace would screw up the URI it produces
+PATH_TO_ROOT: path from here to version root, replacing all parts except the last one with '../'
+NOTE:
+     the capture is a single line because extraneous whitespace would screw up the URI it produces
 {% endcomment %}
-{% capture path_to_root %}{% for item in my_entry_parts %}{% if forloop.rindex > 1 %}../{% endif %}{% endfor %}{% endcapture %}
+{% capture PATH_TO_ROOT %}{% for item in my_entry_parts %}{% if forloop.rindex > 1 %}../{% endif %}{% endfor %}{% endcapture %}
 
 <div class="docs container">
 
     <!-- Table of Contents -->
     <div class="hidden-xs hidden-sm col-md-4 col-lg-3 site-toc-container">
-        {% include toc_recursive_main.html entries=tocfile my_entry=my_entry path_to_root=path_to_root %}
+        {% include toc_recursive_main.html entries=TOCFILE my_entry=MY_ENTRY path_to_root=PATH_TO_ROOT %}
     </div>
 
     <!-- Page content -->
@@ -42,51 +45,69 @@ analytics_id: UA-64283057-1
                             <span class="caret"></span>
                         </button>
                         <ul class="dropdown-menu">
-                            {% include toc_recursive_dropdown.html entries=tocfile my_entry=my_entry path_to_root=path_to_root %}
+                            {% include toc_recursive_dropdown.html entries=TOCFILE my_entry=MY_ENTRY path_to_root=PATH_TO_ROOT %}
                         </ul>
                     </div>
 
                     {% comment %}
-                    Show a single edit link if the page has a specific edit link.
+                    Show a single edit-link if the page has a specific edit-link.
                     {% endcomment %}
                     {% if page.edit_link %}
                         <a class="edit" href="{{ page.edit_link }}"><span class="glyphicon glyphicon-pencil" aria-hidden="true"></span> {{ page.edit_text }}</a>
 
                     {% comment %}
                     Otherwise, show editing and translating options.
+
+                    Edit-links obey the following rules:
+
+                    if page in /dev/ or /latest/:
+                        show edit link for /dev/ page in source language
+                        if page not in source language:
+                            show translation link for /dev/ page
+                    else:
+                        show edit link for the page in its version and language
+
                     {% endcomment %}
                     {% else %}
 
-                        {% capture edit_link %}{{ site.repo.uri }}/tree/{{ site.repo.branch }}/www/{{ page.path }}{% endcapture %}
-                        {% capture version_string %}/{{ page.version }}/{% endcapture %}
-                        {% capture language_string %}/{{ page.language }}/{% endcapture %}
-                        {% capture src_language_string %}/{{ site.src_language }}/{% endcapture %}
+                        {% capture base_edit_link %}https://github.com/apache/cordova-docs/tree/master/www/{{ page.path }}{% endcapture %}
+                        {% capture base_version %}/{{ page.version }}/{% endcapture %}
+                        {% capture base_language %}/{{ page.language }}/{% endcapture %}
+                        {% capture dev_version %}/dev/{% endcapture %}
+                        {% capture src_language %}/{{ site.src_language }}/{% endcapture %}
 
                         {% comment %}
-                        Compute related edit links (i.e. source language edit link and /dev/ edit link).
-                        {% endcomment %}
-                        {% assign dev_edit_link     = edit_link | replace:version_string,"/dev/" %}
-                        {% assign src_dev_edit_link = dev_edit_link | replace:language_string,src_language_string %}
-
-                        {% comment %}
+                        Edit-links for current pages in non-source languages
                         NOTE:
                              Pages that are under /dev/ or /latest/ (i.e. site.latest_docs_version) have page.current set to "true".
                         {% endcomment %}
-
-                        <!-- Links for editing -->
                         {% if page.language != site.src_language and page.current %}
 
+                            {% comment %}
+                            Compute crowdin link
+                            {% endcomment %}
                             {% capture page_path_prefix %}docs/{{ page.language }}/{{ page.version }}{% endcapture %}
                             {% assign page_path_end = page.path | split:"/" | last %}
-                            {% assign page_path     = page.path | replace:page_path_prefix,"docs/en/dev" | replace:page_path_end,"" %}
-                            {% capture crowdin_link %}https://crowdin.com/project/cordova/{{ page.language }}#/cordova-docs/{{ page_path }}{% endcapture %}
+                            {% assign crowdin_path  = page.path | replace:page_path_prefix,"docs/en/dev" | replace:page_path_end,"" %}
+                            {% capture crowdin_link %}https://crowdin.com/project/cordova/{{ page.language }}#/cordova-docs/{{ crowdin_path }}{% endcapture %}
 
-                            <a class="edit" href="{{ src_dev_edit_link }}"><span class="glyphicon glyphicon-pencil" aria-hidden="true"></span> {{ page.edit_source_text }}</a>
+                            {% assign edit_link = base_edit_link | replace:base_language,src_language | replace:base_version,dev_version %}
+
+                            <a class="edit" href="{{ edit_link }}"><span class="glyphicon glyphicon-pencil" aria-hidden="true"></span> {{ page.edit_source_text }}</a>
                             <a class="edit" href="{{ crowdin_link }}"><span class="glyphicon glyphicon-pencil" aria-hidden="true"></span> {{ page.edit_translation_text }}</a>
 
+                        {% comment %}
+                        Edit-links for all other pages
+                        {% endcomment %}
                         {% else %}
+
+                            {% comment %}
+                            Edit-link for latest version points to dev instead
+                            {% endcomment %}
                             {% if page.version == site.latest_docs_version %}
-                                {% assign edit_link = dev_edit_link %}
+                                {% assign edit_link = base_edit_link | replace:base_version,dev_version %}
+                            {% else %}
+                                {% assign edit_link = base_edit_link %}
                             {% endif %}
 
                             <a class="edit" href="{{ edit_link }}"><span class="glyphicon glyphicon-pencil" aria-hidden="true"></span> {{ page.edit_source_text }}</a>
@@ -96,46 +117,35 @@ analytics_id: UA-64283057-1
                     <!-- Language dropdown -->
                     <div class="dropdown">
                         <button class="btn btn-default dropdown-toggle" type="button" id="languageDropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-                            {{ site.data.docs-versions.[page.language].name }}
+                            {{ site.data.docs-versions[page.language].name }}
                             <span class="caret"></span>
                         </button>
 
                         <!-- List all languages -->
                         <ul class="dropdown-menu" aria-labelledby="languageDropdown">
-                            {% for language_entry in site.data.docs-versions %}
+                            {% for other_language_entry in site.data.docs-versions %}
 
-                            {% assign language_id = language_entry[0] %}
-                            {% assign language    = language_entry[1] %}
+                            {% assign other_language_id       = other_language_entry[0] %}
+                            {% assign other_language          = other_language_entry[1] %}
+                            {% assign other_language_versions = other_language.versions %}
+                            {% assign other_language_name     = other_language.name %}
 
-                            {% capture current_language_path %}/docs/{{ page.language }}/{% endcapture %}
-                            {% capture target_language_path %}/docs/{{ language_id }}/{% endcapture %}
+                            {% capture other_language_root %}/docs/{{ other_language_id }}/{% endcapture %}
 
                             {% comment %}
-                            <!--
-                            Replace only the language part of the URI, thereby
-                            redirecting to the same page in the other language.
-                            The page will exist because translations are clones
-                            of each other.
-                             -->
+                            Replace only the language part of the URI, thereby redirecting to the same page
+                            in the other language. The page will exist because translations are clones of each other.
                             {% endcomment %}
-                            {% assign target_language_url = page.url | replace:current_language_path,target_language_path %}
-
-                            {% capture missing_version_class %}
-                                {% if language.versions contains page.version %}
-                                {% else %}
-                                    missing-version
-                                {% endif %}
-                            {% endcapture %}
+                            {% assign other_language_url = page.url | replace:LANGUAGE_ROOT,other_language_root %}
 
                             <li>
-                                <a href="{{ site.baseurl }}{{ target_language_url }}" class="{{ missing_version_class }}"
-                                >
-                                    {% if page.language == language_id %}
+                                <a href="{{ site.baseurl }}{{ other_language_url }}" class="{% unless other_language_versions contains page.version %}missing-page{% endunless %}">
+                                    {% if page.language == other_language_id %}
                                         <span class="selected">
-                                            {{ language.name }}
+                                            {{ other_language_name }}
                                         </span>
                                     {% else %}
-                                        {{ language.name }}
+                                        {{ other_language_name }}
                                     {% endif %}
                                 </a>
                             </li>
@@ -155,42 +165,41 @@ analytics_id: UA-64283057-1
                         <ul class="dropdown-menu" aria-labelledby="versionDropdown">
 
                             <!-- List versions available in this language -->
-                            {% for version in site.data.docs-versions.[page.language].versions reversed %}
+                            {% for other_version in site.data.docs-versions[page.language].versions reversed %}
                             <li>
                                 {% comment %}
-                                Name the latest version as "latest" to take advantage of
-                                redirects for "/latest/".
+                                Name the latest version as "latest" to take advantage of redirects for "/latest/".
                                 {% endcomment %}
-                                {% if version == site.latest_docs_version %}
-                                    {% assign version_string = "latest" %}
+                                {% if other_version == site.latest_docs_version %}
+                                    {% assign other_version_string = "latest" %}
                                 {% else %}
-                                    {% assign version_string = version %}
+                                    {% assign other_version_string = other_version %}
                                 {% endif %}
 
-                                {% capture current_version_path %}/docs/{{ page.language }}/{{ page.version }}/{% endcapture %}
-                                {% capture target_version_path %}/docs/{{ page.language }}/{{ version_string }}/{% endcapture %}
-
                                 {% capture version_entry_string %}
-                                    {{ version }}
-                                    {% if version == site.latest_docs_version %}
+                                    {{ other_version }}
+                                    {% if other_version == site.latest_docs_version %}
                                         ({{ page.latest_text }})
                                     {% endif %}
                                 {% endcapture %}
 
                                 {% comment %}
-                                <!--
-                                Replace only the version part of the URI, thereby
-                                redirecting to the same page in the other version.
+                                Replace only the version part of the URI, thereby redirecting to
+                                the same page in the other version.
 
-                                WARNING:
-                                    this page might not exist in the target version
-                                    because page layouts change from version to version
-                                 -->
+                                NOTE:
+                                     This page might not exist in the target version because page
+                                     layouts change from version to version
                                 {% endcomment %}
-                                {% assign target_version_url = page.url | replace:current_version_path,target_version_path%}
+                                {% capture other_version_root %}/docs/{{ page.language }}/{{ other_version_string }}/{% endcapture %}
+                                {% assign other_version_url = page.url | replace:VERSION_ROOT,other_version_root %}
 
-                                <a href="{{ site.baseurl }}{{ target_version_url }}">
-                                    {% if page.version == version %}
+                                {% unless ALL_PAGES contains other_version_url %}
+                                    {% assign other_version_url = other_version_root %}
+                                {% endunless %}
+
+                                <a href="{{ site.baseurl }}{{ other_version_url }}" class="{% unless ALL_PAGES contains other_version_url %}missing-page{% endunless %}">
+                                    {% if page.version == other_version %}
                                         <span class="selected">
                                             {{ version_entry_string }}
                                         </span>
@@ -204,34 +213,47 @@ analytics_id: UA-64283057-1
                     </div>
                 </div>
 
-                <!-- Get URL for this page in the latest version -->
-                {% capture current_version_path %}/docs/{{ page.language }}/{{ page.version }}/{% endcapture %}
-                {% capture latest_version_path %}/docs/{{ page.language }}/latest/{% endcapture %}
-                {% assign latest_url = page.url | replace:current_version_path,latest_version_path %}
+                {% comment %}
+                Get URL for this page in the latest version
+                {% endcomment %}
+                {% capture latest_root %}/docs/{{ page.language }}/latest/{% endcapture %}
+                {% assign latest_url = page.url | replace:VERSION_ROOT,latest_root %}
 
-                <!-- Show warnings for special versions (i.e. non-latest, and dev) -->
-                {% if page.version == 'dev' or page.version != site.latest_docs_version %}
+                {% comment %}
+                If this page doesn't exist, just use root
+                {% endcomment %}
+                {% unless ALL_PAGES contains latest_url %}
+                    {% assign latest_url = latest_root %}
+                {% endunless %}
 
-                    {% if page.version == 'dev' %}
-                        {% assign alert_class = "alert-info" %}
-                        {% assign warning_text = page.in_development_text %}
-                    {% elsif page.version != site.latest_docs_version %}
-                        {% assign alert_class = "alert-danger" %}
-                        {% assign warning_text = page.outdated_text %}
-                    {% endif %}
-
-                    <div class="alert {{ alert_class }} docs-alert" role="alert">
+                <!-- Show warnings for special versions -->
+                <!-- dev warning -->
+                {% if page.version == 'dev' %}
+                    <div class="alert docs-alert alert-info" role="alert">
                         <button type="button" class="close" data-dismiss="alert" aria-label="Close">
                             <span aria-hidden="true">&times;</span>
                         </button>
-                        {{ warning_text }}
+                        {{ page.in_development_text }}
                         <a href="{{ site.baseurl }}{{ latest_url }}">
                             {{ page.click_here_text }}
                         </a>
                     </div>
-
                 {% endif %}
 
+                <!-- outdated warning -->
+                {% if page.version != 'dev' and page.version != site.latest_docs_version %}
+                    <div class="alert docs-alert alert-danger" role="alert">
+                        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                            <span aria-hidden="true">&times;</span>
+                        </button>
+                        {{ page.outdated_text }}
+                        <a href="{{ site.baseurl }}{{ latest_url }}">
+                            {{ page.click_here_text }}
+                        </a>
+                    </div>
+                {% endif %}
+
+                <!-- plugin version warning -->
                 {% if page.plugin_name and page.plugin_version %}
                     <div class="alert alert-warning docs-alert" role="alert">
                         <button type="button" class="close" data-dismiss="alert" aria-label="Close">

--- a/www/static/css-src/_docs.scss
+++ b/www/static/css-src/_docs.scss
@@ -227,8 +227,8 @@
         margin-top: 15px;
     }
 
-    /* missing version highlight */
-    .missing-version {
+    /* missing page highlight */
+    .missing-page {
         color: gray !important;
     }
 


### PR DESCRIPTION
Relevant changes:
- added a new data file, `all-pages.yml`, which stores a list of valid links on the site
- version dropdowns and out-of-date alerts now use the new data file to only link to valid pages
- redirects are now a dictionary instead of a list, which is more flexible and easier to work with

Miscellaneous changes:
- refactored Makefile dependencies to properly rebuild some files when necessary
- refactored `docs.html` to be a bit more readable