### PR TITLE
Fix french translation of Images.md

### DIFF
--- a/www/docs/fr/dev/config_ref/images.md
+++ b/www/docs/fr/dev/config_ref/images.md
@@ -23,11 +23,11 @@ toc_title: Customize icons
 
 # Icones et Splash Screen
 
-Cette section indique comment configurer une icône et un écran de démarrage facultatif pour une application sur diverses plates-formes, les deux lorsque vous travaillez dans la CLI de Cordova (décrites dans l'Interface de ligne de commande) ou en utilisant les outils du SDK spécifique à la plateforme (détaillées dans les Guides de la plate-forme).
+Cette section indique comment configurer une icône et un écran de démarrage facultatif pour une application sur diverses plates-formes, les deux lorsque vous travaillez avec la CLI de Cordova (décrites dans l'Interface de ligne de commande) ou en utilisant les outils du SDK spécifique à la plateforme (détaillées dans les Guides de la plate-forme).
 
 ## Configuration des icônes dans le CLI
 
-Quand travaillant dans la CLI, vous pouvez définir des app icônes via `<icon>` élément ( `config.xml` ). Si vous ne spécifiez pas une icône, puis le logo Apache Cordova est utilisé.
+En utilisant la CLI, vous pouvez définir des icônes pour votre application via l'élément `<icon>` ( `config.xml` ). Si vous ne spécifiez pas une icône, alors le logo Apache Cordova est utilisé.
 
         <icon src="res/ios/icon.png" platform="ios" width="57" height="57" density="mdpi" />
     
@@ -42,12 +42,12 @@ hauteur : hauteur d'icône (facultatif) en pixels
 
 densité : android (facultatif) spécifique, spécifie la densité de l'icône
 
-La configuration suivante peut être utilisée pour définir l'icône par défaut unique qui sera utilisé pour toutes les plates-formes.
+La configuration suivante peut être utilisée pour définir l'icône par défaut unique qui sera utilisée pour toutes les plates-formes.
 
         <icon src="res/icon.png" />
     
 
-Pour chaque plate-forme, vous pouvez également définir un set pour s'adapter à des résolutions d'écran différentes d'icônes de pixellisés.
+Pour chaque plate-forme, vous pouvez également définir un jeu d'icônes pour s'adapter à des résolutions d'écran différentes.
 
 Amazon Fire OS
 
@@ -88,7 +88,30 @@ Firefox OS
 
 iOS
 
-         < nom de plate-forme = "ios" ><!--iOS 8.0 +--> <!--iPhone Plus 6--> < icône src = "res/ios/icon-60@3x.png" width = "180" height = "180" / ><!--iOS 7.0 +--> <!--iPhone / iPod Touch--> < icône src="res/ios/icon-60.png" largeur = "60" height = "60" / >< icône src = "res/ios/icon-60@2x.png" width = "120" height = "120" / ><!--iPad--> < icône src="res/ios/icon-76.png" largeur = hauteur "76" = "76" / >< icône src = "res/ios/icon-76@2x.png" width = "152" height = "152" /><!--iOS 6.1--> <!--icône Spotlight--> < icône src="res/ios/icon-40.png" largeur = "40" height = "40" / >< icône src = "res/ios/icon-40@2x.png" width = "80" height = "80" / ><!--iPhone / iPod Touch--> < icône src="res/ios/icon.png" largeur = "57" height = "57" / >< icône src = "res/ios/icon@2x.png" width = "114" height = "114" / ><!--iPad--> < icône src="res/ios/icon-72.png" largeur = hauteur "72" = "72" / >< icône src = "res/ios/icon-72@2x.png" width = "144" hauteur = "144" / ><!--iPhone Spotlight et icône Paramètres--> < icône src="res/ios/icon-small.png" largeur = "29" height = "29" / >< icône src = "res/ios/icon-small@2x.png" width = height "58" = "58" / ><!--iPad Spotlight et icône Paramètres--> < icône src="res/ios/icon-50.png" largeur = "50" height = "50" / >< icône src = "res/ios/icon-50@2x.png" width = "100" height = "100" / >< / plate-forme >
+         <platform name="ios">
+           <!--iOS 8.0 +--><!--iPhone Plus 6-->
+           <icon src="res/ios/icon-60@3x.png" width="180" height="180" />
+           <!--iOS 7.0 +--><!--iPhone / iPod Touch-->
+           <icon src="res/ios/icon-60.png" width="60" height="60" />
+           <icon src="res/ios/icon-60@2x.png" width="120" height="120" />
+           <!--iPad-->
+           <icon src="res/ios/icon-76.png" width="76" height="76" />
+           <icon src="res/ios/icon-76@2x.png" width="152" height="152" />
+           <!--iOS 6.1--><!--icône Spotlight-->
+           <icon src="res/ios/icon-40.png" width="40" height="40" />
+           <icon src="res/ios/icon-40@2x.png" width="80" height="80" />
+           <!--iPhone / iPod Touch-->
+           <icon src="res/ios/icon.png" width="57" height="57" />
+           <icon src="res/ios/icon@2x.png" width="114" height="114" />
+           <!--iPad--> <icon src="res/ios/icon-72.png" width="72" height="72" />
+           <icon src="res/ios/icon-72@2x.png" width="144" height="144" />
+           <!--iPhone Spotlight et icône Paramètres-->
+           <icon src="res/ios/icon-small.png" width="29" height="29" />
+           <icon src="res/ios/icon-small@2x.png" width="58" height="58" />
+           <!--iPad Spotlight et icône Paramètres-->
+           <icon src="res/ios/icon-50.png" width="50" height="50" />
+           <icon src="res/ios/icon-50@2x.png" width="100" height="100" />
+         </platform>
     
 
 Paciarelli
@@ -118,14 +141,21 @@ Windows8
 
 ## Configuration du Splashscreen dans la CLI
 
-Dans le premier niveau `config.xml` fichier (pas celui de `platforms` ), ajouter des éléments de configuration tels que celles spécifiées ici.
+Dans le fichier `config.xml` (pas celui de `platforms` ), vous pouvez ajouter des éléments de configuration tels que spécifiés ici.
 
 # Exemple de configuration
 
-Veuillez noter que la valeur de l'attribut « src » est relatif au répertoire de projet et de ne pas le répertoire www. Vous pouvez nommer l'image source, ce qui vous plait. Le nom interne de l'application sont déterminées par Cordova.
+Veuillez noter que la valeur de l'attribut « src » est relatif au répertoire du projet et non au répertoire www. Vous pouvez nommer l'image source comme il vous plait. Le nom interne de l'application sont déterminées par Cordova.
 
     <platform name="android">
-        <!-- you can use any density that exists in the Android project -->
+        <!-- you can use any density that exists in the Android project
+            ldpi    : 36x36 px
+            mdpi    : 48x48 px
+            hdpi    : 72x72 px
+            xhdpi   : 96x96 px
+            xxhdpi  : 144x144 px
+            xxxhdpi : 192x192 px
+        -->
         <splash src="res/screen/android/splash-land-hdpi.png" density="land-hdpi"/>
         <splash src="res/screen/android/splash-land-ldpi.png" density="land-ldpi"/>
         <splash src="res/screen/android/splash-land-mdpi.png" density="land-mdpi"/>
@@ -138,12 +168,19 @@ Veuillez noter que la valeur de l'attribut « src » est relatif au répertoire 
     </platform>
     
     <platform name="ios">
-        <!-- images are determined by width and height. Suivants sont pris en charge--> < éclabousser src="res/screen/ios/Default~iphone.png" largeur = "320" height = "480" / >< éclabousser src="res/screen/ios/Default@2x~iphone.png" largeur = "640" height = "960" / >< éclabousser src="res/screen/ios/Default-Portrait~ipad.png" largeur = "768" hauteur = "1024" / >< éclabousser src="res/screen/ios/Default-Portrait@2x~ipad.png" largeur = "1536" height = "2048" / >< éclabousser src="res/screen/ios/Default-Landscape~ipad.png" largeur = "1024" height = "768" / >< éclabousser src="res/screen/ios/Default-Landscape@2x~ipad.png" largeur = "2048" hauteur = "1536" / >< éclabousser src="res/screen/ios/Default-568h@2x~iphone.png" largeur = "640" height = "1136" / >< éclabousser src="res/screen/ios/Default-667h.png" largeur = "750" height = "1334" / >< éclabousser src="res/screen/ios/Default-736h.png" largeur = "1242" height = "2208" / >< éclabousser src="res/screen/ios/Default-Landscape-736h.png" largeur = "2208" height = "1242" / >< / plateforme >< nom de plate-forme = "at 8" ><!--images sont déterminées par la largeur et la hauteur. The following are supported -->
-        <splash src="res/screen/wp8/SplashScreenImage.jpg" width="768" height="1280"/>
-    </platform>
+        <splash src="res/screen/ios/Default~iphone.png" width="320" height="480" />
+        <splash src="res/screen/ios/Default@2x~iphone.png" width="640" height="960" />
+        <splash src="res/screen/ios/Default-Portrait~ipad.png" width="768" height="1024" />
+        <splash src="res/screen/ios/Default-Portrait@2x~ipad.png" width="1536" height="2048" />
+        <splash src="res/screen/ios/Default-Landscape~ipad.png" width="1024" height="768" />
+        <splash src="res/screen/ios/Default-Landscape@2x~ipad.png" width="2048" height="1536" />
+        <splash src="res/screen/ios/Default-568h@2x~iphone.png" width="640" height="1136" />
+        <splash src="res/screen/ios/Default-667h.png" width="750" height="1334" />
+        <splash src="res/screen/ios/Default-736h.png" width="1242" height="2208" />
+        <splash src="res/screen/ios/Default-Landscape-736h.png" width="2208" height="1242" />
+    </plateform>
     
     <platform name="windows8">
-        <!-- images are determined by width and height. The following are supported -->
         <splash src="res/screen/windows8/splashscreen.png" width="620" height="300"/>
     </platform>
     
@@ -159,7 +196,7 @@ Veuillez noter que la valeur de l'attribut « src » est relatif au répertoire 
 
 # Plates-formes prises en charge
 
-A partir de maintenant (Cordova 3.5.0 juillet 2014) les plates-formes suivants prennent en charge les écrans de démarrage.
+A partir de maintenant (Cordova 3.5.0 juillet 2014) les plates-formes suivantes prennent en charge les écrans de démarrage.
 
     android
     ios
@@ -170,4 +207,4 @@ A partir de maintenant (Cordova 3.5.0 juillet 2014) les plates-formes suivants p
 
 # SplashScreen Plugin
 
-Apache Cordova offre également des projections spéciales écran plugin qui pourrait servir à afficher et masquer un écran de démarrage pendant https://github.com/apache/cordova-plugin-splashscreen lancement application par programme
+Apache Cordova met également à disposition un plugin pouvant afficher et masquer un écran de démarrage  https://github.com/apache/cordova-plugin-splashscreen 


### PR DESCRIPTION

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
All

### What does this PR do?
Not sure content is up-to-date, but at least icons/splashscreen documentation is readable by a french person, and configuration names and attributes are no more translated in examples (!)


### What testing has been done on this change?
Reading the preview

### Checklist
None, as it is a documentation fix only.
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
