### PR TITLE
[CB-13925] Making file fetch happen on every build.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -313,13 +313,16 @@ gulp.task("regen", ["jekyll"], function () {
 });
 
 gulp.task("fetch", function (done) {
-    if (!fs.existsSync(FETCH_DIR)) {
-        exec("node", [bin("fetch_docs.js"), "--config", FETCH_CONFIG, '--docsRoot', DOCS_DIR], done);
-    } else {
+
+    // skip fetching if --nofetch was passed
+    if (gutil.env.nofetch) {
         gutil.log(gutil.colors.yellow(
-            "Skipping fetching external docs. Run 'gulp clean' first to initiate another fetch."));
+            "Skipping fetching external docs."));
         done();
+        return;
     }
+
+    exec("node", [bin("fetch_docs.js"), "--config", FETCH_CONFIG, '--docsRoot', DOCS_DIR], done);
 });
 
 gulp.task("reload", function () {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "baconjs": "^0.7.70",
     "browser-sync": "^2.8.0",
     "browserify": "^10.2.4",
+    "chalk": "^2.3.1",
     "cheerio": "^0.17.0",
     "classnames": "^2.1.2",
     "envify": "^3.4.0",

--- a/tools/bin/augment_toc.js
+++ b/tools/bin/augment_toc.js
@@ -22,6 +22,7 @@ var path = require('path');
 
 var yaml = require('js-yaml');
 var optimist = require('optimist');
+var chalk = require('chalk');
 
 var util = require('./util');
 
@@ -46,7 +47,7 @@ function augmentEntry (originalEntry, prefix) {
 
     // skip entries that don't point to a valid file
     if (!fs.existsSync(filePath)) {
-        console.warn('WARNING! Possible 404 in ToC: "' + filePath + '"');
+        console.warn(chalk.red('WARNING! Possible 404 in ToC: "' + filePath + '"; create the file to fix'));
         return originalEntry;
     }
 


### PR DESCRIPTION
- Making `gulpfile.js` always fetch fetched files on build.
- Adding --nofetch option to `gulpfile.js`, which skips fetching.
- Improving error message in `augment_toc.js` a bit.

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
None. It's a docs change.

### What does this PR do?
Fixes CB-13925.

### What testing has been done on this change?
Built the docs site locally.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
