### PR TITLE
CB-12514 - docs for Carthage support.

### DIFF
--- a/www/docs/en/dev/guide/platforms/ios/index.md
+++ b/www/docs/en/dev/guide/platforms/ios/index.md
@@ -251,7 +251,7 @@ within Xcode. Double-click to open the `${PROJECT_NAME}/platforms/ios/${PROJECT_
 file or open Xcode from your terminal:
 
 ```bash
-$ open platforms/ios/HelloWorld.xcworkspace/
+$ open -a Xcode platforms/ios
 ```
 
 The screen should look like this:

--- a/www/docs/en/dev/guide/platforms/ios/upgrade.md
+++ b/www/docs/en/dev/guide/platforms/ios/upgrade.md
@@ -28,8 +28,16 @@ created with an older set of command-line tools that precede the
 `cordova` CLI utility. See [The Command-Line Interface](../../cli/index.html) for information
 how to update the version of the CLI.
 
-__NOTE__: Xcode 6 is required. Currently, to submit to the
-Apple App Store, you should use the latest shipped version of the iOS SDK, which is iOS 8 and this is included only with Xcode 6.
+__NOTE__: Xcode 8 is required. Currently, to submit to the
+Apple App Store, you should use the latest shipped version of the iOS SDK, which is iOS 10 and this is included only with Xcode 8.
+
+## Upgrading 4.x projects
+
+```
+cordova platform rm ios
+cordova platform add ios
+```
+
 
 ## Upgrading 3.6.0 Projects to 4.0.0
 

--- a/www/docs/en/dev/guide/platforms/ios/webview.md
+++ b/www/docs/en/dev/guide/platforms/ios/webview.md
@@ -31,7 +31,7 @@ Support for WebViews for iOS started with Cordova version 1.4, using a
 implementation.  Cordova 2.0 and later versions only support the
 subproject-based Cleaver implementation.
 
-These instructions require at least Cordova 3.x and Xcode 6.0, along
+These instructions require at least Cordova 4.x and Xcode 8.0, along
 with a `config.xml` file from a newly created iOS project. You can use
 the procedure in [The Command-Line Interface](../../cli/index.html) to create a new project,
 then obtain the `config.xml` file from within the named application's
@@ -42,7 +42,24 @@ distribution. Download it from
 [cordova.apache.org](http://cordova.apache.org) and unzip its iOS
 package.
 
-## Adding Cleaver to the Xcode Project (CordovaLib Sub-Project)
+You have two methods for adding Cordova to your project. The first is using [Carthage](https://github.com/Carthage/Carthage), and the 
+second is to manually add Cordova. After using either of these two methods, continue with the **"Using CDVViewController"** section.
+
+## 1. Add Cordova.framework to the Xcode Project using Carthage
+
+1. Install [Carthage](https://github.com/Carthage/Carthage)
+
+1. In your [Cartfile](https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#cartfile), add (substitute &lt;version_or_tag&gt; for the appropriate version):
+
+        git "git://git.apache.org/cordova-ios.git" "<version_or_tag>" # Apache
+
+1. Run 
+
+        carthage update
+
+1. Add `Carthage/Build/iOS/Cordova.framework` into your Xcode project.
+
+## 2. Adding Cleaver to the Xcode Project (CordovaLib Sub-Project)
 
 1. Quit Xcode if it is running.
 


### PR DESCRIPTION
Fixed up some old Xcode references in corresponding docs as well.

### Platforms affected

iOS

### What does this PR do?

Adds docs for Carthage support in iOS.

### What testing has been done on this change?

Followed the docs to actually add cordova-ios to an existing Xcode project.

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
