### PR TITLE
CB-14096: Fix platforms image overflowing on mobile

### DIFF
--- a/www/static/css-src/_home.scss
+++ b/www/static/css-src/_home.scss
@@ -283,6 +283,10 @@ img#logo_top {
     padding-top: 20px;
     padding-bottom: 20px;
     text-align: center;
+
+    img {
+        max-width: 100%;
+    }
 }
 .card_gallery {
     color:white;


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Website

### What does this PR do?
As part of https://github.com/apache/cordova-docs/pull/818, I removed deprecated platforms from the image under supported platforms on the landing page. However, as a result, the image does not resize correctly on mobile. This PR sets a `max-width` to resize it correctly.

Before:
![before](https://user-images.githubusercontent.com/2932890/40335281-cf40a01a-5d9d-11e8-9cba-9faed785372f.png)

After:
![screen shot 2018-05-22 at 8 42 24](https://user-images.githubusercontent.com/2932890/40335293-da68acda-5d9d-11e8-88fc-c0d21231ea8d.png)

### What testing has been done on this change?
Manual testing on Chrome on Android

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
