### PR TITLE
CB-12904 - Document <edit-config> in config.xml

### DIFF
--- a/www/docs/en/6.x/config_ref/index.md
+++ b/www/docs/en/6.x/config_ref/index.md
@@ -205,6 +205,10 @@ Examples:
 <allow-intent href="sms:*" />
 ```
 
+## edit-config
+
+See [<edit-config> docs][edit_config] for plugin.xml.
+
 ## engine
 Specifies details about what platform to restore during a prepare.
 
@@ -525,3 +529,4 @@ Below is a sample config.xml file:
 [whitelist_navigation]: ../reference/cordova-plugin-whitelist/index.html#navigation-whitelist
 [whitelist_intent]:     ../reference/cordova-plugin-whitelist/index.html#intent-whitelist
 [statusbar_plugin]:     ../reference/cordova-plugin-statusbar/
+[edit_config]:          ../plugin_ref/spec.html#edit-config

--- a/www/docs/en/7.x/config_ref/index.md
+++ b/www/docs/en/7.x/config_ref/index.md
@@ -204,6 +204,9 @@ Examples:
 <allow-intent href="tel:*" />
 <allow-intent href="sms:*" />
 ```
+## edit-config
+
+See [<edit-config> docs][edit_config] for plugin.xml.
 
 ## engine
 Specifies details about what platform to restore during a prepare.
@@ -527,3 +530,4 @@ Below is a sample config.xml file:
 [whitelist_navigation]: ../reference/cordova-plugin-whitelist/index.html#navigation-whitelist
 [whitelist_intent]:     ../reference/cordova-plugin-whitelist/index.html#intent-whitelist
 [statusbar_plugin]:     ../reference/cordova-plugin-statusbar/
+[edit_config]:          ../plugin_ref/spec.html#edit-config

--- a/www/docs/en/dev/config_ref/index.md
+++ b/www/docs/en/dev/config_ref/index.md
@@ -204,6 +204,9 @@ Examples:
 <allow-intent href="tel:*" />
 <allow-intent href="sms:*" />
 ```
+## edit-config
+
+See [<edit-config> docs][edit_config] for plugin.xml.
 
 ## engine
 Specifies details about what platform to restore during a prepare.
@@ -527,3 +530,4 @@ Below is a sample config.xml file:
 [whitelist_navigation]: ../reference/cordova-plugin-whitelist/index.html#navigation-whitelist
 [whitelist_intent]:     ../reference/cordova-plugin-whitelist/index.html#intent-whitelist
 [statusbar_plugin]:     ../reference/cordova-plugin-statusbar/
+[edit_config]:          ../plugin_ref/spec.html#edit-config


### PR DESCRIPTION
### Platforms affected

All

### What does this PR do?

Document the <edit-config> feature in config.xml. The feature has been there for a while but it wasn't documented at all in config.xml. The changes add a section in config.xml for it, that points to the same section in plugin.xml

### What testing has been done on this change?

Built production docs, and tested the 6.x, 7.x and dev doc trees.

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
