### PR TITLE
Update plugman.md

### DIFF
--- a/www/docs/en/dev/plugin_ref/plugman.md
+++ b/www/docs/en/dev/plugin_ref/plugman.md
@@ -77,7 +77,7 @@ listed on the Platform guides page.
 Once you have installed Plugman and have created a Cordova project, you can start adding plugins to the platform with:
 
 ```bash
-$ plugman --platform <ios|android|blackberry10|wp8> --project <directory> --plugin <name|url|path> [--plugins_dir <directory>] [--www <directory>] [--variable <name>=<value> [--variable <name>=<value> ...]]
+$ plugman install --platform <ios|android|blackberry10|wp8> --project <directory> --plugin <name|url|path> [--plugins_dir <directory>] [--www <directory>] [--variable <name>=<value> [--variable <name>=<value> ...]]
 ```
 
 Using minimum parameters, this command installs a plugin into a cordova project. You must specify a platform and cordova project location for that platform. You also must specify a plugin, with the different `--plugin` parameter forms being:
@@ -171,107 +171,107 @@ platform, and reference the platform's project directory.
 * cordova-plugin-battery-status
 
     ```bash
-    plugman --platform <ios|android|blackberry10|wp8> --project <directory> --plugin cordova-plugin-battery-status
+    plugman install --platform <ios|android|blackberry10|wp8> --project <directory> --plugin cordova-plugin-battery-status
     ```
 
 * cordova-plugin-camera
 
     ```bash
-    plugman --platform <ios|android|blackberry10|wp8> --project <directory> --plugin cordova-plugin-camera
+    plugman install --platform <ios|android|blackberry10|wp8> --project <directory> --plugin cordova-plugin-camera
     ```
 
 * cordova-plugin-console
 
     ```bash
-    plugman --platform <ios|android|blackberry10|wp8> --project <directory> --plugin cordova-plugin-console
+    plugman install --platform <ios|android|blackberry10|wp8> --project <directory> --plugin cordova-plugin-console
     ```
 
 * cordova-plugin-contacts
 
     ```bash
-    plugman --platform <ios|android|blackberry10|wp8> --project <directory> --plugin cordova-plugin-contacts
+    plugman install --platform <ios|android|blackberry10|wp8> --project <directory> --plugin cordova-plugin-contacts
     ```
 
 * cordova-plugin-device
 
     ```bash
-    plugman --platform <ios|android|blackberry10|wp8> --project <directory> --plugin cordova-plugin-device
+    plugman install --platform <ios|android|blackberry10|wp8> --project <directory> --plugin cordova-plugin-device
     ```
 
 * cordova-plugin-device-motion (accelerometer)
 
     ```bash
-    plugman --platform <ios|android|blackberry10|wp8> --project <directory> --plugin cordova-plugin-device-motion
+    plugman install --platform <ios|android|blackberry10|wp8> --project <directory> --plugin cordova-plugin-device-motion
     ```
 
 * cordova-plugin-device-orientation (compass)
 
     ```bash
-    plugman --platform <ios|android|blackberry10|wp8> --project <directory> --plugin cordova-plugin-device-orientation
+    plugman install --platform <ios|android|blackberry10|wp8> --project <directory> --plugin cordova-plugin-device-orientation
     ```
 
 * cordova-plugin-dialogs
 
     ```bash
-    plugman --platform <ios|android|blackberry10|wp8> --project <directory> --plugin cordova-plugin-dialogs
+    plugman install --platform <ios|android|blackberry10|wp8> --project <directory> --plugin cordova-plugin-dialogs
     ```
 
 * cordova-plugin-file
 
     ```bash
-    plugman --platform <ios|android|blackberry10|wp8> --project <directory> --plugin cordova-plugin-file
+    plugman install --platform <ios|android|blackberry10|wp8> --project <directory> --plugin cordova-plugin-file
     ```
 
 * cordova-plugin-file-transfer
 
     ```bash
-    plugman --platform <ios|android|blackberry10|wp8> --project <directory> --plugin cordova-plugin-file-transfer
+    plugman install --platform <ios|android|blackberry10|wp8> --project <directory> --plugin cordova-plugin-file-transfer
     ```
 
 * cordova-plugin-geolocation
 
     ```bash
-    plugman --platform <ios|android|blackberry10|wp8> --project <directory> --plugin cordova-plugin-geolocation
+    plugman install --platform <ios|android|blackberry10|wp8> --project <directory> --plugin cordova-plugin-geolocation
     ```
 
 * cordova-plugin-globalization
 
     ```bash
-    plugman --platform <ios|android|blackberry10|wp8> --project <directory> --plugin cordova-plugin-globalization
+    plugman install --platform <ios|android|blackberry10|wp8> --project <directory> --plugin cordova-plugin-globalization
     ```
 
 * cordova-plugin-inappbrowser
 
     ```bash
-    plugman --platform <ios|android|blackberry10|wp8> --project <directory> --plugin cordova-plugin-inappbrowser
+    plugman install --platform <ios|android|blackberry10|wp8> --project <directory> --plugin cordova-plugin-inappbrowser
     ```
 
 * cordova-plugin-media
 
     ```bash
-    plugman --platform <ios|android|blackberry10|wp8> --project <directory> --plugin cordova-plugin-media
+    plugman install --platform <ios|android|blackberry10|wp8> --project <directory> --plugin cordova-plugin-media
     ```
 
 * cordova-plugin-media-capture
 
     ```bash
-    plugman --platform <ios|android|blackberry10|wp8> --project <directory> --plugin cordova-plugin-media-capture
+    plugman install --platform <ios|android|blackberry10|wp8> --project <directory> --plugin cordova-plugin-media-capture
     ```
 
 * cordova-plugin-network-information
 
     ```bash
-    plugman --platform <ios|android|blackberry10|wp8> --project <directory> --plugin cordova-plugin-network-information
+    plugman install --platform <ios|android|blackberry10|wp8> --project <directory> --plugin cordova-plugin-network-information
     ```
 
 * cordova-plugin-splashscreen
 
     ```bash
-    plugman --platform <ios|android|blackberry10|wp8> --project <directory> --plugin cordova-plugin-splashscreen
+    plugman install --platform <ios|android|blackberry10|wp8> --project <directory> --plugin cordova-plugin-splashscreen
     ```
 
 * cordova-plugin-vibration
 
     ```bash
-    plugman --platform <ios|android|blackberry10|wp8> --project <directory> --plugin cordova-plugin-vibration
+    plugman install --platform <ios|android|blackberry10|wp8> --project <directory> --plugin cordova-plugin-vibration
     ```


### PR DESCRIPTION
In installing plugins using Plugman, command install is required.
Without the command install, the plugin install fails and shows About Plugman instead.