### PR TITLE
CB-13066: Removed references of contacts plugin

### DIFF
--- a/www/docs/en/dev/guide/support/index.md
+++ b/www/docs/en/dev/guide/support/index.md
@@ -123,17 +123,6 @@ the core plugins, additional APIs are available via
     </tr>
 
     <tr>
-        <th><a href="../../reference/cordova-plugin-contacts/">Contacts</a></th>
-        <td data-col="android"    class="y"></td>
-        <td data-col="blackberry10" class="y"></td>
-        <td data-col="ios"        class="y"></td>
-        <td data-col="osx"       class="n"></td>
-        <td data-col="ubuntu"        class="p">desktop only</td>
-        <td data-col="win8"       class="p">partially</td>
-        <td data-col="wp8"  class="y"></td>
-    </tr>
-
-    <tr>
         <th><a href="../../reference/cordova-plugin-device/">Device</a></th>
         <td data-col="android"    class="y"></td>
         <td data-col="blackberry10" class="y"></td>

--- a/www/static/plugins/official-plugins.json
+++ b/www/static/plugins/official-plugins.json
@@ -3,7 +3,6 @@
         "cordova-plugin-battery-status",
         "cordova-plugin-camera",
         "cordova-plugin-console",
-        "cordova-plugin-contacts",
         "cordova-plugin-device",
         "cordova-plugin-dialogs",
         "cordova-plugin-file",


### PR DESCRIPTION
Removed references of the contacts plugin from cordova - docs as part of the process of deprecating the cordova-plugin-contacts 


### What testing has been done on this change?


### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
