### PR TITLE
Remove no longer required link to ICLA

### DIFF
--- a/www/contribute/index.html
+++ b/www/contribute/index.html
@@ -21,7 +21,6 @@ title: Contribute
             <li>Read the <a href="./contribute_guidelines.html">Contributor Guidelines</a></li>
             <li>Join the <a href="{{ site.baseurl }}/contact">Dev mailing list</a> and send a brief introduction of yourself to it</li>
             <li>Join the discussion on <a href="http://slack.cordova.io/">Slack</a></li>
-            <li>Sign the <a href="http://www.apache.org/licenses/#clas">Individual Contributor License Agreement (ICLA)</a> and <a href="mailto:secretary@apache.org">submit it</a></li>
             <li>Try out the next version of Cordova using <a href="{{ site.baseurl }}/contribute/nightly_builds.html">nightly builds</a></li>
         </ul>
     </div>


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
N/A

### What does this PR do?
The requirement to sign an ICLA was removed about 18 months ago (see https://github.com/apache/cordova-docs/commit/a6f1ab072182d5f7f0c769b38f9a69989f524d3d), but it was not removed from the main contributing page. This PR removes it.

### What testing has been done on this change?
N/A

### Checklist
- [x] Commit message follows the format: "GH-3232: (android) Fix bug with resolving file paths", where GH-xxxx is the GitHub issue ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
