### PR TITLE
Moved 40px Spotlight Icon to iOS 7.0+

### DIFF
--- a/www/docs/en/dev/config_ref/images.md
+++ b/www/docs/en/dev/config_ref/images.md
@@ -102,10 +102,10 @@ Icons are not applicable to the Browser platform.
         <!-- iPad -->
         <icon src="res/ios/icon-76.png" width="76" height="76" />
         <icon src="res/ios/icon-76@2x.png" width="152" height="152" />
-        <!-- iOS 6.1 -->
         <!-- Spotlight Icon -->
         <icon src="res/ios/icon-40.png" width="40" height="40" />
         <icon src="res/ios/icon-40@2x.png" width="80" height="80" />
+        <!-- iOS 6.1 -->
         <!-- iPhone / iPod Touch -->
         <icon src="res/ios/icon.png" width="57" height="57" />
         <icon src="res/ios/icon@2x.png" width="114" height="114" />


### PR DESCRIPTION
in Xcode's AppIcon Image Set, it clearly states 40pt size is for iOS 7-9 Spotlight Icon for both iPhone and iPad, therefore it should be listed under iOS 7.0+. The 50pt size is for iOS 5-6.