### PR TITLE
CB-13283 Fetching of download counts fails on plugins.cordova.io

### DIFF
--- a/www/static/plugins/app.js
+++ b/www/static/plugins/app.js
@@ -333,6 +333,9 @@ var App = React.createClass({
             var packageNames = "";
             var downloadCountRequests = [];
             for(var index = 0; index < plugins.length; index++) {
+                if (/^@.*\//.test(plugins[index].name)) {
+                    continue;
+                }
                 packageNames += plugins[index].name + ",";
 
                 if(index % Constants.DownloadCountBatch === 0 || index === plugins.length - 1) {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Docs

### What does this PR do?

Just before fetching the download counts from npmjs, this filters plugins based on name, removing scoped packages. This allows the bulk search to go ahead for the remaining packages.

### What testing has been done on this change?

Manual testing

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
