### PR TITLE
CB-12980: (iOS) Improve instruction and add detail steps for plugins in cordova project.

### DIFF
--- a/www/docs/en/dev/guide/platforms/ios/webview.md
+++ b/www/docs/en/dev/guide/platforms/ios/webview.md
@@ -61,6 +61,8 @@ After using either of these two methods, continue with the **"Using CDVViewContr
 
 1. Add `Carthage/Build/iOS/Cordova.framework` into your Xcode project.
 
+1. Add Cordova.framework into Embedded Binaries in your Xcode General Setting page.
+
 ## 2. Adding Cleaver to the Xcode Project (CordovaLib Sub-Project)
 
 1. Quit Xcode if it is running.
@@ -220,5 +222,16 @@ After using either of these two methods, continue with the **"Using CDVViewContr
     */
     viewController.wwwFolderName = @"myfolder";
     viewController.startPage = @"mypage.html"
-    ```
+    ```
+## Adding Plugins files used in you cordova project
 
+1. Open a terminal and navigate to within the named application's
+subdirectory within `platforms/ios`.
+
+1. Add the `Plugins` directory into the project
+   directory.
+
+1. Choose __Create groups for any added folders__ and press
+   __Finish__.
+   
+1. If plugin compile error occurred, please delete related plugins.


### PR DESCRIPTION
1. Embed dynamic binaries for Cordova.framework for xcode 8.3.2
2. Add step to show how to integrate plugins in xcode which used in cordova project.

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Embed cordova in ios native app documentation only.

### What does this PR do?
Improve instruction and add detail steps for plugins in cordova project.

### What testing has been done on this change?
N/A

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
