### PR TITLE
CB-12000 - (iOS 4.3.0) Add documentation for --buildFlag cli option

### DIFF
--- a/www/docs/en/dev/guide/platforms/ios/index.md
+++ b/www/docs/en/dev/guide/platforms/ios/index.md
@@ -186,6 +186,13 @@ build configuration file:
 }
 ```
 
+## Xcode Build Flags
+
+If you have a custom situation where you need to pass additional build flags to Xcode -- you would use one or more `--buildFlag` options to pass these flags to `xcodebuild`. If you use an `xcodebuild` built-in flag, it will show a warning.
+
+    cordova build --device --buildFlag="MYSETTING=myvalue" --buildFlag="MY_OTHER_SETTING=othervalue"
+    cordova run --device --buildFlag="DEVELOPMENT_TEAM=FG35JLLMXX4A" --buildFlag="-scheme TestSchemeFlag"
+
 ## Debugging
 
 For details on the debugging tools that come with Xcode, see this [article](https://developer.apple.com/support/debugging)


### PR DESCRIPTION
### Platforms affected

iOS

### What does this PR do?

Document `--buildFlag` option when using `cordova run` or `cordova build` on iOS.

### What testing has been done on this change?

Platform manual tests, unit tests.

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [X] Added automated test coverage as appropriate for this change.

