### PR TITLE
Added instruction to install Ruby Gems locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,7 @@ www/static/js/plugins.js
 www/docs/*/dev/reference
 
 node_modules
+ruby_modules
+.bundle
+.DS_Store
 Gemfile.lock

--- a/README.md
+++ b/README.md
@@ -101,9 +101,9 @@ Verify the installation by running:
 Once Ruby and JavaScript are installed, install Ruby dependencies by running:
 
     gem install bundle
-    bundle install
+    bundle install --path ./ruby_modules
 
-On some systems, the above commands need to be prefixed with `sudo`. Similarly on Windows, the `cmd` window in which those commands are to be run might need to have been "Run as Administrator."
+This will install the required Ruby Gems locally into a subfolder called `ruby_modules` in your repo folder. On some systems, the above commands need to be prefixed with `sudo`. Similarly on Windows, the `cmd` window in which those commands are to be run might need to have been "Run as Administrator."
 
 Finally, install JavaScript dependencies by running:
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Verify the installation by running:
 
 Once Ruby and JavaScript are installed, install Ruby dependencies by running:
 
-    gem install bundle
+    gem install bundler
     bundle install --path ./ruby_modules
 
 This will install the required Ruby Gems locally into a subfolder called `ruby_modules` in your repo folder. On some systems, the above commands need to be prefixed with `sudo`. Similarly on Windows, the `cmd` window in which those commands are to be run might need to have been "Run as Administrator."


### PR DESCRIPTION
### What does this PR do?

Modified instruction to install the required Ruby Gems locally in a subfolder of the repo. Installing jekyll and some modules under OS X 10.11 and up runs into problems, [especially with System Integrity Protection (SIP)](https://stackoverflow.com/questions/31567029/how-can-i-install-jekyll-on-osx-10-11/33059347#33059347)

### What testing has been done on this change?

Ran `node_modules/.bin/gulp build`
