### PR TITLE
[RFR] Fix icon app density -> qualifier

### DIFF
--- a/www/docs/de/7.x/config_ref/images.md
+++ b/www/docs/de/7.x/config_ref/images.md
@@ -29,8 +29,8 @@ In diesem Abschnitt veranschaulicht, wie einer app-Symbol und optionale Splash-S
 
 Beim Arbeiten in der CLI Sie können definieren app obige über `<icon>` Element ( `config.xml` ). Wenn Sie kein Symbol angeben ist das Apache-Cordova-Logo verwendet.
 
-        <icon src="res/ios/icon.png" platform="ios" width="57" height="57" density="mdpi" />
-    
+        <icon src="res/ios/icon.png" platform="ios" width="57" height="57" qualifier="mdpi" />
+
 
 Src: (erforderlich) gibt den Speicherort der Bilddatei, im Verhältnis zu Ihrem Projektverzeichnis
 
@@ -45,29 +45,29 @@ Dichte: (optional)-Android-spezifisch, gibt Symbol Dichte
 Die folgende Konfiguration kann verwendet werden, einzelne Standard-Icon zu definieren, die für alle Plattformen verwendet werden.
 
         <icon src="res/icon.png" />
-    
+
 
 Für jede Plattform können Sie auch eine pixelgenaue Icons set an unterschiedliche Bildschirmauflösungen angepasst definieren.
 
 Amazon Fire OS
 
          <platform name="amazon-fireos">
-                  <icon src="res/android/ldpi.png" density="ldpi" />
-                  <icon src="res/android/mdpi.png" density="mdpi" />
-                  <icon src="res/android/hdpi.png" density="hdpi" />
-                  <icon src="res/android/xhdpi.png" density="xhdpi" />
+                  <icon src="res/android/ldpi.png" qualifier="ldpi" />
+                  <icon src="res/android/mdpi.png" qualifier="mdpi" />
+                  <icon src="res/android/hdpi.png" qualifier="hdpi" />
+                  <icon src="res/android/xhdpi.png" qualifier="xhdpi" />
          </platform>
-    
+
 
 Android
 
          <platform name="android">
-                  <icon src="res/android/ldpi.png" density="ldpi" />
-                  <icon src="res/android/mdpi.png" density="mdpi" />
-                  <icon src="res/android/hdpi.png" density="hdpi" />
-                  <icon src="res/android/xhdpi.png" density="xhdpi" />
+                  <icon src="res/android/ldpi.png" qualifier="ldpi" />
+                  <icon src="res/android/mdpi.png" qualifier="mdpi" />
+                  <icon src="res/android/hdpi.png" qualifier="hdpi" />
+                  <icon src="res/android/xhdpi.png" qualifier="xhdpi" />
          </platform>
-    
+
 
 BlackBerry10
 
@@ -75,7 +75,7 @@ BlackBerry10
                   <icon src="res/bb10/icon-86.png" />
                   <icon src="res/bb10/icon-150.png" />
          </platform>
-    
+
 
 Finden Sie BlackBerry Dokumentation gezielt mehrere Größen und Gebietsschemas. [http://developer.blackberry.com/html5/documentation/icon_element.html]
 
@@ -84,7 +84,7 @@ Firefox OS
          <platform name="firefoxos">
                   <icon src="res/ff/logo.png" width="60" height="60" />
          </platform>
-    
+
 
 iOS
 
@@ -116,14 +116,14 @@ iOS
                   <icon src="res/ios/icon-50.png" width="50" height="50" />
                   <icon src="res/ios/icon-50@2x.png" width="100" height="100" />
          </platform>
-    
+
 
 Tizen
 
          <platform name="tizen">
                   <icon src="res/tizen/icon-128.png" width="128" height="128" />
          </platform>
-    
+
 
 Windows Phone8
 
@@ -132,7 +132,7 @@ Windows Phone8
                   <!-- tile image -->
                   <icon src="res/wp/Background.png" width="159" height="159" />
          </platform>
-    
+
 
 Windows8
 
@@ -141,7 +141,7 @@ Windows8
                   <icon src="res/windows8/smalllogo.png" width="30" height="30" />
                   <icon src="res/windows8/storelogo.png" width="50" height="50" />
          </platform>
-    
+
 
 ## Splash-Screens in der CLI konfigurieren
 
@@ -152,18 +152,18 @@ In der obersten Ebene `config.xml` Datei (nicht diejenige in `platforms` ), Konf
 Bitte beachten Sie, dass der Wert des Attributs "Src" relativ zum Projektverzeichnis und nicht in das Www-Verzeichnis. Sie können das Quellbild benennen, was Sie wollen. Der interne Name in der app hängen von Cordova.
 
     <platform name="android">
-        <!-- you can use any density that exists in the Android project -->
-        <splash src="res/screen/android/splash-land-hdpi.png" density="land-hdpi"/>
-        <splash src="res/screen/android/splash-land-ldpi.png" density="land-ldpi"/>
-        <splash src="res/screen/android/splash-land-mdpi.png" density="land-mdpi"/>
-        <splash src="res/screen/android/splash-land-xhdpi.png" density="land-xhdpi"/>
-    
-        <splash src="res/screen/android/splash-port-hdpi.png" density="port-hdpi"/>
-        <splash src="res/screen/android/splash-port-ldpi.png" density="port-ldpi"/>
-        <splash src="res/screen/android/splash-port-mdpi.png" density="port-mdpi"/>
-        <splash src="res/screen/android/splash-port-xhdpi.png" density="port-xhdpi"/>
+        <!-- you can use any qualifier that exists in the Android project -->
+        <splash src="res/screen/android/splash-land-hdpi.png" qualifier="land-hdpi"/>
+        <splash src="res/screen/android/splash-land-ldpi.png" qualifier="land-ldpi"/>
+        <splash src="res/screen/android/splash-land-mdpi.png" qualifier="land-mdpi"/>
+        <splash src="res/screen/android/splash-land-xhdpi.png" qualifier="land-xhdpi"/>
+
+        <splash src="res/screen/android/splash-port-hdpi.png" qualifier="port-hdpi"/>
+        <splash src="res/screen/android/splash-port-ldpi.png" qualifier="port-ldpi"/>
+        <splash src="res/screen/android/splash-port-mdpi.png" qualifier="port-mdpi"/>
+        <splash src="res/screen/android/splash-port-xhdpi.png" qualifier="port-xhdpi"/>
     </platform>
-    
+
     <platform name="ios">
         <!-- images are determined by width and height. The following are supported -->
         <splash src="res/screen/ios/Default~iphone.png" width="320" height="480"/>
@@ -177,26 +177,26 @@ Bitte beachten Sie, dass der Wert des Attributs "Src" relativ zum Projektverzeic
         <splash src="res/screen/ios/Default-736h.png" width="1242" height="2208"/>
         <splash src="res/screen/ios/Default-Landscape-736h.png" width="2208" height="1242"/>
     </platform>
-    
+
     <platform name="wp8">
         <!-- images are determined by width and height. The following are supported -->
         <splash src="res/screen/wp8/SplashScreenImage.jpg" width="768" height="1280"/>
     </platform>
-    
+
     <platform name="windows8">
         <!-- images are determined by width and height. The following are supported -->
         <splash src="res/screen/windows8/splashscreen.png" width="620" height="300"/>
     </platform>
-    
+
     <platform name="blackberry10">
         <!-- Add a rim:splash element for each resolution and locale you wish -->
         <!-- http://developer.blackberry.com/html5/documentation/rim_splash_element.html -->
         <rim:splash src="res/screen/windows8/splashscreen.png"/>
     </platform>
-    
-    
+
+
     <preference name="SplashScreenDelay" value="10000" />
-    
+
 
 # Unterstützte Plattformen
 
@@ -207,7 +207,7 @@ Ab sofort (Cordova 3.5.0 Juli 2014) die folgenden Plattformen unterstützen Spla
     wp8
     windows8
     blackberry10
-    
+
 
 # SplashScreen-Plugin
 

--- a/www/docs/en/7.x/config_ref/images.md
+++ b/www/docs/en/7.x/config_ref/images.md
@@ -32,7 +32,7 @@ When working in the CLI you can define application icon(s) via the `<icon>` elem
 If you do not specify an icon, the Apache Cordova logo is used.
 
 ```xml
-    <icon src="res/ios/icon.png" platform="ios" width="57" height="57" density="mdpi" />
+    <icon src="res/ios/icon.png" platform="ios" width="57" height="57" qualifier="mdpi" />
 ```
 
 Attributes    | Description
@@ -41,7 +41,7 @@ src           | *Required* <br/> Location of the image file, relative to your pr
 platform      | *Optional* <br/> Target platform
 width         | *Optional* <br/> Icon width in pixels
 height        | *Optional* <br/> Icon height in pixels
-density       | *Optional* <br/> ==Android== <br/> Specified icon density
+qualifier       | *Optional* <br/> ==Android== <br/> Specified icon qualifier
 target        | *Optional* <br/> ==Windows== <br/> Destination filename for the image file and all its' MRT companions
 
 
@@ -64,12 +64,12 @@ different screen resolutions.
             xxhdpi  : 144x144 px
             xxxhdpi : 192x192 px
         -->
-        <icon src="res/android/ldpi.png" density="ldpi" />
-        <icon src="res/android/mdpi.png" density="mdpi" />
-        <icon src="res/android/hdpi.png" density="hdpi" />
-        <icon src="res/android/xhdpi.png" density="xhdpi" />
-        <icon src="res/android/xxhdpi.png" density="xxhdpi" />
-        <icon src="res/android/xxxhdpi.png" density="xxxhdpi" />
+        <icon src="res/android/ldpi.png" qualifier="ldpi" />
+        <icon src="res/android/mdpi.png" qualifier="mdpi" />
+        <icon src="res/android/hdpi.png" qualifier="hdpi" />
+        <icon src="res/android/xhdpi.png" qualifier="xhdpi" />
+        <icon src="res/android/xxhdpi.png" qualifier="xxhdpi" />
+        <icon src="res/android/xxxhdpi.png" qualifier="xxxhdpi" />
     </platform>
 ```
 ###See Also

--- a/www/docs/es/7.x/config_ref/images.md
+++ b/www/docs/es/7.x/config_ref/images.md
@@ -29,8 +29,8 @@ Esta sección le muestra cómo configurar el icono de una aplicación y opcional
 
 Cuando trabajes en el CLI puedes definir los iconos de la app haciendo uso del elemento `<icon>` (`config.xml`). Si no se especifica un icono se utilizara el logo de Apache Cordova.
 
-        <icon src="res/ios/icon.png" platform="ios" width="57" height="57" density="mdpi" />
-    
+        <icon src="res/ios/icon.png" platform="ios" width="57" height="57" qualifier="mdpi" />
+
 
 Fuente: (requerido) especifica la ubicación del archivo de imagen, en relación a su directorio de proyecto
 
@@ -40,34 +40,34 @@ width: anchura de icono en pixeles (opcional)
 
 height: altura del icono en pixeles (opcional)
 
-density: específico de android, especifica la densidad del icono (opcional)
+qualifier: específico de android, especifica la densidad del icono (opcional)
 
 Puede utilizar la siguiente configuración para definir un icono único por defecto, que se utilizará para todas las plataformas.
 
         <icon src="res/icon.png" />
-    
+
 
 Para cada plataforma también puede definir un conjunto de iconos para adaptarse a distintas resoluciones de pantalla.
 
 Amazon fire OS
 
          <platform name="amazon-fireos">
-                  <icon src="res/android/ldpi.png" density="ldpi" />
-                  <icon src="res/android/mdpi.png" density="mdpi" />
-                  <icon src="res/android/hdpi.png" density="hdpi" />
-                  <icon src="res/android/xhdpi.png" density="xhdpi" />
+                  <icon src="res/android/ldpi.png" qualifier="ldpi" />
+                  <icon src="res/android/mdpi.png" qualifier="mdpi" />
+                  <icon src="res/android/hdpi.png" qualifier="hdpi" />
+                  <icon src="res/android/xhdpi.png" qualifier="xhdpi" />
          </platform>
-    
+
 
 Android
 
          <platform name="android">
-                  <icon src="res/android/ldpi.png" density="ldpi" />
-                  <icon src="res/android/mdpi.png" density="mdpi" />
-                  <icon src="res/android/hdpi.png" density="hdpi" />
-                  <icon src="res/android/xhdpi.png" density="xhdpi" />
+                  <icon src="res/android/ldpi.png" qualifier="ldpi" />
+                  <icon src="res/android/mdpi.png" qualifier="mdpi" />
+                  <icon src="res/android/hdpi.png" qualifier="hdpi" />
+                  <icon src="res/android/xhdpi.png" qualifier="xhdpi" />
          </platform>
-    
+
 
 BlackBerry10
 
@@ -75,7 +75,7 @@ BlackBerry10
                   <icon src="res/bb10/icon-86.png" />
                   <icon src="res/bb10/icon-150.png" />
          </platform>
-    
+
 
 Consulte la documentación de BlackBerry para apuntar varios tamaños y configuraciones regionales. [http://developer.blackberry.com/html5/documentation/icon_element.html]
 
@@ -84,19 +84,19 @@ Firefox OS
          <platform name="firefoxos">
                   <icon src="res/ff/logo.png" width="60" height="60" />
          </platform>
-    
+
 
 iOS
 
          < nombre de plataforma = "ios" ><!--iOS 8.0 +--> <!--iPhone Plus 6--> < icono src = "res/ios/icon-60@3x.png" width = "180" altura = "180" / ><!--iOS 7.0 +--> <!--iPhone / iPod Touch--> < icono src="res/ios/icon-60.png" ancho = "60" height = "60" / >< icono src = "res/ios/icon-60@2x.png" width = "120" height = "120" / ><!----> iPad < icono src="res/ios/icon-76.png" ancho = altura "76" = "76" / >< icono src = "res/ios/icon-76@2x.png" width = "152" height = "152" /><!--iOS 6.1--> <!--icono Spotlight--> < icono src="res/ios/icon-40.png" ancho = "40" altura = "40" / >< icono src = "res/ios/icon-40@2x.png" width = "80" height = "80" / ><!--iPhone / iPod Touch--> < icono src="res/ios/icon.png" ancho = altura "57" = "57" / >< icono src = "res/ios/icon@2x.png" width = altura "114" = "114" / ><!--iPad--> < icono src="res/ios/icon-72.png" ancho = altura "72" = "72" / >< icono src = "res/ios/icon-72@2x.png" width = "144" altura = "144" / ><!--iPhone Spotlight y el icono Configuración--> < icono src="res/ios/icon-small.png" ancho = "29" height = "29" / >< icono src = "res/ios/icon-small@2x.png" width = "58" height = "58" / ><!--iPad Spotlight y el icono Configuración--> < icono src="res/ios/icon-50.png" ancho = "50" altura = "50" / >< icono src = "res/ios/icon-50@2x.png" width = "100" height = "100" / >< / plataforma >
-    
+
 
 Tizen
 
          <platform name="tizen">
                   <icon src="res/tizen/icon-128.png" width="128" height="128" />
          </platform>
-    
+
 
 Windows Phone8
 
@@ -105,7 +105,7 @@ Windows Phone8
                   <!-- tile image -->
                   <icon src="res/wp/Background.png" width="159" height="159" />
          </platform>
-    
+
 
 Windows8
 
@@ -114,7 +114,7 @@ Windows8
                   <icon src="res/windows8/smalllogo.png" width="30" height="30" />
                   <icon src="res/windows8/storelogo.png" width="50" height="50" />
          </platform>
-    
+
 
 ## Configurando pantallas de inicio en el CLI
 
@@ -125,37 +125,37 @@ En el nivel superior `config.xml` archivo (no el que está en `platforms` ), añ
 Por favor observe que el valor del atributo "src" es relativa al directorio de proyecto y no en el directorio de www. Puedes nombrar a la imagen de origen lo que quieras. El nombre interno de la aplicación están determinados por Córdoba.
 
     <platform name="android">
-        <!-- you can use any density that exists in the Android project -->
-        <splash src="res/screen/android/splash-land-hdpi.png" density="land-hdpi"/>
-        <splash src="res/screen/android/splash-land-ldpi.png" density="land-ldpi"/>
-        <splash src="res/screen/android/splash-land-mdpi.png" density="land-mdpi"/>
-        <splash src="res/screen/android/splash-land-xhdpi.png" density="land-xhdpi"/>
-    
-        <splash src="res/screen/android/splash-port-hdpi.png" density="port-hdpi"/>
-        <splash src="res/screen/android/splash-port-ldpi.png" density="port-ldpi"/>
-        <splash src="res/screen/android/splash-port-mdpi.png" density="port-mdpi"/>
-        <splash src="res/screen/android/splash-port-xhdpi.png" density="port-xhdpi"/>
+        <!-- you can use any qualifier that exists in the Android project -->
+        <splash src="res/screen/android/splash-land-hdpi.png" qualifier="land-hdpi"/>
+        <splash src="res/screen/android/splash-land-ldpi.png" qualifier="land-ldpi"/>
+        <splash src="res/screen/android/splash-land-mdpi.png" qualifier="land-mdpi"/>
+        <splash src="res/screen/android/splash-land-xhdpi.png" qualifier="land-xhdpi"/>
+
+        <splash src="res/screen/android/splash-port-hdpi.png" qualifier="port-hdpi"/>
+        <splash src="res/screen/android/splash-port-ldpi.png" qualifier="port-ldpi"/>
+        <splash src="res/screen/android/splash-port-mdpi.png" qualifier="port-mdpi"/>
+        <splash src="res/screen/android/splash-port-xhdpi.png" qualifier="port-xhdpi"/>
     </platform>
-    
+
     <platform name="ios">
         <!-- images are determined by width and height. Se admiten las siguientes--> < salpicar src="res/screen/ios/Default~iphone.png" ancho = "320" height = "480" / >< splash src="res/screen/ios/Default@2x~iphone.png" ancho = "640" altura = "960" / >< splash src="res/screen/ios/Default-Portrait~ipad.png" ancho = altura "768" = "1024" / >< splash src="res/screen/ios/Default-Portrait@2x~ipad.png" ancho = altura "1536" = "2048" / >< splash src="res/screen/ios/Default-Landscape~ipad.png" ancho = "1024" altura = "768" / >< splash src="res/screen/ios/Default-Landscape@2x~ipad.png" ancho = "2048" altura = "1536" / >< splash src="res/screen/ios/Default-568h@2x~iphone.png" ancho = "640" height = "1136" / >< splash src="res/screen/ios/Default-667h.png" ancho = "750" height = "1334" / >< splash src="res/screen/ios/Default-736h.png" ancho = "1242" altura = "2208" / >< splash src="res/screen/ios/Default-Landscape-736h.png" ancho = altura "2208" = "1242" / >< / plataforma >< nombre de plataforma = "wp8" ><!--imágenes están determinados por la anchura y la altura. The following are supported -->
         <splash src="res/screen/wp8/SplashScreenImage.jpg" width="768" height="1280"/>
     </platform>
-    
+
     <platform name="windows8">
         <!-- images are determined by width and height. The following are supported -->
         <splash src="res/screen/windows8/splashscreen.png" width="620" height="300"/>
     </platform>
-    
+
     <platform name="blackberry10">
         <!-- Add a rim:splash element for each resolution and locale you wish -->
         <!-- http://developer.blackberry.com/html5/documentation/rim_splash_element.html -->
         <rim:splash src="res/screen/windows8/splashscreen.png"/>
     </platform>
-    
-    
+
+
     <preference name="SplashScreenDelay" value="10000" />
-    
+
 
 # Plataformas soportadas
 
@@ -166,7 +166,7 @@ A partir de ahora (Cordova 3.5.0 julio de 2014) las siguientes plataformas sopor
     wp8
     windows8
     blackberry10
-    
+
 
 # SplashScreen Plugin
 

--- a/www/docs/fr/7.x/config_ref/images.md
+++ b/www/docs/fr/7.x/config_ref/images.md
@@ -29,8 +29,8 @@ Cette section indique comment configurer une icône et un écran de démarrage f
 
 Quand travaillant dans la CLI, vous pouvez définir des app icônes via `<icon>` élément ( `config.xml` ). Si vous ne spécifiez pas une icône, puis le logo Apache Cordova est utilisé.
 
-        <icon src="res/ios/icon.png" platform="ios" width="57" height="57" density="mdpi" />
-    
+        <icon src="res/ios/icon.png" platform="ios" width="57" height="57" qualifier="mdpi" />
+
 
 SRC: (obligatoire) spécifie l'emplacement du fichier image, par rapport à votre répertoire de projet
 
@@ -45,29 +45,29 @@ densité : android (facultatif) spécifique, spécifie la densité de l'icône
 La configuration suivante peut être utilisée pour définir l'icône par défaut unique qui sera utilisé pour toutes les plates-formes.
 
         <icon src="res/icon.png" />
-    
+
 
 Pour chaque plate-forme, vous pouvez également définir un set pour s'adapter à des résolutions d'écran différentes d'icônes de pixellisés.
 
 Amazon Fire OS
 
          <platform name="amazon-fireos">
-                  <icon src="res/android/ldpi.png" density="ldpi" />
-                  <icon src="res/android/mdpi.png" density="mdpi" />
-                  <icon src="res/android/hdpi.png" density="hdpi" />
-                  <icon src="res/android/xhdpi.png" density="xhdpi" />
+                  <icon src="res/android/ldpi.png" qualifier="ldpi" />
+                  <icon src="res/android/mdpi.png" qualifier="mdpi" />
+                  <icon src="res/android/hdpi.png" qualifier="hdpi" />
+                  <icon src="res/android/xhdpi.png" qualifier="xhdpi" />
          </platform>
-    
+
 
 Android
 
          <platform name="android">
-                  <icon src="res/android/ldpi.png" density="ldpi" />
-                  <icon src="res/android/mdpi.png" density="mdpi" />
-                  <icon src="res/android/hdpi.png" density="hdpi" />
-                  <icon src="res/android/xhdpi.png" density="xhdpi" />
+                  <icon src="res/android/ldpi.png" qualifier="ldpi" />
+                  <icon src="res/android/mdpi.png" qualifier="mdpi" />
+                  <icon src="res/android/hdpi.png" qualifier="hdpi" />
+                  <icon src="res/android/xhdpi.png" qualifier="xhdpi" />
          </platform>
-    
+
 
 BlackBerry10
 
@@ -75,7 +75,7 @@ BlackBerry10
                   <icon src="res/bb10/icon-86.png" />
                   <icon src="res/bb10/icon-150.png" />
          </platform>
-    
+
 
 Voir la documentation de BlackBerry pour le ciblage de plusieurs tailles et paramètres régionaux. [http://developer.blackberry.com/html5/documentation/icon_element.html]
 
@@ -84,19 +84,19 @@ Firefox OS
          <platform name="firefoxos">
                   <icon src="res/ff/logo.png" width="60" height="60" />
          </platform>
-    
+
 
 iOS
 
          < nom de plate-forme = "ios" ><!--iOS 8.0 +--> <!--iPhone Plus 6--> < icône src = "res/ios/icon-60@3x.png" width = "180" height = "180" / ><!--iOS 7.0 +--> <!--iPhone / iPod Touch--> < icône src="res/ios/icon-60.png" largeur = "60" height = "60" / >< icône src = "res/ios/icon-60@2x.png" width = "120" height = "120" / ><!--iPad--> < icône src="res/ios/icon-76.png" largeur = hauteur "76" = "76" / >< icône src = "res/ios/icon-76@2x.png" width = "152" height = "152" /><!--iOS 6.1--> <!--icône Spotlight--> < icône src="res/ios/icon-40.png" largeur = "40" height = "40" / >< icône src = "res/ios/icon-40@2x.png" width = "80" height = "80" / ><!--iPhone / iPod Touch--> < icône src="res/ios/icon.png" largeur = "57" height = "57" / >< icône src = "res/ios/icon@2x.png" width = "114" height = "114" / ><!--iPad--> < icône src="res/ios/icon-72.png" largeur = hauteur "72" = "72" / >< icône src = "res/ios/icon-72@2x.png" width = "144" hauteur = "144" / ><!--iPhone Spotlight et icône Paramètres--> < icône src="res/ios/icon-small.png" largeur = "29" height = "29" / >< icône src = "res/ios/icon-small@2x.png" width = height "58" = "58" / ><!--iPad Spotlight et icône Paramètres--> < icône src="res/ios/icon-50.png" largeur = "50" height = "50" / >< icône src = "res/ios/icon-50@2x.png" width = "100" height = "100" / >< / plate-forme >
-    
+
 
 Paciarelli
 
          <platform name="tizen">
                   <icon src="res/tizen/icon-128.png" width="128" height="128" />
          </platform>
-    
+
 
 Windows Phone8
 
@@ -105,7 +105,7 @@ Windows Phone8
                   <!-- tile image -->
                   <icon src="res/wp/Background.png" width="159" height="159" />
          </platform>
-    
+
 
 Windows8
 
@@ -114,7 +114,7 @@ Windows8
                   <icon src="res/windows8/smalllogo.png" width="30" height="30" />
                   <icon src="res/windows8/storelogo.png" width="50" height="50" />
          </platform>
-    
+
 
 ## Configuration du Splashscreen dans la CLI
 
@@ -125,37 +125,37 @@ Dans le premier niveau `config.xml` fichier (pas celui de `platforms` ), ajouter
 Veuillez noter que la valeur de l'attribut « src » est relatif au répertoire de projet et de ne pas le répertoire www. Vous pouvez nommer l'image source, ce qui vous plait. Le nom interne de l'application sont déterminées par Cordova.
 
     <platform name="android">
-        <!-- you can use any density that exists in the Android project -->
-        <splash src="res/screen/android/splash-land-hdpi.png" density="land-hdpi"/>
-        <splash src="res/screen/android/splash-land-ldpi.png" density="land-ldpi"/>
-        <splash src="res/screen/android/splash-land-mdpi.png" density="land-mdpi"/>
-        <splash src="res/screen/android/splash-land-xhdpi.png" density="land-xhdpi"/>
-    
-        <splash src="res/screen/android/splash-port-hdpi.png" density="port-hdpi"/>
-        <splash src="res/screen/android/splash-port-ldpi.png" density="port-ldpi"/>
-        <splash src="res/screen/android/splash-port-mdpi.png" density="port-mdpi"/>
-        <splash src="res/screen/android/splash-port-xhdpi.png" density="port-xhdpi"/>
+        <!-- you can use any qualifier that exists in the Android project -->
+        <splash src="res/screen/android/splash-land-hdpi.png" qualifier="land-hdpi"/>
+        <splash src="res/screen/android/splash-land-ldpi.png" qualifier="land-ldpi"/>
+        <splash src="res/screen/android/splash-land-mdpi.png" qualifier="land-mdpi"/>
+        <splash src="res/screen/android/splash-land-xhdpi.png" qualifier="land-xhdpi"/>
+
+        <splash src="res/screen/android/splash-port-hdpi.png" qualifier="port-hdpi"/>
+        <splash src="res/screen/android/splash-port-ldpi.png" qualifier="port-ldpi"/>
+        <splash src="res/screen/android/splash-port-mdpi.png" qualifier="port-mdpi"/>
+        <splash src="res/screen/android/splash-port-xhdpi.png" qualifier="port-xhdpi"/>
     </platform>
-    
+
     <platform name="ios">
         <!-- images are determined by width and height. Suivants sont pris en charge--> < éclabousser src="res/screen/ios/Default~iphone.png" largeur = "320" height = "480" / >< éclabousser src="res/screen/ios/Default@2x~iphone.png" largeur = "640" height = "960" / >< éclabousser src="res/screen/ios/Default-Portrait~ipad.png" largeur = "768" hauteur = "1024" / >< éclabousser src="res/screen/ios/Default-Portrait@2x~ipad.png" largeur = "1536" height = "2048" / >< éclabousser src="res/screen/ios/Default-Landscape~ipad.png" largeur = "1024" height = "768" / >< éclabousser src="res/screen/ios/Default-Landscape@2x~ipad.png" largeur = "2048" hauteur = "1536" / >< éclabousser src="res/screen/ios/Default-568h@2x~iphone.png" largeur = "640" height = "1136" / >< éclabousser src="res/screen/ios/Default-667h.png" largeur = "750" height = "1334" / >< éclabousser src="res/screen/ios/Default-736h.png" largeur = "1242" height = "2208" / >< éclabousser src="res/screen/ios/Default-Landscape-736h.png" largeur = "2208" height = "1242" / >< / plateforme >< nom de plate-forme = "at 8" ><!--images sont déterminées par la largeur et la hauteur. The following are supported -->
         <splash src="res/screen/wp8/SplashScreenImage.jpg" width="768" height="1280"/>
     </platform>
-    
+
     <platform name="windows8">
         <!-- images are determined by width and height. The following are supported -->
         <splash src="res/screen/windows8/splashscreen.png" width="620" height="300"/>
     </platform>
-    
+
     <platform name="blackberry10">
         <!-- Add a rim:splash element for each resolution and locale you wish -->
         <!-- http://developer.blackberry.com/html5/documentation/rim_splash_element.html -->
         <rim:splash src="res/screen/windows8/splashscreen.png"/>
     </platform>
-    
-    
+
+
     <preference name="SplashScreenDelay" value="10000" />
-    
+
 
 # Plates-formes prises en charge
 
@@ -166,7 +166,7 @@ A partir de maintenant (Cordova 3.5.0 juillet 2014) les plates-formes suivants p
     wp8
     windows8
     blackberry10
-    
+
 
 # SplashScreen Plugin
 

--- a/www/docs/it/7.x/config_ref/images.md
+++ b/www/docs/it/7.x/config_ref/images.md
@@ -29,8 +29,8 @@ In questa sezione viene illustrato come configurare un'app icona e schermata ini
 
 Quando funziona il CLI si può definire icone di app tramite `<icon>` elemento ( `config.xml` ). Se non si specifica un'icona viene utilizzato il logo Apache Cordova.
 
-        <icon src="res/ios/icon.png" platform="ios" width="57" height="57" density="mdpi" />
-    
+        <icon src="res/ios/icon.png" platform="ios" width="57" height="57" qualifier="mdpi" />
+
 
 src: (obbligatorio) specifica il percorso del file immagine, relativo alla directory del progetto
 
@@ -45,29 +45,29 @@ densità: androide (opzionale) specifica, specifica icona densità
 Possibile utilizzare la configurazione seguente per definire l'icona di default unico che sarà utilizzato per tutte le piattaforme.
 
         <icon src="res/icon.png" />
-    
+
 
 Per ogni piattaforma è inoltre possibile definire un icone pixel-perfect set per adattarsi a diverse risoluzioni dello schermo.
 
 Amazon fuoco OS
 
          <platform name="amazon-fireos">
-                  <icon src="res/android/ldpi.png" density="ldpi" />
-                  <icon src="res/android/mdpi.png" density="mdpi" />
-                  <icon src="res/android/hdpi.png" density="hdpi" />
-                  <icon src="res/android/xhdpi.png" density="xhdpi" />
+                  <icon src="res/android/ldpi.png" qualifier="ldpi" />
+                  <icon src="res/android/mdpi.png" qualifier="mdpi" />
+                  <icon src="res/android/hdpi.png" qualifier="hdpi" />
+                  <icon src="res/android/xhdpi.png" qualifier="xhdpi" />
          </platform>
-    
+
 
 Android
 
          <platform name="android">
-                  <icon src="res/android/ldpi.png" density="ldpi" />
-                  <icon src="res/android/mdpi.png" density="mdpi" />
-                  <icon src="res/android/hdpi.png" density="hdpi" />
-                  <icon src="res/android/xhdpi.png" density="xhdpi" />
+                  <icon src="res/android/ldpi.png" qualifier="ldpi" />
+                  <icon src="res/android/mdpi.png" qualifier="mdpi" />
+                  <icon src="res/android/hdpi.png" qualifier="hdpi" />
+                  <icon src="res/android/xhdpi.png" qualifier="xhdpi" />
          </platform>
-    
+
 
 BlackBerry10
 
@@ -75,7 +75,7 @@ BlackBerry10
                   <icon src="res/bb10/icon-86.png" />
                   <icon src="res/bb10/icon-150.png" />
          </platform>
-    
+
 
 Vedere la documentazione di BlackBerry per il targeting più dimensioni e impostazioni internazionali. [http://developer.blackberry.com/html5/documentation/icon_element.html]
 
@@ -84,7 +84,7 @@ Firefox OS
          <platform name="firefoxos">
                   <icon src="res/ff/logo.png" width="60" height="60" />
          </platform>
-    
+
 
 iOS
 
@@ -116,14 +116,14 @@ iOS
                   <icon src="res/ios/icon-50.png" width="50" height="50" />
                   <icon src="res/ios/icon-50@2x.png" width="100" height="100" />
          </platform>
-    
+
 
 Tizen
 
          <platform name="tizen">
                   <icon src="res/tizen/icon-128.png" width="128" height="128" />
          </platform>
-    
+
 
 Windows Phone8
 
@@ -132,7 +132,7 @@ Windows Phone8
                   <!-- tile image -->
                   <icon src="res/wp/Background.png" width="159" height="159" />
          </platform>
-    
+
 
 Windows8
 
@@ -141,7 +141,7 @@ Windows8
                   <icon src="res/windows8/smalllogo.png" width="30" height="30" />
                   <icon src="res/windows8/storelogo.png" width="50" height="50" />
          </platform>
-    
+
 
 ## Configurazione schermate iniziali in CLI
 
@@ -152,18 +152,18 @@ Nel primo livello `config.xml` file (non quello di `platforms` ), aggiungere gli
 Si prega di notare che il valore dell'attributo "src" è relativo alla directory del progetto e non nella directory di www. È possibile denominare l'immagine sorgente quello che vuoi. Il nome interno nell'app sono determinati da Cordova.
 
     <platform name="android">
-        <!-- you can use any density that exists in the Android project -->
-        <splash src="res/screen/android/splash-land-hdpi.png" density="land-hdpi"/>
-        <splash src="res/screen/android/splash-land-ldpi.png" density="land-ldpi"/>
-        <splash src="res/screen/android/splash-land-mdpi.png" density="land-mdpi"/>
-        <splash src="res/screen/android/splash-land-xhdpi.png" density="land-xhdpi"/>
-    
-        <splash src="res/screen/android/splash-port-hdpi.png" density="port-hdpi"/>
-        <splash src="res/screen/android/splash-port-ldpi.png" density="port-ldpi"/>
-        <splash src="res/screen/android/splash-port-mdpi.png" density="port-mdpi"/>
-        <splash src="res/screen/android/splash-port-xhdpi.png" density="port-xhdpi"/>
+        <!-- you can use any qualifier that exists in the Android project -->
+        <splash src="res/screen/android/splash-land-hdpi.png" qualifier="land-hdpi"/>
+        <splash src="res/screen/android/splash-land-ldpi.png" qualifier="land-ldpi"/>
+        <splash src="res/screen/android/splash-land-mdpi.png" qualifier="land-mdpi"/>
+        <splash src="res/screen/android/splash-land-xhdpi.png" qualifier="land-xhdpi"/>
+
+        <splash src="res/screen/android/splash-port-hdpi.png" qualifier="port-hdpi"/>
+        <splash src="res/screen/android/splash-port-ldpi.png" qualifier="port-ldpi"/>
+        <splash src="res/screen/android/splash-port-mdpi.png" qualifier="port-mdpi"/>
+        <splash src="res/screen/android/splash-port-xhdpi.png" qualifier="port-xhdpi"/>
     </platform>
-    
+
     <platform name="ios">
         <!-- images are determined by width and height. The following are supported -->
         <splash src="res/screen/ios/Default~iphone.png" width="320" height="480"/>
@@ -177,26 +177,26 @@ Si prega di notare che il valore dell'attributo "src" è relativo alla directory
         <splash src="res/screen/ios/Default-736h.png" width="1242" height="2208"/>
         <splash src="res/screen/ios/Default-Landscape-736h.png" width="2208" height="1242"/>
     </platform>
-    
+
     <platform name="wp8">
         <!-- images are determined by width and height. The following are supported -->
         <splash src="res/screen/wp8/SplashScreenImage.jpg" width="768" height="1280"/>
     </platform>
-    
+
     <platform name="windows8">
         <!-- images are determined by width and height. The following are supported -->
         <splash src="res/screen/windows8/splashscreen.png" width="620" height="300"/>
     </platform>
-    
+
     <platform name="blackberry10">
         <!-- Add a rim:splash element for each resolution and locale you wish -->
         <!-- http://developer.blackberry.com/html5/documentation/rim_splash_element.html -->
         <rim:splash src="res/screen/windows8/splashscreen.png"/>
     </platform>
-    
-    
+
+
     <preference name="SplashScreenDelay" value="10000" />
-    
+
 
 # Piattaforme supportate
 
@@ -207,7 +207,7 @@ A partire da ora (Cordova 3.5.0 luglio 2014) le seguenti piattaforme supportano 
     wp8
     windows8
     blackberry10
-    
+
 
 # Splashscreen Plugin
 

--- a/www/docs/ja/7.x/config_ref/images.md
+++ b/www/docs/ja/7.x/config_ref/images.md
@@ -29,8 +29,8 @@ toc_title: Customize icons
 
 場合、CLI での作業を定義できますアプリケーション アイコンを介して `<icon>` 要素 ( `config.xml` )。アイコンを指定しない場合、Apache コルドバ ロゴを使用します。
 
-        <icon src="res/ios/icon.png" platform="ios" width="57" height="57" density="mdpi" />
-    
+        <icon src="res/ios/icon.png" platform="ios" width="57" height="57" qualifier="mdpi" />
+
 
 src: (必須)、プロジェクト ディレクトリを基準にして、イメージ ファイルの場所を指定します。
 
@@ -45,29 +45,29 @@ src: (必須)、プロジェクト ディレクトリを基準にして、イメ
 次の構成は、すべてのプラットフォーム用に使用される 1 つの既定のアイコンを定義する使用できます。
 
         <icon src="res/icon.png" />
-    
+
 
 プラットフォームごとに異なる画面解像度に合わせてピクセル パーフェクトなアイコンも定義できます。
 
 アマゾン火 OS
 
          <platform name="amazon-fireos">
-                  <icon src="res/android/ldpi.png" density="ldpi" />
-                  <icon src="res/android/mdpi.png" density="mdpi" />
-                  <icon src="res/android/hdpi.png" density="hdpi" />
-                  <icon src="res/android/xhdpi.png" density="xhdpi" />
+                  <icon src="res/android/ldpi.png" qualifier="ldpi" />
+                  <icon src="res/android/mdpi.png" qualifier="mdpi" />
+                  <icon src="res/android/hdpi.png" qualifier="hdpi" />
+                  <icon src="res/android/xhdpi.png" qualifier="xhdpi" />
          </platform>
-    
+
 
 アンドロイド
 
          <platform name="android">
-                  <icon src="res/android/ldpi.png" density="ldpi" />
-                  <icon src="res/android/mdpi.png" density="mdpi" />
-                  <icon src="res/android/hdpi.png" density="hdpi" />
-                  <icon src="res/android/xhdpi.png" density="xhdpi" />
+                  <icon src="res/android/ldpi.png" qualifier="ldpi" />
+                  <icon src="res/android/mdpi.png" qualifier="mdpi" />
+                  <icon src="res/android/hdpi.png" qualifier="hdpi" />
+                  <icon src="res/android/xhdpi.png" qualifier="xhdpi" />
          </platform>
-    
+
 
 BlackBerry10
 
@@ -75,7 +75,7 @@ BlackBerry10
                   <icon src="res/bb10/icon-86.png" />
                   <icon src="res/bb10/icon-150.png" />
          </platform>
-    
+
 
 複数のサイズとロケールのブラックベリーのマニュアルを参照してください。[http://developer.blackberry.com/html5/documentation/icon_element.html]
 
@@ -84,7 +84,7 @@ Firefox の OS
          <platform name="firefoxos">
                   <icon src="res/ff/logo.png" width="60" height="60" />
          </platform>
-    
+
 
 iOS
 
@@ -116,14 +116,14 @@ iOS
                   <icon src="res/ios/icon-50.png" width="50" height="50" />
                   <icon src="res/ios/icon-50@2x.png" width="100" height="100" />
          </platform>
-    
+
 
 Tizen
 
          <platform name="tizen">
                   <icon src="res/tizen/icon-128.png" width="128" height="128" />
          </platform>
-    
+
 
 Windows Phone8
 
@@ -132,7 +132,7 @@ Windows Phone8
                   <!-- tile image -->
                   <icon src="res/wp/Background.png" width="159" height="159" />
          </platform>
-    
+
 
 Windows8
 
@@ -141,7 +141,7 @@ Windows8
                   <icon src="res/windows8/smalllogo.png" width="30" height="30" />
                   <icon src="res/windows8/storelogo.png" width="50" height="50" />
          </platform>
-    
+
 
 ## CLI でスプラッシュ スクリーンを構成します。
 
@@ -152,18 +152,18 @@ Windows8
 "Src"属性の値は、プロジェクト ディレクトリからの相対ではなく、www ディレクトリに注意してください。 どのようにソース イメージ名前ことができます。 アプリの内部名はコルドバによって決定されます。
 
     <platform name="android">
-        <!-- you can use any density that exists in the Android project -->
-        <splash src="res/screen/android/splash-land-hdpi.png" density="land-hdpi"/>
-        <splash src="res/screen/android/splash-land-ldpi.png" density="land-ldpi"/>
-        <splash src="res/screen/android/splash-land-mdpi.png" density="land-mdpi"/>
-        <splash src="res/screen/android/splash-land-xhdpi.png" density="land-xhdpi"/>
-    
-        <splash src="res/screen/android/splash-port-hdpi.png" density="port-hdpi"/>
-        <splash src="res/screen/android/splash-port-ldpi.png" density="port-ldpi"/>
-        <splash src="res/screen/android/splash-port-mdpi.png" density="port-mdpi"/>
-        <splash src="res/screen/android/splash-port-xhdpi.png" density="port-xhdpi"/>
+        <!-- you can use any qualifier that exists in the Android project -->
+        <splash src="res/screen/android/splash-land-hdpi.png" qualifier="land-hdpi"/>
+        <splash src="res/screen/android/splash-land-ldpi.png" qualifier="land-ldpi"/>
+        <splash src="res/screen/android/splash-land-mdpi.png" qualifier="land-mdpi"/>
+        <splash src="res/screen/android/splash-land-xhdpi.png" qualifier="land-xhdpi"/>
+
+        <splash src="res/screen/android/splash-port-hdpi.png" qualifier="port-hdpi"/>
+        <splash src="res/screen/android/splash-port-ldpi.png" qualifier="port-ldpi"/>
+        <splash src="res/screen/android/splash-port-mdpi.png" qualifier="port-mdpi"/>
+        <splash src="res/screen/android/splash-port-xhdpi.png" qualifier="port-xhdpi"/>
     </platform>
-    
+
     <platform name="ios">
         <!-- images are determined by width and height. The following are supported -->
         <splash src="res/screen/ios/Default~iphone.png" width="320" height="480"/>
@@ -177,26 +177,26 @@ Windows8
         <splash src="res/screen/ios/Default-736h.png" width="1242" height="2208"/>
         <splash src="res/screen/ios/Default-Landscape-736h.png" width="2208" height="1242"/>
     </platform>
-    
+
     <platform name="wp8">
         <!-- images are determined by width and height. The following are supported -->
         <splash src="res/screen/wp8/SplashScreenImage.jpg" width="768" height="1280"/>
     </platform>
-    
+
     <platform name="windows8">
         <!-- images are determined by width and height. The following are supported -->
         <splash src="res/screen/windows8/splashscreen.png" width="620" height="300"/>
     </platform>
-    
+
     <platform name="blackberry10">
         <!-- Add a rim:splash element for each resolution and locale you wish -->
         <!-- http://developer.blackberry.com/html5/documentation/rim_splash_element.html -->
         <rim:splash src="res/screen/windows8/splashscreen.png"/>
     </platform>
-    
-    
+
+
     <preference name="SplashScreenDelay" value="10000" />
-    
+
 
 # サポートされているプラットフォーム
 
@@ -207,7 +207,7 @@ Windows8
     wp8
     windows8
     blackberry10
-    
+
 
 # Splashscreen プラグイン
 

--- a/www/docs/ko/7.x/config_ref/images.md
+++ b/www/docs/ko/7.x/config_ref/images.md
@@ -29,8 +29,8 @@ toc_title: Customize icons
 
 CLI에서 근무를 통해 애플 리 케이 션 아이콘을 정의할 수 있습니다 때 `<icon>` 요소 ( `config.xml` ). 아이콘을 지정 하지 않으면 아파치 코르도바 로고 사용 됩니다.
 
-        <icon src="res/ios/icon.png" platform="ios" width="57" height="57" density="mdpi" />
-    
+        <icon src="res/ios/icon.png" platform="ios" width="57" height="57" qualifier="mdpi" />
+
 
 src: (필수) 이미지 파일을 프로젝트 디렉터리에 상대적인 위치를 지정 합니다
 
@@ -45,29 +45,29 @@ src: (필수) 이미지 파일을 프로젝트 디렉터리에 상대적인 위�
 다음 구성은 모든 플랫폼에 사용할 수 있는 단일 기본 아이콘을 정의 하기 위해 사용할 수 있습니다.
 
         <icon src="res/icon.png" />
-    
+
 
 각 플랫폼에 대해 다른 화면 해상도 맞게 설정 픽셀 완벽 한 아이콘을 정의할 수 있습니다.
 
 아마존 화재 운영 체제
 
          <platform name="amazon-fireos">
-                  <icon src="res/android/ldpi.png" density="ldpi" />
-                  <icon src="res/android/mdpi.png" density="mdpi" />
-                  <icon src="res/android/hdpi.png" density="hdpi" />
-                  <icon src="res/android/xhdpi.png" density="xhdpi" />
+                  <icon src="res/android/ldpi.png" qualifier="ldpi" />
+                  <icon src="res/android/mdpi.png" qualifier="mdpi" />
+                  <icon src="res/android/hdpi.png" qualifier="hdpi" />
+                  <icon src="res/android/xhdpi.png" qualifier="xhdpi" />
          </platform>
-    
+
 
 안 드 로이드
 
          <platform name="android">
-                  <icon src="res/android/ldpi.png" density="ldpi" />
-                  <icon src="res/android/mdpi.png" density="mdpi" />
-                  <icon src="res/android/hdpi.png" density="hdpi" />
-                  <icon src="res/android/xhdpi.png" density="xhdpi" />
+                  <icon src="res/android/ldpi.png" qualifier="ldpi" />
+                  <icon src="res/android/mdpi.png" qualifier="mdpi" />
+                  <icon src="res/android/hdpi.png" qualifier="hdpi" />
+                  <icon src="res/android/xhdpi.png" qualifier="xhdpi" />
          </platform>
-    
+
 
 BlackBerry10
 
@@ -75,7 +75,7 @@ BlackBerry10
                   <icon src="res/bb10/icon-86.png" />
                   <icon src="res/bb10/icon-150.png" />
          </platform>
-    
+
 
 여러 크기 및 로케일을 타겟팅에 대 한 블랙베리의 설명서를 참조 하십시오. [http://developer.blackberry.com/html5/documentation/icon_element.html]
 
@@ -84,7 +84,7 @@ Firefox 운영 체제
          <platform name="firefoxos">
                   <icon src="res/ff/logo.png" width="60" height="60" />
          </platform>
-    
+
 
 iOS
 
@@ -116,14 +116,14 @@ iOS
                   <icon src="res/ios/icon-50.png" width="50" height="50" />
                   <icon src="res/ios/icon-50@2x.png" width="100" height="100" />
          </platform>
-    
+
 
 Tizen
 
          <platform name="tizen">
                   <icon src="res/tizen/icon-128.png" width="128" height="128" />
          </platform>
-    
+
 
 윈도우 Phone8
 
@@ -132,7 +132,7 @@ Tizen
                   <!-- tile image -->
                   <icon src="res/wp/Background.png" width="159" height="159" />
          </platform>
-    
+
 
 Windows8
 
@@ -141,7 +141,7 @@ Windows8
                   <icon src="res/windows8/smalllogo.png" width="30" height="30" />
                   <icon src="res/windows8/storelogo.png" width="50" height="50" />
          </platform>
-    
+
 
 ## CLI에서 시작 화면을 구성
 
@@ -152,18 +152,18 @@ Windows8
 "Src" 특성의 값은 프로젝트 디렉터리를 기준으로 그리고 www 디렉토리를 주의 하십시오. 원하는 소스 이미지 이름을 지정할 수 있습니다. 응용 프로그램에서 내부 이름은 코르도바에 의해 결정 됩니다.
 
     <platform name="android">
-        <!-- you can use any density that exists in the Android project -->
-        <splash src="res/screen/android/splash-land-hdpi.png" density="land-hdpi"/>
-        <splash src="res/screen/android/splash-land-ldpi.png" density="land-ldpi"/>
-        <splash src="res/screen/android/splash-land-mdpi.png" density="land-mdpi"/>
-        <splash src="res/screen/android/splash-land-xhdpi.png" density="land-xhdpi"/>
-    
-        <splash src="res/screen/android/splash-port-hdpi.png" density="port-hdpi"/>
-        <splash src="res/screen/android/splash-port-ldpi.png" density="port-ldpi"/>
-        <splash src="res/screen/android/splash-port-mdpi.png" density="port-mdpi"/>
-        <splash src="res/screen/android/splash-port-xhdpi.png" density="port-xhdpi"/>
+        <!-- you can use any qualifier that exists in the Android project -->
+        <splash src="res/screen/android/splash-land-hdpi.png" qualifier="land-hdpi"/>
+        <splash src="res/screen/android/splash-land-ldpi.png" qualifier="land-ldpi"/>
+        <splash src="res/screen/android/splash-land-mdpi.png" qualifier="land-mdpi"/>
+        <splash src="res/screen/android/splash-land-xhdpi.png" qualifier="land-xhdpi"/>
+
+        <splash src="res/screen/android/splash-port-hdpi.png" qualifier="port-hdpi"/>
+        <splash src="res/screen/android/splash-port-ldpi.png" qualifier="port-ldpi"/>
+        <splash src="res/screen/android/splash-port-mdpi.png" qualifier="port-mdpi"/>
+        <splash src="res/screen/android/splash-port-xhdpi.png" qualifier="port-xhdpi"/>
     </platform>
-    
+
     <platform name="ios">
         <!-- images are determined by width and height. The following are supported -->
         <splash src="res/screen/ios/Default~iphone.png" width="320" height="480"/>
@@ -177,26 +177,26 @@ Windows8
         <splash src="res/screen/ios/Default-736h.png" width="1242" height="2208"/>
         <splash src="res/screen/ios/Default-Landscape-736h.png" width="2208" height="1242"/>
     </platform>
-    
+
     <platform name="wp8">
         <!-- images are determined by width and height. The following are supported -->
         <splash src="res/screen/wp8/SplashScreenImage.jpg" width="768" height="1280"/>
     </platform>
-    
+
     <platform name="windows8">
         <!-- images are determined by width and height. The following are supported -->
         <splash src="res/screen/windows8/splashscreen.png" width="620" height="300"/>
     </platform>
-    
+
     <platform name="blackberry10">
         <!-- Add a rim:splash element for each resolution and locale you wish -->
         <!-- http://developer.blackberry.com/html5/documentation/rim_splash_element.html -->
         <rim:splash src="res/screen/windows8/splashscreen.png"/>
     </platform>
-    
-    
+
+
     <preference name="SplashScreenDelay" value="10000" />
-    
+
 
 # 지원 되는 플랫폼
 
@@ -207,7 +207,7 @@ Windows8
     wp8
     windows8
     blackberry10
-    
+
 
 # Splashscreen 플러그인
 

--- a/www/docs/pl/7.x/config_ref/images.md
+++ b/www/docs/pl/7.x/config_ref/images.md
@@ -29,8 +29,8 @@ Ta sekcja pokazuje jak skonfigurować ikonę aplikacji i opcjonalne opryskać t�
 
 Kiedy pracuje w consoli można zdefiniować ikona aplikacji przez `<icon>` elementu ( `config.xml` ). Jeśli nie określisz ikona logo Apache Cordova jest używany.
 
-        <icon src="res/ios/icon.png" platform="ios" width="57" height="57" density="mdpi" />
-    
+        <icon src="res/ios/icon.png" platform="ios" width="57" height="57" qualifier="mdpi" />
+
 
 src: (wymagane) określa lokalizację pliku obrazu, do katalogu projektu
 
@@ -45,29 +45,29 @@ gęstość: (opcjonalne) android specyficzne, określa gęstość ikona
 Następująca konfiguracja może służyć do określenia jednej domyślnej ikony, która będzie używana dla wszystkich platform.
 
         <icon src="res/icon.png" />
-    
+
 
 Dla każdej platformy, można również zdefiniować ikony idealny zestaw do różnych rozdzielczościach ekranu.
 
 Amazon Fire OS
 
          <platform name="amazon-fireos">
-                  <icon src="res/android/ldpi.png" density="ldpi" />
-                  <icon src="res/android/mdpi.png" density="mdpi" />
-                  <icon src="res/android/hdpi.png" density="hdpi" />
-                  <icon src="res/android/xhdpi.png" density="xhdpi" />
+                  <icon src="res/android/ldpi.png" qualifier="ldpi" />
+                  <icon src="res/android/mdpi.png" qualifier="mdpi" />
+                  <icon src="res/android/hdpi.png" qualifier="hdpi" />
+                  <icon src="res/android/xhdpi.png" qualifier="xhdpi" />
          </platform>
-    
+
 
 Android
 
          <platform name="android">
-                  <icon src="res/android/ldpi.png" density="ldpi" />
-                  <icon src="res/android/mdpi.png" density="mdpi" />
-                  <icon src="res/android/hdpi.png" density="hdpi" />
-                  <icon src="res/android/xhdpi.png" density="xhdpi" />
+                  <icon src="res/android/ldpi.png" qualifier="ldpi" />
+                  <icon src="res/android/mdpi.png" qualifier="mdpi" />
+                  <icon src="res/android/hdpi.png" qualifier="hdpi" />
+                  <icon src="res/android/xhdpi.png" qualifier="xhdpi" />
          </platform>
-    
+
 
 BlackBerry10
 
@@ -75,7 +75,7 @@ BlackBerry10
                   <icon src="res/bb10/icon-86.png" />
                   <icon src="res/bb10/icon-150.png" />
          </platform>
-    
+
 
 Dokumentacji BlackBerry do kierowania w wielu rozmiarach i ustawień regionalnych. [http://developer.blackberry.com/html5/documentation/icon_element.html]
 
@@ -84,7 +84,7 @@ Firefox OS
          <platform name="firefoxos">
                   <icon src="res/ff/logo.png" width="60" height="60" />
          </platform>
-    
+
 
 iOS
 
@@ -116,14 +116,14 @@ iOS
                   <icon src="res/ios/icon-50.png" width="50" height="50" />
                   <icon src="res/ios/icon-50@2x.png" width="100" height="100" />
          </platform>
-    
+
 
 Tizen
 
          <platform name="tizen">
                   <icon src="res/tizen/icon-128.png" width="128" height="128" />
          </platform>
-    
+
 
 Phone8 systemu Windows
 
@@ -132,7 +132,7 @@ Phone8 systemu Windows
                   <!-- tile image -->
                   <icon src="res/wp/Background.png" width="159" height="159" />
          </platform>
-    
+
 
 Windows8
 
@@ -141,7 +141,7 @@ Windows8
                   <icon src="res/windows8/smalllogo.png" width="30" height="30" />
                   <icon src="res/windows8/storelogo.png" width="50" height="50" />
          </platform>
-    
+
 
 ## Konfigurowanie ekrany powitalne w aplikacjach w consoli
 
@@ -152,18 +152,18 @@ W najwyższego poziomu `config.xml` pliku (nie ten w `platforms` ), dodać eleme
 Proszę zauważyć, że wartość atrybutu "src" jest katalogiem projektu, a nie do katalogu www. Możesz wymienić obrazu źródłowego cokolwiek chcesz. Nazwa wewnętrzna w aplikacji są określane przez Cordova.
 
     <platform name="android">
-        <!-- you can use any density that exists in the Android project -->
-        <splash src="res/screen/android/splash-land-hdpi.png" density="land-hdpi"/>
-        <splash src="res/screen/android/splash-land-ldpi.png" density="land-ldpi"/>
-        <splash src="res/screen/android/splash-land-mdpi.png" density="land-mdpi"/>
-        <splash src="res/screen/android/splash-land-xhdpi.png" density="land-xhdpi"/>
-    
-        <splash src="res/screen/android/splash-port-hdpi.png" density="port-hdpi"/>
-        <splash src="res/screen/android/splash-port-ldpi.png" density="port-ldpi"/>
-        <splash src="res/screen/android/splash-port-mdpi.png" density="port-mdpi"/>
-        <splash src="res/screen/android/splash-port-xhdpi.png" density="port-xhdpi"/>
+        <!-- you can use any qualifier that exists in the Android project -->
+        <splash src="res/screen/android/splash-land-hdpi.png" qualifier="land-hdpi"/>
+        <splash src="res/screen/android/splash-land-ldpi.png" qualifier="land-ldpi"/>
+        <splash src="res/screen/android/splash-land-mdpi.png" qualifier="land-mdpi"/>
+        <splash src="res/screen/android/splash-land-xhdpi.png" qualifier="land-xhdpi"/>
+
+        <splash src="res/screen/android/splash-port-hdpi.png" qualifier="port-hdpi"/>
+        <splash src="res/screen/android/splash-port-ldpi.png" qualifier="port-ldpi"/>
+        <splash src="res/screen/android/splash-port-mdpi.png" qualifier="port-mdpi"/>
+        <splash src="res/screen/android/splash-port-xhdpi.png" qualifier="port-xhdpi"/>
     </platform>
-    
+
     <platform name="ios">
         <!-- images are determined by width and height. The following are supported -->
         <splash src="res/screen/ios/Default~iphone.png" width="320" height="480"/>
@@ -177,26 +177,26 @@ Proszę zauważyć, że wartość atrybutu "src" jest katalogiem projektu, a nie
         <splash src="res/screen/ios/Default-736h.png" width="1242" height="2208"/>
         <splash src="res/screen/ios/Default-Landscape-736h.png" width="2208" height="1242"/>
     </platform>
-    
+
     <platform name="wp8">
         <!-- images are determined by width and height. The following are supported -->
         <splash src="res/screen/wp8/SplashScreenImage.jpg" width="768" height="1280"/>
     </platform>
-    
+
     <platform name="windows8">
         <!-- images are determined by width and height. The following are supported -->
         <splash src="res/screen/windows8/splashscreen.png" width="620" height="300"/>
     </platform>
-    
+
     <platform name="blackberry10">
         <!-- Add a rim:splash element for each resolution and locale you wish -->
         <!-- http://developer.blackberry.com/html5/documentation/rim_splash_element.html -->
         <rim:splash src="res/screen/windows8/splashscreen.png"/>
     </platform>
-    
-    
+
+
     <preference name="SplashScreenDelay" value="10000" />
-    
+
 
 # Obsługiwane platformy
 
@@ -207,7 +207,7 @@ W chwili obecnej (Cordova 3.5.0 lipca 2014 roku) następujących platformach obs
     wp8
     windows8
     blackberry10
-    
+
 
 # Plugin ekranu powitalnego
 

--- a/www/docs/ru/7.x/config_ref/images.md
+++ b/www/docs/ru/7.x/config_ref/images.md
@@ -29,8 +29,8 @@ toc_title: Customize icons
 
 При работе в CLI можно определить icon(s) app через элемент `<icon>` (`config.xml`). Если значок не задан, то используется логотип Apache Cordova.
 
-        <icon src="res/ios/icon.png" platform="ios" width="57" height="57" density="mdpi" />
-    
+        <icon src="res/ios/icon.png" platform="ios" width="57" height="57" qualifier="mdpi" />
+
 
 src: (обязательный) указывает расположение файла с изображением, относительно каталога проекта
 
@@ -40,34 +40,34 @@ width: (необязательно) ширина иконки в пикселя�
 
 height: (необязательно) высота иконки в пикселях
 
-density: (опционально) Только для android, указывает плотность пикселей для иконки
+qualifier: (опционально) Только для android, указывает плотность пикселей для иконки
 
 Следующая конфигурация может использоваться для определения одной иконки по умолчанию, которая будет использоваться для всех платформ.
 
         <icon src="res/icon.png" />
-    
+
 
 Для каждой платформы можно также определить подобранные с точностью до пикселя значки, заданные для различных разрешений экрана.
 
 Amazon Fire OS
 
          <platform name="amazon-fireos">
-                  <icon src="res/android/ldpi.png" density="ldpi" />
-                  <icon src="res/android/mdpi.png" density="mdpi" />
-                  <icon src="res/android/hdpi.png" density="hdpi" />
-                  <icon src="res/android/xhdpi.png" density="xhdpi" />
+                  <icon src="res/android/ldpi.png" qualifier="ldpi" />
+                  <icon src="res/android/mdpi.png" qualifier="mdpi" />
+                  <icon src="res/android/hdpi.png" qualifier="hdpi" />
+                  <icon src="res/android/xhdpi.png" qualifier="xhdpi" />
          </platform>
-    
+
 
 Android
 
          <platform name="android">
-                  <icon src="res/android/ldpi.png" density="ldpi" />
-                  <icon src="res/android/mdpi.png" density="mdpi" />
-                  <icon src="res/android/hdpi.png" density="hdpi" />
-                  <icon src="res/android/xhdpi.png" density="xhdpi" />
+                  <icon src="res/android/ldpi.png" qualifier="ldpi" />
+                  <icon src="res/android/mdpi.png" qualifier="mdpi" />
+                  <icon src="res/android/hdpi.png" qualifier="hdpi" />
+                  <icon src="res/android/xhdpi.png" qualifier="xhdpi" />
          </platform>
-    
+
 
 BlackBerry10
 
@@ -75,7 +75,7 @@ BlackBerry10
                   <icon src="res/bb10/icon-86.png" />
                   <icon src="res/bb10/icon-150.png" />
          </platform>
-    
+
 
 Смотрите документацию BlackBerry при ориентировании на набор различных размеров и языков. [http://developer.blackberry.com/html5/documentation/icon_element.html]
 
@@ -84,7 +84,7 @@ Firefox OS
          <platform name="firefoxos">
                   <icon src="res/ff/logo.png" width="60" height="60" />
          </platform>
-    
+
 
 iOS
 
@@ -116,14 +116,14 @@ iOS
                   <icon src="res/ios/icon-50.png" width="50" height="50" />
                   <icon src="res/ios/icon-50@2x.png" width="100" height="100" />
          </platform>
-    
+
 
 Tizen
 
          <platform name="tizen">
                   <icon src="res/tizen/icon-128.png" width="128" height="128" />
          </platform>
-    
+
 
 Windows Phone8
 
@@ -132,7 +132,7 @@ Windows Phone8
                   <!-- tile image -->
                   <icon src="res/wp/Background.png" width="159" height="159" />
          </platform>
-    
+
 
 Windows8
 
@@ -141,7 +141,7 @@ Windows8
                   <icon src="res/windows8/smalllogo.png" width="30" height="30" />
                   <icon src="res/windows8/storelogo.png" width="50" height="50" />
          </platform>
-    
+
 
 ## Настройка заставки с помощью CLI
 
@@ -152,18 +152,18 @@ Windows8
 Пожалуйста, обратите внимание, что значение атрибута "src" определяется относительно каталога проекта, а не относительно каталога www. Вы можете называть файл исходного изображения как угодно. Внутреннее имя в приложении определяется Cordova.
 
     <platform name="android">
-        <!-- you can use any density that exists in the Android project -->
-        <splash src="res/screen/android/splash-land-hdpi.png" density="land-hdpi"/>
-        <splash src="res/screen/android/splash-land-ldpi.png" density="land-ldpi"/>
-        <splash src="res/screen/android/splash-land-mdpi.png" density="land-mdpi"/>
-        <splash src="res/screen/android/splash-land-xhdpi.png" density="land-xhdpi"/>
-    
-        <splash src="res/screen/android/splash-port-hdpi.png" density="port-hdpi"/>
-        <splash src="res/screen/android/splash-port-ldpi.png" density="port-ldpi"/>
-        <splash src="res/screen/android/splash-port-mdpi.png" density="port-mdpi"/>
-        <splash src="res/screen/android/splash-port-xhdpi.png" density="port-xhdpi"/>
+        <!-- you can use any qualifier that exists in the Android project -->
+        <splash src="res/screen/android/splash-land-hdpi.png" qualifier="land-hdpi"/>
+        <splash src="res/screen/android/splash-land-ldpi.png" qualifier="land-ldpi"/>
+        <splash src="res/screen/android/splash-land-mdpi.png" qualifier="land-mdpi"/>
+        <splash src="res/screen/android/splash-land-xhdpi.png" qualifier="land-xhdpi"/>
+
+        <splash src="res/screen/android/splash-port-hdpi.png" qualifier="port-hdpi"/>
+        <splash src="res/screen/android/splash-port-ldpi.png" qualifier="port-ldpi"/>
+        <splash src="res/screen/android/splash-port-mdpi.png" qualifier="port-mdpi"/>
+        <splash src="res/screen/android/splash-port-xhdpi.png" qualifier="port-xhdpi"/>
     </platform>
-    
+
     <platform name="ios">
         <!-- images are determined by width and height. The following are supported -->
         <splash src="res/screen/ios/Default~iphone.png" width="320" height="480"/>
@@ -177,26 +177,26 @@ Windows8
         <splash src="res/screen/ios/Default-736h.png" width="1242" height="2208"/>
         <splash src="res/screen/ios/Default-Landscape-736h.png" width="2208" height="1242"/>
     </platform>
-    
+
     <platform name="wp8">
         <!-- images are determined by width and height. The following are supported -->
         <splash src="res/screen/wp8/SplashScreenImage.jpg" width="768" height="1280"/>
     </platform>
-    
+
     <platform name="windows8">
         <!-- images are determined by width and height. The following are supported -->
         <splash src="res/screen/windows8/splashscreen.png" width="620" height="300"/>
     </platform>
-    
+
     <platform name="blackberry10">
         <!-- Add a rim:splash element for each resolution and locale you wish -->
         <!-- http://developer.blackberry.com/html5/documentation/rim_splash_element.html -->
         <rim:splash src="res/screen/windows8/splashscreen.png"/>
     </platform>
-    
-    
+
+
     <preference name="SplashScreenDelay" value="10000" />
-    
+
 
 # Поддерживаемые платформы
 
@@ -207,7 +207,7 @@ Windows8
     wp8
     windows8
     blackberry10
-    
+
 
 # Плагин SplashScreen
 

--- a/www/docs/zh-cn/7.x/config_ref/images.md
+++ b/www/docs/zh-cn/7.x/config_ref/images.md
@@ -29,8 +29,8 @@ toc_title: Customize icons
 
 當工作在 CLI 中你可以定義應用程式圖示通過 `<icon>` 元素 （ `config.xml` ）。如果你不指定一個圖示然後使用 Apache 科爾多瓦徽標。
 
-        <icon src="res/ios/icon.png" platform="ios" width="57" height="57" density="mdpi" />
-    
+        <icon src="res/ios/icon.png" platform="ios" width="57" height="57" qualifier="mdpi" />
+
 
 src： （必填） 指定的影像檔，與您的專案目錄的位置
 
@@ -45,29 +45,29 @@ src： （必填） 指定的影像檔，與您的專案目錄的位置
 下面的配置可以用於定義單個預設圖示，將用於所有平臺。
 
         <icon src="res/icon.png" />
-    
+
 
 為每個平臺還可以定義設置以適合不同的螢幕解析度圖元完美圖示。
 
 亞馬遜火 OS
 
          <platform name="amazon-fireos">
-                  <icon src="res/android/ldpi.png" density="ldpi" />
-                  <icon src="res/android/mdpi.png" density="mdpi" />
-                  <icon src="res/android/hdpi.png" density="hdpi" />
-                  <icon src="res/android/xhdpi.png" density="xhdpi" />
+                  <icon src="res/android/ldpi.png" qualifier="ldpi" />
+                  <icon src="res/android/mdpi.png" qualifier="mdpi" />
+                  <icon src="res/android/hdpi.png" qualifier="hdpi" />
+                  <icon src="res/android/xhdpi.png" qualifier="xhdpi" />
          </platform>
-    
+
 
 Android 系統
 
          <platform name="android">
-                  <icon src="res/android/ldpi.png" density="ldpi" />
-                  <icon src="res/android/mdpi.png" density="mdpi" />
-                  <icon src="res/android/hdpi.png" density="hdpi" />
-                  <icon src="res/android/xhdpi.png" density="xhdpi" />
+                  <icon src="res/android/ldpi.png" qualifier="ldpi" />
+                  <icon src="res/android/mdpi.png" qualifier="mdpi" />
+                  <icon src="res/android/hdpi.png" qualifier="hdpi" />
+                  <icon src="res/android/xhdpi.png" qualifier="xhdpi" />
          </platform>
-    
+
 
 BlackBerry10
 
@@ -75,7 +75,7 @@ BlackBerry10
                   <icon src="res/bb10/icon-86.png" />
                   <icon src="res/bb10/icon-150.png" />
          </platform>
-    
+
 
 請參閱針對多個大小和地區設定黑莓的文檔。[] HTTP://developer.blackberry.com/html5/documentation/icon_element.html
 
@@ -84,7 +84,7 @@ BlackBerry10
          <platform name="firefoxos">
                   <icon src="res/ff/logo.png" width="60" height="60" />
          </platform>
-    
+
 
 iOS
 
@@ -116,14 +116,14 @@ iOS
                   <icon src="res/ios/icon-50.png" width="50" height="50" />
                   <icon src="res/ios/icon-50@2x.png" width="100" height="100" />
          </platform>
-    
+
 
 Tizen
 
          <platform name="tizen">
                   <icon src="res/tizen/icon-128.png" width="128" height="128" />
          </platform>
-    
+
 
 Windows Phone8
 
@@ -132,7 +132,7 @@ Windows Phone8
                   <!-- tile image -->
                   <icon src="res/wp/Background.png" width="159" height="159" />
          </platform>
-    
+
 
 Windows8
 
@@ -141,7 +141,7 @@ Windows8
                   <icon src="res/windows8/smalllogo.png" width="30" height="30" />
                   <icon src="res/windows8/storelogo.png" width="50" height="50" />
          </platform>
-    
+
 
 ## 在 CLI 中配置初始螢幕
 
@@ -152,18 +152,18 @@ Windows8
 請注意"src"屬性的值是相對於專案目錄而不是 www 目錄。 你可以命名源映射任何你喜歡的。 在應用程式中的內部名稱取決於科爾多瓦。
 
     <platform name="android">
-        <!-- you can use any density that exists in the Android project -->
-        <splash src="res/screen/android/splash-land-hdpi.png" density="land-hdpi"/>
-        <splash src="res/screen/android/splash-land-ldpi.png" density="land-ldpi"/>
-        <splash src="res/screen/android/splash-land-mdpi.png" density="land-mdpi"/>
-        <splash src="res/screen/android/splash-land-xhdpi.png" density="land-xhdpi"/>
-    
-        <splash src="res/screen/android/splash-port-hdpi.png" density="port-hdpi"/>
-        <splash src="res/screen/android/splash-port-ldpi.png" density="port-ldpi"/>
-        <splash src="res/screen/android/splash-port-mdpi.png" density="port-mdpi"/>
-        <splash src="res/screen/android/splash-port-xhdpi.png" density="port-xhdpi"/>
+        <!-- you can use any qualifier that exists in the Android project -->
+        <splash src="res/screen/android/splash-land-hdpi.png" qualifier="land-hdpi"/>
+        <splash src="res/screen/android/splash-land-ldpi.png" qualifier="land-ldpi"/>
+        <splash src="res/screen/android/splash-land-mdpi.png" qualifier="land-mdpi"/>
+        <splash src="res/screen/android/splash-land-xhdpi.png" qualifier="land-xhdpi"/>
+
+        <splash src="res/screen/android/splash-port-hdpi.png" qualifier="port-hdpi"/>
+        <splash src="res/screen/android/splash-port-ldpi.png" qualifier="port-ldpi"/>
+        <splash src="res/screen/android/splash-port-mdpi.png" qualifier="port-mdpi"/>
+        <splash src="res/screen/android/splash-port-xhdpi.png" qualifier="port-xhdpi"/>
     </platform>
-    
+
     <platform name="ios">
         <!-- images are determined by width and height. The following are supported -->
         <splash src="res/screen/ios/Default~iphone.png" width="320" height="480"/>
@@ -177,26 +177,26 @@ Windows8
         <splash src="res/screen/ios/Default-736h.png" width="1242" height="2208"/>
         <splash src="res/screen/ios/Default-Landscape-736h.png" width="2208" height="1242"/>
     </platform>
-    
+
     <platform name="wp8">
         <!-- images are determined by width and height. The following are supported -->
         <splash src="res/screen/wp8/SplashScreenImage.jpg" width="768" height="1280"/>
     </platform>
-    
+
     <platform name="windows8">
         <!-- images are determined by width and height. The following are supported -->
         <splash src="res/screen/windows8/splashscreen.png" width="620" height="300"/>
     </platform>
-    
+
     <platform name="blackberry10">
         <!-- Add a rim:splash element for each resolution and locale you wish -->
         <!-- http://developer.blackberry.com/html5/documentation/rim_splash_element.html -->
         <rim:splash src="res/screen/windows8/splashscreen.png"/>
     </platform>
-    
-    
+
+
     <preference name="SplashScreenDelay" value="10000" />
-    
+
 
 # 支援的平臺
 
@@ -207,7 +207,7 @@ Windows8
     wp8
     windows8
     blackberry10
-    
+
 
 # 閃屏外掛程式
 

--- a/www/docs/zh-tw/7.x/config_ref/images.md
+++ b/www/docs/zh-tw/7.x/config_ref/images.md
@@ -29,8 +29,8 @@ toc_title: Customize icons
 
 當工作在 CLI 中你可以定義應用程式圖示通過 `<icon>` 元素 （ `config.xml` ）。如果你不指定一個圖示然後使用 Apache 科爾多瓦徽標。
 
-        <icon src="res/ios/icon.png" platform="ios" width="57" height="57" density="mdpi" />
-    
+        <icon src="res/ios/icon.png" platform="ios" width="57" height="57" qualifier="mdpi" />
+
 
 src： （必填） 指定的影像檔，與您的專案目錄的位置
 
@@ -45,29 +45,29 @@ src： （必填） 指定的影像檔，與您的專案目錄的位置
 下面的配置可以用於定義單個預設圖示，將用於所有平臺。
 
         <icon src="res/icon.png" />
-    
+
 
 為每個平臺還可以定義設置以適合不同的螢幕解析度圖元完美圖示。
 
 亞馬遜火 OS
 
          <platform name="amazon-fireos">
-                  <icon src="res/android/ldpi.png" density="ldpi" />
-                  <icon src="res/android/mdpi.png" density="mdpi" />
-                  <icon src="res/android/hdpi.png" density="hdpi" />
-                  <icon src="res/android/xhdpi.png" density="xhdpi" />
+                  <icon src="res/android/ldpi.png" qualifier="ldpi" />
+                  <icon src="res/android/mdpi.png" qualifier="mdpi" />
+                  <icon src="res/android/hdpi.png" qualifier="hdpi" />
+                  <icon src="res/android/xhdpi.png" qualifier="xhdpi" />
          </platform>
-    
+
 
 Android 系統
 
          <platform name="android">
-                  <icon src="res/android/ldpi.png" density="ldpi" />
-                  <icon src="res/android/mdpi.png" density="mdpi" />
-                  <icon src="res/android/hdpi.png" density="hdpi" />
-                  <icon src="res/android/xhdpi.png" density="xhdpi" />
+                  <icon src="res/android/ldpi.png" qualifier="ldpi" />
+                  <icon src="res/android/mdpi.png" qualifier="mdpi" />
+                  <icon src="res/android/hdpi.png" qualifier="hdpi" />
+                  <icon src="res/android/xhdpi.png" qualifier="xhdpi" />
          </platform>
-    
+
 
 BlackBerry10
 
@@ -75,7 +75,7 @@ BlackBerry10
                   <icon src="res/bb10/icon-86.png" />
                   <icon src="res/bb10/icon-150.png" />
          </platform>
-    
+
 
 請參閱針對多個大小和地區設定黑莓的文檔。[] HTTP://developer.blackberry.com/html5/documentation/icon_element.html
 
@@ -84,7 +84,7 @@ BlackBerry10
          <platform name="firefoxos">
                   <icon src="res/ff/logo.png" width="60" height="60" />
          </platform>
-    
+
 
 iOS
 
@@ -116,14 +116,14 @@ iOS
                   <icon src="res/ios/icon-50.png" width="50" height="50" />
                   <icon src="res/ios/icon-50@2x.png" width="100" height="100" />
          </platform>
-    
+
 
 Tizen
 
          <platform name="tizen">
                   <icon src="res/tizen/icon-128.png" width="128" height="128" />
          </platform>
-    
+
 
 Windows Phone8
 
@@ -132,7 +132,7 @@ Windows Phone8
                   <!-- tile image -->
                   <icon src="res/wp/Background.png" width="159" height="159" />
          </platform>
-    
+
 
 Windows8
 
@@ -141,7 +141,7 @@ Windows8
                   <icon src="res/windows8/smalllogo.png" width="30" height="30" />
                   <icon src="res/windows8/storelogo.png" width="50" height="50" />
          </platform>
-    
+
 
 ## 在 CLI 中配置初始螢幕
 
@@ -152,18 +152,18 @@ Windows8
 請注意"src"屬性的值是相對於專案目錄而不是 www 目錄。 你可以命名源映射任何你喜歡的。 在應用程式中的內部名稱取決於科爾多瓦。
 
     <platform name="android">
-        <!-- you can use any density that exists in the Android project -->
-        <splash src="res/screen/android/splash-land-hdpi.png" density="land-hdpi"/>
-        <splash src="res/screen/android/splash-land-ldpi.png" density="land-ldpi"/>
-        <splash src="res/screen/android/splash-land-mdpi.png" density="land-mdpi"/>
-        <splash src="res/screen/android/splash-land-xhdpi.png" density="land-xhdpi"/>
-    
-        <splash src="res/screen/android/splash-port-hdpi.png" density="port-hdpi"/>
-        <splash src="res/screen/android/splash-port-ldpi.png" density="port-ldpi"/>
-        <splash src="res/screen/android/splash-port-mdpi.png" density="port-mdpi"/>
-        <splash src="res/screen/android/splash-port-xhdpi.png" density="port-xhdpi"/>
+        <!-- you can use any qualifier that exists in the Android project -->
+        <splash src="res/screen/android/splash-land-hdpi.png" qualifier="land-hdpi"/>
+        <splash src="res/screen/android/splash-land-ldpi.png" qualifier="land-ldpi"/>
+        <splash src="res/screen/android/splash-land-mdpi.png" qualifier="land-mdpi"/>
+        <splash src="res/screen/android/splash-land-xhdpi.png" qualifier="land-xhdpi"/>
+
+        <splash src="res/screen/android/splash-port-hdpi.png" qualifier="port-hdpi"/>
+        <splash src="res/screen/android/splash-port-ldpi.png" qualifier="port-ldpi"/>
+        <splash src="res/screen/android/splash-port-mdpi.png" qualifier="port-mdpi"/>
+        <splash src="res/screen/android/splash-port-xhdpi.png" qualifier="port-xhdpi"/>
     </platform>
-    
+
     <platform name="ios">
         <!-- images are determined by width and height. The following are supported -->
         <splash src="res/screen/ios/Default~iphone.png" width="320" height="480"/>
@@ -177,26 +177,26 @@ Windows8
         <splash src="res/screen/ios/Default-736h.png" width="1242" height="2208"/>
         <splash src="res/screen/ios/Default-Landscape-736h.png" width="2208" height="1242"/>
     </platform>
-    
+
     <platform name="wp8">
         <!-- images are determined by width and height. The following are supported -->
         <splash src="res/screen/wp8/SplashScreenImage.jpg" width="768" height="1280"/>
     </platform>
-    
+
     <platform name="windows8">
         <!-- images are determined by width and height. The following are supported -->
         <splash src="res/screen/windows8/splashscreen.png" width="620" height="300"/>
     </platform>
-    
+
     <platform name="blackberry10">
         <!-- Add a rim:splash element for each resolution and locale you wish -->
         <!-- http://developer.blackberry.com/html5/documentation/rim_splash_element.html -->
         <rim:splash src="res/screen/windows8/splashscreen.png"/>
     </platform>
-    
-    
+
+
     <preference name="SplashScreenDelay" value="10000" />
-    
+
 
 # 支援的平臺
 
@@ -207,7 +207,7 @@ Windows8
     wp8
     windows8
     blackberry10
-    
+
 
 # 閃屏外掛程式
 


### PR DESCRIPTION
### Platforms affected

Android

### What does this PR do?

Fix documentation, replace density by qualifier

### What testing has been done on this change?

Build my own app with density, icon Android doesn't appear, use qualifier it's work.

### Checklist

n/a