### PR TITLE
remove deprecated platforms from dev docs

### DIFF
--- a/www/docs/en/dev/cordova/storage/storage.md
+++ b/www/docs/en/dev/cordova/storage/storage.md
@@ -83,7 +83,6 @@ As such, it provides all the power (and complexity) of SQL.
 It is supported by the underlying WebView on the following Cordova platforms:
 
 - Android
-- BlackBerry 10
 - iOS
 
 ### Usage Summary
@@ -165,7 +164,6 @@ database, and its asynchronous API and search indexes provide performance benefi
 
 IndexedDB is supported by the underlying WebView on the following Cordova platforms:
 
-- BlackBerry 10
 - Windows (with some limitations)
 - Android (4.4 and above)
 

--- a/www/docs/en/dev/guide/appdev/whitelist/index.md
+++ b/www/docs/en/dev/guide/appdev/whitelist/index.md
@@ -132,45 +132,6 @@ In iOS 10 and above, the `<access>` tag supports these three attributes below, w
 
 See the [ATS Technote](https://developer.apple.com/library/prerelease/ios/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW33) for more details.
 
-## BlackBerry 10 Whitelisting
-
-The whitelisting rules are found in `www/config.xml`.
-
-BlackBerry 10's use of wildcards differs from other platforms in two
-ways:
-
-* Any content accessed by `XMLHttpRequest` must be declared
-  explicitly. Setting `origin="*"` does not work in this case.
-  Alternatively, all web security may be disabled using the
-  `WebSecurity` preference described in BlackBerry Configuration:
-
-    ```xml
-    <preference name="websecurity" value="disable" />
-    ```
-
-* As an alternative to setting `*.domain`, set an additional
-  `subdomains` attribute to `true`. It should be set to `false` by
-  default.
-
-    ```xml
-    <!-- Narrows access to google.com -->
-    <access origin="http://google.com" subdomains="false" />
-
-    <!-- Allows access to maps.google.com and docs.google.com -->
-    <access origin="http://google.com" subdomains="true" />
-
-    <!-- Allows access to all domains, including the local `file://` protocol -->
-    <access origin="*" subdomains="true" />
-    ```
-
-For more information on support, see BlackBerry's documentation on the
-[access element][8].
-
-## Windows Phone Whitelisting
-
-The whitelisting rules for Windows Phone 8 are found in the
-app's `config.xml` file.
-
 [wlp]: ../../../reference/cordova-plugin-whitelist/
 [1]: http://www.w3.org/TR/widgets-access/
 [2]: http://google.com
@@ -179,4 +140,3 @@ app's `config.xml` file.
 [5]: http://mail.google.com
 [6]: http://docs.google.com
 [7]: http://developer.mozilla.org
-[8]: https://developer.blackberry.com/html5/documentation/v1_0/access_element_834677_11.html

--- a/www/docs/en/dev/guide/hybrid/webviews/index.md
+++ b/www/docs/en/dev/guide/hybrid/webviews/index.md
@@ -37,4 +37,3 @@ supported platforms:
 
 - [Android WebViews](../../platforms/android/webview.html)
 - [iOS WebViews](../../platforms/ios/webview.html)
-- [Windows Phone 8.0 WebViews](../../platforms/wp8/webview.html)

--- a/www/docs/en/dev/guide/next/index.md
+++ b/www/docs/en/dev/guide/next/index.md
@@ -165,7 +165,6 @@ Weinre creates a local server that can host a remote debug client for your Cordo
 
 ## Other Options
 
-* BlackBerry 10 supports debugging as well: [Documentation]( https://developer.blackberry.com/html5/documentation/v2_0/debugging_using_web_inspector.html)
 * For more examples and explanation of the above debugging tips, see: [http://developer.telerik.com/featured/a-concise-guide-to-remote-debugging-on-ios-android-and-windows-phone/](http://developer.telerik.com/featured/a-concise-guide-to-remote-debugging-on-ios-android-and-windows-phone/)
 
 # User Interface

--- a/www/docs/en/dev/plugin_ref/plugman.md
+++ b/www/docs/en/dev/plugin_ref/plugman.md
@@ -77,7 +77,7 @@ listed on the Platform guides page.
 Once you have installed Plugman and have created a Cordova project, you can start adding plugins to the platform with:
 
 ```bash
-$ plugman install --platform <ios|android|blackberry10|wp8> --project <directory> --plugin <name|url|path> [--plugins_dir <directory>] [--www <directory>] [--variable <name>=<value> [--variable <name>=<value> ...]]
+$ plugman install --platform <ios|android> --project <directory> --plugin <name|url|path> [--plugins_dir <directory>] [--www <directory>] [--variable <name>=<value> [--variable <name>=<value> ...]]
 ```
 
 Using minimum parameters, this command installs a plugin into a cordova project. You must specify a platform and cordova project location for that platform. You also must specify a plugin, with the different `--plugin` parameter forms being:
@@ -90,16 +90,15 @@ Other parameters:
 
 * `--plugins_dir` defaults to `<project>/cordova/plugins`, but can be any directory containing a subdirectory for each fetched plugin.
 * `--www` defaults to the project's `www` folder location, but can be any directory that is to be used as cordova project application web assets.
-* `--variable` allows to specify certain variables at install time, necessary for certain plugins requiring API keys or other custom, user-defined parameters. Please see the [plugin specification](spec.md.html#Plugin%20Specification) for more information.
+* `--variable` allows to specify certain variables at install time, necessary for certain plugins requiring API keys or other custom, user-defined parameters. Please see the [plugin specification](spec.html#Plugin%20Specification) for more information.
 
 ## Remove a Plugin
 
 To uninstall a plugin, you simply pass the `uninstall` command and provide the plugin ID.
 
 ```bash
-$ plugman uninstall --platform <ios|android|blackberry10|wp8> --project <directory> --plugin <id> [--www <directory>] [--plugins_dir <directory>]
+$ plugman uninstall --platform <ios|android> --project <directory> --plugin <id> [--www <directory>] [--plugins_dir <directory>]
 ```
-
 
 ## Help Commands
 
@@ -171,107 +170,107 @@ platform, and reference the platform's project directory.
 * cordova-plugin-battery-status
 
     ```bash
-    plugman install --platform <ios|android|blackberry10|wp8> --project <directory> --plugin cordova-plugin-battery-status
+    plugman install --platform <ios|android> --project <directory> --plugin cordova-plugin-battery-status
     ```
 
 * cordova-plugin-camera
 
     ```bash
-    plugman install --platform <ios|android|blackberry10|wp8> --project <directory> --plugin cordova-plugin-camera
+    plugman install --platform <ios|android> --project <directory> --plugin cordova-plugin-camera
     ```
 
 * cordova-plugin-console
 
     ```bash
-    plugman install --platform <ios|android|blackberry10|wp8> --project <directory> --plugin cordova-plugin-console
+    plugman install --platform <ios|android> --project <directory> --plugin cordova-plugin-console
     ```
 
 * cordova-plugin-contacts
 
     ```bash
-    plugman install --platform <ios|android|blackberry10|wp8> --project <directory> --plugin cordova-plugin-contacts
+    plugman install --platform <ios|android> --project <directory> --plugin cordova-plugin-contacts
     ```
 
 * cordova-plugin-device
 
     ```bash
-    plugman install --platform <ios|android|blackberry10|wp8> --project <directory> --plugin cordova-plugin-device
+    plugman install --platform <ios|android> --project <directory> --plugin cordova-plugin-device
     ```
 
 * cordova-plugin-device-motion (accelerometer)
 
     ```bash
-    plugman install --platform <ios|android|blackberry10|wp8> --project <directory> --plugin cordova-plugin-device-motion
+    plugman install --platform <ios|android> --project <directory> --plugin cordova-plugin-device-motion
     ```
 
 * cordova-plugin-device-orientation (compass)
 
     ```bash
-    plugman install --platform <ios|android|blackberry10|wp8> --project <directory> --plugin cordova-plugin-device-orientation
+    plugman install --platform <ios|android> --project <directory> --plugin cordova-plugin-device-orientation
     ```
 
 * cordova-plugin-dialogs
 
     ```bash
-    plugman install --platform <ios|android|blackberry10|wp8> --project <directory> --plugin cordova-plugin-dialogs
+    plugman install --platform <ios|android> --project <directory> --plugin cordova-plugin-dialogs
     ```
 
 * cordova-plugin-file
 
     ```bash
-    plugman install --platform <ios|android|blackberry10|wp8> --project <directory> --plugin cordova-plugin-file
+    plugman install --platform <ios|android> --project <directory> --plugin cordova-plugin-file
     ```
 
 * cordova-plugin-file-transfer
 
     ```bash
-    plugman install --platform <ios|android|blackberry10|wp8> --project <directory> --plugin cordova-plugin-file-transfer
+    plugman install --platform <ios|android> --project <directory> --plugin cordova-plugin-file-transfer
     ```
 
 * cordova-plugin-geolocation
 
     ```bash
-    plugman install --platform <ios|android|blackberry10|wp8> --project <directory> --plugin cordova-plugin-geolocation
+    plugman install --platform <ios|android> --project <directory> --plugin cordova-plugin-geolocation
     ```
 
 * cordova-plugin-globalization
 
     ```bash
-    plugman install --platform <ios|android|blackberry10|wp8> --project <directory> --plugin cordova-plugin-globalization
+    plugman install --platform <ios|android> --project <directory> --plugin cordova-plugin-globalization
     ```
 
 * cordova-plugin-inappbrowser
 
     ```bash
-    plugman install --platform <ios|android|blackberry10|wp8> --project <directory> --plugin cordova-plugin-inappbrowser
+    plugman install --platform <ios|android> --project <directory> --plugin cordova-plugin-inappbrowser
     ```
 
 * cordova-plugin-media
 
     ```bash
-    plugman install --platform <ios|android|blackberry10|wp8> --project <directory> --plugin cordova-plugin-media
+    plugman install --platform <ios|android> --project <directory> --plugin cordova-plugin-media
     ```
 
 * cordova-plugin-media-capture
 
     ```bash
-    plugman install --platform <ios|android|blackberry10|wp8> --project <directory> --plugin cordova-plugin-media-capture
+    plugman install --platform <ios|android> --project <directory> --plugin cordova-plugin-media-capture
     ```
 
 * cordova-plugin-network-information
 
     ```bash
-    plugman install --platform <ios|android|blackberry10|wp8> --project <directory> --plugin cordova-plugin-network-information
+    plugman install --platform <ios|android> --project <directory> --plugin cordova-plugin-network-information
     ```
 
 * cordova-plugin-splashscreen
 
     ```bash
-    plugman install --platform <ios|android|blackberry10|wp8> --project <directory> --plugin cordova-plugin-splashscreen
+    plugman install --platform <ios|android> --project <directory> --plugin cordova-plugin-splashscreen
     ```
 
 * cordova-plugin-vibration
 
     ```bash
-    plugman install --platform <ios|android|blackberry10|wp8> --project <directory> --plugin cordova-plugin-vibration
+    plugman install --platform <ios|android> --project <directory> --plugin cordova-plugin-vibration
     ```

--- a/www/docs/en/dev/plugin_ref/spec.md
+++ b/www/docs/en/dev/plugin_ref/spec.md
@@ -55,10 +55,10 @@ The child elements of the `<engines>` element specify versions of Apache Cordova
 
 Attributes(type) <br/> <span class="sub-header">Only for platform:</span> | Description
 ---------------- | ------------
-name(string) | *Required* <br/> Name of the engine. Here are the default engines that are supported : <ul><li> `cordova` </li> <li> `cordova-plugman` </li> <li> `cordova-android` </li> <li> `cordova-ios` </li> <li> `cordova-blackberry10` </li> <li> `cordova-wp8` </li> <li> `cordova-windows` </li> <li> `cordova-osx` </li> <li> `windows-os` </li> <li> `android-sdk` (returns the highest Android api level installed) </li> <li> `windows-sdk` (returns the native windows SDK version) </li> <li> `apple-xcode` (returns the xcode version) </li> <li> `apple-ios` (returns the highest iOS version installed) </li> <li> `apple-osx` (returns the OSX version) </li> <li> `blackberry-ndk` (returns the native blackberry SDK version) </li> You can also specify a custom framework apart from the default ones.
+name(string) | *Required* <br/> Name of the engine. Here are the default engines that are supported : <ul><li> `cordova` </li> <li> `cordova-plugman` </li> <li> `cordova-android` </li> <li> `cordova-ios` </li> <li> `cordova-windows` </li> <li> `cordova-osx` </li> <li> `windows-os` </li> <li> `android-sdk` (returns the highest Android api level installed) </li> <li> `windows-sdk` (returns the native windows SDK version) </li> <li> `apple-xcode` (returns the xcode version) </li> <li> `apple-ios` (returns the highest iOS version installed) </li> <li> `apple-osx` (returns the OSX version) </li> You can also specify a custom framework apart from the default ones.
 version(string) | *Required* <br/> The version that your framework must have in order to install. Semver syntax is supported.
 scriptSrc(string) | **For custom frameworks only** <br/> *Required* <br/>  The script file that tells plugman the version of the custom framework. Ideally, this file should be within the top level directory of your plugin directory.
-platform(string) | **For custom frameworks only** <br/> *Required* <br/> The platforms your framework supports. You may use the wildcard `*` to say supported for all platforms, specify multiple with a pipe character like `android|ios|blackberry10` or just a single platform like `android`.
+platform(string) | **For custom frameworks only** <br/> *Required* <br/> The platforms your framework supports. You may use the wildcard `*` to say supported for all platforms, specify multiple with a pipe character like `android|ios` or just a single platform like `android`.
 
 Examples:
 ```xml
@@ -245,7 +245,7 @@ Identifies platforms that have associated native code or require modifications t
 
 Attributes(type) <br/> <span class="sub-header">Only for platform:</span> | Description
 ---------------- | ------------
-name(string) | *Required* <br/> Allowed values: ios, android, blackberry10, amazon-fireos, wp8, windows <br/> Identifies a platform as supported, associating the element's children with that platform.
+name(string) | *Required* <br/> Allowed values: ios, android, windows, browser, osx <br/> Identifies a platform as supported, associating the element's children with that platform.
 
 Example:
 ```xml


### PR DESCRIPTION
I removed some more mentions of deprecated platforms from the dev version of the docs.