### PR TITLE
CB-13284: Slackin.js on docs fails to load due to insecure response

### DIFF
--- a/www/_includes/footer_contents.html
+++ b/www/_includes/footer_contents.html
@@ -56,7 +56,7 @@
             Learn More
         </a>
         <p style="padding-top:20px"> <a href="https://twitter.com/apachecordova" class="twitter-follow-button" data-show-count="false">Follow @apachecordova</a></p>
-        <script async defer src="https://slack.cordova.io/slackin.js"></script>
+        <script async defer src="https://slack-cordova-io.herokuapp.com/slackin.js"></script>
     </div>
 </div>
 <p class="copyright_text">


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Docs

### What does this PR do?

Changed location of slackin.js to https://slack-cordova-io.herokuapp.com
to match the TLS certificate


### What testing has been done on this change?

Manual testing


### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
