### PR TITLE
CB-13963: (android) Fix error in platform guide.

### DIFF
--- a/www/docs/en/7.x/guide/platforms/android/index.md
+++ b/www/docs/en/7.x/guide/platforms/android/index.md
@@ -63,8 +63,7 @@ they dip below 5% on Google's
 
 ### Java Development Kit (JDK)
 
-Install [Java Development Kit (JDK) 8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
-or later.
+Install [Java Development Kit (JDK) 8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html).
 
 When installing on Windows you also need to set `JAVA_HOME` Environment Variable
 according to your JDK installation path (see [Setting Environment Variables](#setting-environment-variables))

--- a/www/docs/en/dev/guide/platforms/android/index.md
+++ b/www/docs/en/dev/guide/platforms/android/index.md
@@ -64,8 +64,7 @@ they dip below 5% on Google's
 
 ### Java Development Kit (JDK)
 
-Install [Java Development Kit (JDK) 8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
-or later.
+Install [Java Development Kit (JDK) 8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html).
 
 When installing on Windows you also need to set `JAVA_HOME` Environment Variable
 according to your JDK installation path (see [Setting Environment Variables](#setting-environment-variables))


### PR DESCRIPTION
### Platforms affected
android

### What does this PR do?
remove "or later" post "install jdk8" because jdk 9 doesn't work with cordova (or android).

### What testing has been done on this change?
none

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
