### PR TITLE
CB-13195 Source Code link in footer on cordova.apache.org needs updated

### DIFF
--- a/www/_includes/footer_contents.html
+++ b/www/_includes/footer_contents.html
@@ -22,7 +22,7 @@
             <div class="col-sm-4">
                 <h2>Development</h2>
                 <ul class="nav">
-                    <li><a target="_blank" href="https://github.com/apache?utf8=%E2%9C%93&amp;query=cordova-">Source Code</a></li>
+                    <li><a target="_blank" href="https://github.com/apache?utf8=%E2%9C%93&amp;q=cordova-">Source Code</a></li>
                     <li><a target="_blank" href="https://issues.apache.org/jira/browse/CB/">Issue Tracker</a></li>
                     <li><a target="_blank" href="http://stackoverflow.com/questions/tagged/cordova">Stack Overflow</a></li>
                     <li><a href="{{ site.baseurl }}/contact">Mailing List</a></li>


### PR DESCRIPTION
### Platforms affected
N/A

### What does this PR do?
Fix the "Source Code" link in footer (CB-13195)

### What testing has been done on this change?
Tested locally with _node_modules/.bin/gulp serve --nodocs_ and clicked the link.  It works!

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.