### PR TITLE
CB-12163 Add doc for reference attr for resource-file in Windows

### DIFF
--- a/www/docs/en/dev/plugin_ref/spec.md
+++ b/www/docs/en/dev/plugin_ref/spec.md
@@ -302,6 +302,7 @@ target(string) | Path to where the file will be copied in your directory.
 arch(string) <br/> ==windows== | Allowed values: `x86`, `x64` or `ARM`. <br/> Indicates that the file should only be included when building for the specified architecture.
 device-target <br/> ==windows== | Allowed values: `win` (or `windows`), `phone` or `all`. <br/> Indicates that the file should only be included when building for the specified target device type.
 versions <br/> ==windows== | Indicates that the file should only be included when building for versions that match the specified version string. Value can be any valid node semantic version range string.
+reference <br/> ==windows== | Indicates that the file should be referenced from the src rather than copied to the target destination. The file will appear in Visual Studio with the file name specified by target, however will point to the respective src, depending on the architecture.
 
 Examples:
 
@@ -313,6 +314,10 @@ For Android:
 For Windows:
 ```xml
 <resource-file src="src/windows/win81/MobServices.pri" target="win81\MobServices.pri" device-target="windows" versions="8.1" arch="x64"/>
+
+<!-- Example of referencing  -->
+<resource-file src="x86/foo.dll" target="foo.dll" arch="x86" reference="true" />
+<resource-file src="x64/foo.dll" target="foo.dll" arch="x64" reference="true" />
 ```
 __NOTE__: `target` should use backslashes to avoid DEP2100 deploy error in Visual Studio.
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
- Windows
- plugin.xml doc

### What does this PR do?
Adds documentation for the new "reference" attribute for the resource-file tag in plugin.xml for Windows. 

### What testing has been done on this change?
N/A

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [X] Added automated test coverage as appropriate for this change.
