### PR TITLE
Update Android API version table

### DIFF
--- a/www/docs/en/dev/guide/platforms/android/index.md
+++ b/www/docs/en/dev/guide/platforms/android/index.md
@@ -43,6 +43,7 @@ few cordova-android releases can be found in this table:
 
 cordova-android Version | Supported Android API-Levels | Equivalent Android Version
 ------------------------|------------------------------|-----------------------------
+7.X.X                   | 19 - 27                      | 4.4 - 8.1
 6.X.X                   | 16 - 26                      | 4.1 - 8.0.0
 5.X.X                   | 14 - 23                      | 4.0 - 6.0.1
 4.1.X                   | 14 - 22                      | 4.0 - 5.1


### PR DESCRIPTION
### Platforms affected
- Android

### What does this PR do?
- Document which Android API levels are now supported

### What testing has been done on this change?
None, informational only

### Checklist
No issue reported, change is very minor

### Links
Cordova Blog http://webcache.googleusercontent.com/search?q=cache:https://cordova.apache.org/blog
Android API level to Android version table https://developer.android.com/guide/topics/manifest/uses-sdk-element.html

### Open question
Is the max android version correct? The blog post doesn't mention it.