### PR TITLE
CB-13076,CB-13068 : Removed references of cordova device motion and cordova device orientation plugins

### DIFF
--- a/www/docs/en/dev/guide/support/index.md
+++ b/www/docs/en/dev/guide/support/index.md
@@ -88,17 +88,6 @@ CLI's shorthand names.
     </tr>
 
     <tr>
-        <th><a href="../../reference/cordova-plugin-device-motion/">Accelerometer</a></th>
-        <td data-col="android"    class="y"></td>
-        <td data-col="blackberry10" class="y"></td>
-        <td data-col="ios"        class="y"></td>
-        <td data-col="ubuntu"        class="y"></td>
-        <td data-col="winphone8"  class="y"></td>
-        <td data-col="win8"       class="y"></td>
-        <td data-col="osx"       class="n"></td>
-    </tr>
-
-    <tr>
         <th><a href="../../reference/cordova-plugin-battery-status/">BatteryStatus</a></th>
         <td data-col="android"    class="y"></td>
         <td data-col="blackberry10" class="y"></td>

--- a/www/docs/en/dev/guide/support/index.md
+++ b/www/docs/en/dev/guide/support/index.md
@@ -132,17 +132,6 @@ CLI's shorthand names.
     </tr>
 
     <tr>
-        <th><a href="../../reference/cordova-plugin-device-orientation/">Compass</a></th>
-        <td data-col="android"    class="y"></td>
-        <td data-col="blackberry10" class="y"></td>
-        <td data-col="ios"        class="y">(3GS+)</td>
-        <td data-col="ubuntu"        class="y"></td>
-        <td data-col="winphone8"  class="y"></td>
-        <td data-col="win8"       class="y"></td>
-        <td data-col="osx"       class="n"></td>
-    </tr>
-
-    <tr>
         <th><a href="../../reference/cordova-plugin-network-information/">Connection</a></th>
         <td data-col="android"    class="y"></td>
         <td data-col="blackberry10" class="y"></td>

--- a/www/static/plugins/official-plugins.json
+++ b/www/static/plugins/official-plugins.json
@@ -6,7 +6,6 @@
         "cordova-plugin-contacts",
         "cordova-plugin-device",
         "cordova-plugin-device-motion",
-        "cordova-plugin-device-orientation",
         "cordova-plugin-dialogs",
         "cordova-plugin-file",
         "cordova-plugin-file-transfer",

--- a/www/static/plugins/official-plugins.json
+++ b/www/static/plugins/official-plugins.json
@@ -5,7 +5,6 @@
         "cordova-plugin-console",
         "cordova-plugin-contacts",
         "cordova-plugin-device",
-        "cordova-plugin-device-motion",
         "cordova-plugin-dialogs",
         "cordova-plugin-file",
         "cordova-plugin-file-transfer",


### PR DESCRIPTION

### Platforms affected
iOS, Android and Windows

### What does this PR do?
Removes references of cordova-plugin-device-motion and the cordova-plugin-device-orientation from cordova-docs
