### PR TITLE
ios: Add missing Markdown link reference

### DIFF
--- a/www/docs/en/8.x/guide/platforms/ios/plugin.md
+++ b/www/docs/en/8.x/guide/platforms/ios/plugin.md
@@ -265,3 +265,4 @@ For JavaScript, you can attach Safari to the app running within the iOS Simulato
 [CDVPlugin.m]: https://github.com/apache/cordova-ios/blob/master/CordovaLib/Classes/Public/CDVPlugin.m
 [ResumeEvent]: ../../../cordova/events/events.html#resume
 [PauseEvent]: ../../../cordova/events/events.html#pause
+[plugin-dev]: ../../hybrid/plugins/index.html


### PR DESCRIPTION
Hi,

### What does this PR do?

Add a missing Markdown link reference for the iOS plugin development page.

### What testing has been done on this change?

The site has been run locally to check that the link is now properly generated.

Have a nice day !