### PR TITLE
Remove misleading reference to "publisherId" cause it is ignored

### DIFF
--- a/www/docs/en/5.1.1/guide/platforms/win8/packaging.md
+++ b/www/docs/en/5.1.1/guide/platforms/win8/packaging.md
@@ -35,7 +35,7 @@ In Windows project, identity details are kept in a file named package.appxmanife
 - Publisher
 - Version
 
-*Name* and *Version* can be set from **config.xml**. *Publisher* can be provided as a build parameter or can be set on **build.json** file.
+*Name* and *Version* can be set from **config.xml**. *Publisher* can be provided by a signing certificate `.pfx` as a build parameter or can be set on **build.json** file.
 
 ![]({{ site.baseurl }}/static/img/guide/platforms/win8/packaging.png)
 
@@ -54,7 +54,6 @@ Alternatively, these values could be specified using a build configuration file 
             "release": {
                 "packageCertificateKeyFile": "c:\\path-to-key\\keycert.pfx",
                 "packageThumbprint": "ABCABCABCABC123123123123",
-                "publisherId": "CN=FakeCorp.com, L=Redmond, S=Washington, C=US"
             }
         }
     }


### PR DESCRIPTION
The only way to override the `Publisher` value in the generated `AppxManifest.xml` is to provide a custom signing certificate. Merely setting the "publisherId" does not do anything. I've tried it a whole day. Only when I set a custom signing certificate my applications manifest looked like it should. And then setting "publisherId" to anything did not affect how the resulting manifest file looked.
So I propose to remove the value from the docs (and it should also be removed from the Cordova Windows plugin).

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected


### What does this PR do?


### What testing has been done on this change?


### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
