### PR TITLE
Moving analytics script to head

### DIFF
--- a/www/_includes/head.html
+++ b/www/_includes/head.html
@@ -44,4 +44,6 @@
     <script defer type="text/javascript" src="{{ site.baseurl }}/static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="{{ site.baseurl }}/static/js/lib/bootstrap.min.js"></script>
     <script defer type="text/javascript" src="{{ site.baseurl }}/static/js/lib/ZeroClipboard.js"></script>
+
+    {% include analytics.html %}
 </head>

--- a/www/_layouts/base.html
+++ b/www/_layouts/base.html
@@ -7,7 +7,6 @@ analytics_id: UA-64283057-3
 {% include head.html %}
 <body>
     {{ content }}
-    {% include analytics.html %}
     <script defer type="text/javascript" src="{{ site.baseurl }}/static/js/index.js"></script>
     <script defer type="text/javascript" src="{{ site.baseurl }}/static/js/twitter.js"></script>
     {% include algolia.html %}


### PR DESCRIPTION
It looks like it got moved in a refactor. It needs to be in the head of every page to work properly according to this: https://support.google.com/analytics/answer/1008080?hl=en&ref_topic=1008079