### PR TITLE
CB-12058 - (ios 4.3.0) Document CocoaPods support in plugin.xml <framework> tag

### DIFF
--- a/www/docs/en/dev/plugin_ref/spec.md
+++ b/www/docs/en/dev/plugin_ref/spec.md
@@ -254,7 +254,7 @@ Example:
 </platform>
 ```
 
-### source-file
+## source-file
 
 Identifies executable source code that should be installed into a project.
 
@@ -275,7 +275,7 @@ Examples:
 <source-file src="src/ios/someLib.a" compiler-flags="-fno-objc-arc" />
 ```
 
-### header-file
+## header-file
 
 This is like `<source-file>` element but specifically for platforms such as iOS and Android that distinguish between source files, headers, and resources. This is not supported by Windows.
 
@@ -291,7 +291,7 @@ For iOS:
 <header-file src="CDVFoo.h" />
 ```
 
-### resource-file
+## resource-file
 
 This is like `<source-file>` element, but specifically for platforms such as iOS and Android that distinguish between source files, headers, and resources.
 
@@ -315,7 +315,7 @@ For Windows:
 <resource-file src="src/windows/win81/MobServices.pri" target="win81/MobServices.pri" device-target="windows" versions="8.1" arch="x64"/>
 ```
 
-### config-file
+## config-file
 
 Identifies an XML-based configuration file to be modified, where in that document the modification should take place, and what should be modified.
 Two file types that have been tested for modification with this element are `xml` and `plist` files.
@@ -365,7 +365,7 @@ For windows-specific attributes:
 ```
 The above example will set pre-8.1 platforms (Windows 8, specifically) to require the `webcam` device capability and the `picturesLibrary` general capability, and apply the `webcam` device capability only to Windows 8.1 projects that build for Windows Phone.  Windows desktop 8.1 systems are unmodified.
 
-### edit-config
+## edit-config
 Similar to `config-file`, `edit-config` identifies an XML-based configuration file to be modified, where in that document the modification should take place, and what should be modified. Instead of appending new children to an XML document tree, `edit-config` makes modifications to attributes of XML elements. There are two modes which will determine what type of attribute modification will be made, `merge` or `overwrite`. `edit-config` has one child and that child will contain the attributes to be added.
 
 Attributes(type) <br/> <span class="sub-header">Only for platform:</span> | Description
@@ -471,7 +471,7 @@ The resulting AndroidManifest.xml after force adding plugin-2:
 
 Note: Reverted changes from `--force` are gone for good. They will not reappear after removing the plugin that was force added. If the reverted changes are needed, all associated plugins should be removed and re-added.
 
-### plugins-plist
+## plugins-plist
 
 Specifies a key and value to append to the correct `AppInfo.plist` file in an iOS Cordova project. This is _outdated_ as it only applies to cordova-ios 2.2.0 and below. Use the `<config-file>` tag for newer versions of Cordova.
 
@@ -480,7 +480,7 @@ Example:
 <plugins-plist key="Foo" string="CDVFoo" />
 ```
 
-### lib-file
+## lib-file
 
 Like source, resource, and header files, but specifically for platforms such as BlackBerry 10 that use user-generated libraries. For the Windows platform, the `<lib-file>` element allows the inclusion of an `<SDKReference>` in the generated Windows project files.
 
@@ -505,7 +505,7 @@ For Windows:
 <lib-file src="Microsoft.WinJS.2.0, Version=1.0" target="win" versions="8.0" arch="x86" />
 ```
 
-### framework
+## framework
 
 Identifies a framework (usually part of the OS/platform) on which the plugin depends.
 
@@ -520,6 +520,7 @@ arch(string) <br/> ==windows== | Allowed values: `x86`, `x64` or `ARM`. <br/> In
 device-target(string) <br/> ==windows== | Allowed values: `win` (or `windows`), `phone` or `all`. <br/>  Indicates that the framework should only be included when building for the specified target device type.
 versions(string) <br/> ==windows== | Indicates that the framework should only be included when building for versions that match the specified version string. Value can be any valid node semantic version range string.
 target-dir(string) <br/> ==windows== | Indicates a subdirectory into which the framework should be copied. In practice, this is most important when plugin contains different framework versions for different chip architectures or device targets, but which have the same name. This allows you to specify different subfolders for each framework version so that they don't overlap each other.
+spec(string) <br/> ==ios== | Paired with `type="podspec"`, this is the spec string for the CocoaPod you want to install (static library only). CocoaPod support only exists in `cordova-ios 4.3.0` and `cordova-cli 6.4.0`. For your plugin, make sure  you add the appropriate `<engine>` tags and `package.json` [dependencies](../guide/hybrid/plugins/index.html#specifying-cordova-dependencies) to ensure backwards-compatible support.
 
 Examples:
 
@@ -528,6 +529,7 @@ For iOS:
 <framework src="libsqlite3.dylib" />
 <framework src="social.framework" weak="true" />
 <framework src="relative/path/to/my.framework" custom="true" />
+<framework src="GoogleCloudMessaging" type="podspec" spec="~> 1.2.0" />
 ```
 
 On Android (as of cordova-android@4.0.0), framework tags are used to include Maven dependencies, or to include bundled library projects.


### PR DESCRIPTION
### Platforms affected

iOS

### What does this PR do?

Document CocoaPods support in plugin.xml <framework> tag. Cleaned up heading styles so they show up in the sidebar tree.

### What testing has been done on this change?

Platform testing.

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [X] Added automated test coverage as appropriate for this change.

