### PR TITLE
CB-13305: Docs can't build because of ES6 code use

### DIFF
--- a/www/static/plugins/searchbar.jsx
+++ b/www/static/plugins/searchbar.jsx
@@ -8,9 +8,9 @@ var SearchBar = createClass({
 
     // polyfill of sorts for string refs
     linkRef: function(component, name) {
-        let cache = component._linkedRefs || (component._linkedRefs = {});
+        var cache = component._linkedRefs || (component._linkedRefs = {});
         if (!component.refs) component.refs = {};
-        return cache[name] || (cache[name] = c => {
+        return cache[name] || (cache[name] = function(c) {
             component.refs[name] = c;
         });
     },

--- a/www/static/plugins/searchbar.jsx
+++ b/www/static/plugins/searchbar.jsx
@@ -11,7 +11,7 @@ var SearchBar = createClass({
         var cache = component._linkedRefs || (component._linkedRefs = {});
         if (!component.refs) component.refs = {};
         return cache[name] || (cache[name] = function(c) {
-            component.refs[name] = c;
+            return component.refs[name] = c;
         });
     },
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Docs

### What does this PR do?
Updated `linkRef` function to use `var` and ES5 functions instead of
`let` and arrow functions.

### What testing has been done on this change?
Manual as well as: `gulp build --pros`

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
