### PR TITLE
CB-12686 - Add docs for <resource-file> support in config.xml

### DIFF
--- a/www/docs/en/dev/config_ref/index.md
+++ b/www/docs/en/dev/config_ref/index.md
@@ -476,7 +476,7 @@ This tag installs resource files into your platform, and is similar to the same 
 
 Attributes(type) <br/> <span class="sub-header">Only for platform:</span> | Description
 ---------------- | ------------
-src(string) <br/> ==iOS== ==Android==| *Required* <br/> Location of the file relative to `config.xml`. If the src file can't be found, the CLI stops and reverses the installation, issues a notification about the problem, and exits with a non-zero code.
+src(string) <br/> ==iOS== ==Android==| *Required* <br/> Location of the file relative to `config.xml`.
 target(string) | Path to where the file will be copied in your directory.
 
 Examples:

--- a/www/docs/en/dev/config_ref/index.md
+++ b/www/docs/en/dev/config_ref/index.md
@@ -470,6 +470,23 @@ Examples:
 <hook type="after_plugin_install" src="scripts/afterPluginInstall.js" />
 ```
 
+## resource-file
+
+This tag installs resource files into your platform, and is similar to the same tag in plugin.xml. This tag is currently only supported on `cordova-ios@4.4.0` or greater and `cordova-android@6.2.1` or greater.
+
+Attributes(type) <br/> <span class="sub-header">Only for platform:</span> | Description
+---------------- | ------------
+src(string) <br/> ==iOS== ==Android==| *Required* <br/> Location of the file relative to `plugin.xml`. If the src file can't be found, the CLI stops and reverses the installation, issues a notification about the problem, and exits with a non-zero code.
+target(string) | Path to where the file will be copied in your directory.
+
+Examples:
+
+For Android:
+```xml
+<resource-file src="FooPluginStrings.xml" target="res/values/FooPluginStrings.xml" />
+```
+
+
 # Sample config.xml
 Below is a sample config.xml file:
 

--- a/www/docs/en/dev/config_ref/index.md
+++ b/www/docs/en/dev/config_ref/index.md
@@ -476,7 +476,7 @@ This tag installs resource files into your platform, and is similar to the same 
 
 Attributes(type) <br/> <span class="sub-header">Only for platform:</span> | Description
 ---------------- | ------------
-src(string) <br/> ==iOS== ==Android==| *Required* <br/> Location of the file relative to `plugin.xml`. If the src file can't be found, the CLI stops and reverses the installation, issues a notification about the problem, and exits with a non-zero code.
+src(string) <br/> ==iOS== ==Android==| *Required* <br/> Location of the file relative to `config.xml`. If the src file can't be found, the CLI stops and reverses the installation, issues a notification about the problem, and exits with a non-zero code.
 target(string) | Path to where the file will be copied in your directory.
 
 Examples:


### PR DESCRIPTION
### What does this PR do?

Adds docs for <resource-file> config.xml support

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
