### PR TITLE
[Android] Remove outdated `android` command

### DIFF
--- a/www/docs/en/dev/guide/platforms/android/index.md
+++ b/www/docs/en/dev/guide/platforms/android/index.md
@@ -88,7 +88,7 @@ whatever [API level](http://developer.android.com/guide/topics/manifest/uses-sdk
 you wish to target. It is recommended that you install the highest SDK version
 that your version of cordova-android supports (see [Requirements and Support](#requirements-and-support)).
 
-Open the Android SDK Manager (run `android` or `sdkmanager` from the terminal)
+Open the Android SDK Manager (run `sdkmanager` from the terminal)
 and make sure the following are installed:
 
 1. Android Platform SDK for your targeted version of Android


### PR DESCRIPTION
Running android.bat now returns this:

*****************************************************************************************
The "android" command is deprecated. 
For manual SDK, AVD, and project management, please use Android Studio. 
For command-line tools, use tools\bin\sdkmanager.bat and tools\bin\avdmanager.bat
*****************************************************************************************
Invalid or unsupported command ""

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
browser-based document

### What does this PR do?
corrects the documentation at https://cordova.apache.org/docs/en/latest/guide/platforms/android/index.html

### What testing has been done on this change?
n/a

### Checklist
- [NA] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [NA] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [NA] Added automated test coverage as appropriate for this change.
