### PR TITLE
Fix paths to build-extras.gradle and gradle.properties

### DIFF
--- a/www/docs/en/dev/guide/platforms/android/index.md
+++ b/www/docs/en/dev/guide/platforms/android/index.md
@@ -246,9 +246,9 @@ as part of the build command by using the `before_build`
 If you need to customize `build.gradle`, rather than edit it directly, you
 should create a sibling file named `build-extras.gradle`. This file will be
 included by the main `build.gradle` when present. This file must be placed in
-the android platform directory under app subfolder (`<your-project>/platforms/android/app`), so it is
-recommended that you copy it over via a script attached to the `before_build`
-[hook](../../appdev/hooks/index.html).
+the `app` folder of the Android platform directory (`<your-project>/platforms/android/app`), 
+so it is recommended that you copy it over via a script attached to the 
+`before_build` [hook](../../appdev/hooks/index.html).
 
 Here's an example:
 

--- a/www/docs/en/dev/guide/platforms/android/index.md
+++ b/www/docs/en/dev/guide/platforms/android/index.md
@@ -222,7 +222,7 @@ You can set these properties in one of four ways:
       like so:
 
       ```
-      # In <your-project>/platforms/android/gradle.properties
+      # In <your-project>/platforms/android/app/gradle.properties
       cdvMinSdkVersion=20
       ```
 
@@ -230,7 +230,7 @@ You can set these properties in one of four ways:
     and setting the property like so:
 
       ```groovy
-      // In <your-project>/platforms/android/build-extras.gradle
+      // In <your-project>/platforms/android/app/build-extras.gradle
       ext.cdvMinSdkVersion = 20
       ```
 
@@ -246,7 +246,7 @@ as part of the build command by using the `before_build`
 If you need to customize `build.gradle`, rather than edit it directly, you
 should create a sibling file named `build-extras.gradle`. This file will be
 included by the main `build.gradle` when present. This file must be placed in
-the android platform directory (`<your-project>/platforms/android`), so it is
+the android platform directory under app subfolder (`<your-project>/platforms/android/app`), so it is
 recommended that you copy it over via a script attached to the `before_build`
 [hook](../../appdev/hooks/index.html).
 


### PR DESCRIPTION
Since cordova-android v7.0 paths to `build-extras.gradle` and `gradle.properties` have moved to `/app` subfolder (see https://github.com/apache/cordova-android/pull/389)

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
[cordova-anrdoid](https://github.com/apache/cordova-android) v7.0+

### What does this PR do?
Fixes changed paths paths to `build-extras.gradle` and `gradle.properties`


### What testing has been done on this change?
1. Create file `build-extras.gradle` or `gradle.properties` in android platform root, as described in [docs](https://cordova.apache.org/docs/en/latest/guide/platforms/android/index.html)
2. Run `cordova run android`
3. Properties are ignored
4. Follow same steps place files inside `/app` subfolder

### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
