### PR TITLE
CB-12127 - (ios) Add buildFlag support in build.json

### DIFF
--- a/www/docs/en/dev/guide/platforms/ios/index.md
+++ b/www/docs/en/dev/guide/platforms/ios/index.md
@@ -175,12 +175,22 @@ Xcode 8 and iOS 10:
         "debug": {
             "codeSignIdentity": "iPhone Developer",
             "developmentTeam": "FG35JLLMXX4A",
-            "packageType": "development"
+            "packageType": "development",
+            "buildFlag": [
+                "EMBEDDED_CONTENT_CONTAINS_SWIFT = YES", 
+                "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES=NO", 
+                "LD_RUNPATH_SEARCH_PATHS = \"@executable_path/Frameworks\""
+            ]
         },
         "release": {
             "codeSignIdentity": "iPhone Developer",
             "developmentTeam": "FG35JLLMXX4A",
-            "packageType": "app-store"
+            "packageType": "app-store",
+            "buildFlag": [
+                "EMBEDDED_CONTENT_CONTAINS_SWIFT = YES", 
+                "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES=NO", 
+                "LD_RUNPATH_SEARCH_PATHS = \"@executable_path/Frameworks\""
+            ]
         }
     }
 }
@@ -209,7 +219,7 @@ Earlier versions:
 
 ## Xcode Build Flags
 
-If you have a custom situation where you need to pass additional build flags to Xcode -- you would use one or more `--buildFlag` options to pass these flags to `xcodebuild`. If you use an `xcodebuild` built-in flag, it will show a warning.
+If you have a custom situation where you need to pass additional build flags to Xcode -- you would use one or more `--buildFlag` options to pass these flags to `xcodebuild`. If you use an `xcodebuild` built-in flag, it will show a warning. You can also specify a `buildFlag` option in `build.json` above (the value for the `buildFlag` key is a string or an array of strings).
 
     cordova build --device --buildFlag="MYSETTING=myvalue" --buildFlag="MY_OTHER_SETTING=othervalue"
     cordova run --device --buildFlag="DEVELOPMENT_TEAM=FG35JLLMXX4A" --buildFlag="-scheme TestSchemeFlag"


### PR DESCRIPTION
### Platforms affected

iOS

### What does this PR do?

Document the "buildFlag" option in build.json

### What testing has been done on this change?

Manual testing.

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.

