### PR TITLE
CB-13120: Removed references of cordova-plugin-file-transfer

### DIFF
--- a/www/docs/en/dev/guide/support/index.md
+++ b/www/docs/en/dev/guide/support/index.md
@@ -167,17 +167,6 @@ the core plugins, additional APIs are available via
     </tr>
 
     <tr>
-        <th><a href="../../reference/cordova-plugin-file-transfer/">File Transfer</a></th>
-        <td data-col="android"    class="y"></td>
-        <td data-col="blackberry10" class="y">Does not support onprogress nor abort</td>
-        <td data-col="ios"        class="y"></td>
-        <td data-col="osx"       class="n"></td>
-        <td data-col="ubuntu"        class="n"></td>
-        <td data-col="win8"       class="y">Does not support onprogress nor abort</td>
-        <td data-col="wp8"  class="y">Does not support onprogress nor abort</td>
-    </tr>
-
-    <tr>
         <th><a href="../../reference/cordova-plugin-geolocation/">Geolocation</a></th>
         <td data-col="android"    class="y"></td>
         <td data-col="blackberry10" class="y"></td>

--- a/www/static/plugins/official-plugins.json
+++ b/www/static/plugins/official-plugins.json
@@ -7,7 +7,6 @@
         "cordova-plugin-device",
         "cordova-plugin-dialogs",
         "cordova-plugin-file",
-        "cordova-plugin-file-transfer",
         "cordova-plugin-geolocation",
         "cordova-plugin-globalization",
         "cordova-plugin-inappbrowser",


### PR DESCRIPTION
Removed references of cordova-plugin-file-transfer from cordova docs


### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
