### PR TITLE
Update docs design to improve readability

### DIFF
--- a/www/_layouts/docs.html
+++ b/www/_layouts/docs.html
@@ -25,250 +25,248 @@ NOTE:
 {% endcomment %}
 {% capture PATH_TO_ROOT %}{% for item in my_entry_parts %}{% if forloop.rindex > 1 %}../{% endif %}{% endfor %}{% endcapture %}
 
-<div class="docs container">
+<div class="docs">
 
     <!-- Table of Contents -->
-    <div class="hidden-xs hidden-sm col-md-4 col-lg-3 site-toc-container">
+    <div class="hidden-xs hidden-sm site-toc-container">
         {% include toc_recursive_main.html entries=TOCFILE my_entry=MY_ENTRY path_to_root=PATH_TO_ROOT %}
     </div>
 
     <!-- Page content -->
-    <div class="col-md-8 col-md-offset-4 col-lg-9 col-lg-offset-3 page-content-container container">
-        <div class="page-content row">
-            <div class="col-md-offset-1 col-md-10">
-                <div class="content-header">
+    <div class="page-content-container">
+        <div class="page-content">
+            <div class="content-header">
 
-                    <!-- ToC Dropdown (for XS and SM sizes only) -->
-                    <div class="toc-dropdown dropdown visible-xs-block visible-sm-block">
-                        <button class="btn btn-default dropdown-toggle" type="button" id="tocDropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-                            {{ page.toc_text }}
-                            <span class="caret"></span>
-                        </button>
-                        <ul class="dropdown-menu">
-                            {% include toc_recursive_dropdown.html entries=TOCFILE my_entry=MY_ENTRY path_to_root=PATH_TO_ROOT %}
-                        </ul>
-                    </div>
+                <!-- ToC Dropdown (for XS and SM sizes only) -->
+                <div class="toc-dropdown dropdown visible-xs-block visible-sm-block">
+                    <button class="btn btn-default dropdown-toggle" type="button" id="tocDropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+                        {{ page.toc_text }}
+                        <span class="caret"></span>
+                    </button>
+                    <ul class="dropdown-menu">
+                        {% include toc_recursive_dropdown.html entries=TOCFILE my_entry=MY_ENTRY path_to_root=PATH_TO_ROOT %}
+                    </ul>
+                </div>
+
+                {% comment %}
+                Show a single edit-link if the page has a specific edit-link.
+                {% endcomment %}
+                {% if page.edit_link %}
+                    <a class="edit hidden-xs hidden-sm" href="{{ page.edit_link }}"><span class="glyphicon glyphicon-pencil" aria-hidden="true"></span> {{ page.edit_text }}</a>
+
+                {% comment %}
+                Otherwise, show editing and translating options.
+
+                Edit-links obey the following rules:
+
+                if page in /dev/ or /latest/:
+                    show edit link for /dev/ page in source language
+                    if page not in source language:
+                        show translation link for /dev/ page
+                else:
+                    show edit link for the page in its version and language
+
+                {% endcomment %}
+                {% else %}
+
+                    {% capture base_edit_link %}https://github.com/apache/cordova-docs/tree/master/www/{{ page.path }}{% endcapture %}
+                    {% capture base_version %}/{{ page.version }}/{% endcapture %}
+                    {% capture base_language %}/{{ page.language }}/{% endcapture %}
+                    {% capture dev_version %}/dev/{% endcapture %}
+                    {% capture src_language %}/{{ site.src_language }}/{% endcapture %}
 
                     {% comment %}
-                    Show a single edit-link if the page has a specific edit-link.
+                    Edit-links for current pages in non-source languages
+                    NOTE:
+                            Pages that are under /dev/ or /latest/ (i.e. site.latest_docs_version) have page.current set to "true".
                     {% endcomment %}
-                    {% if page.edit_link %}
-                        <a class="edit" href="{{ page.edit_link }}"><span class="glyphicon glyphicon-pencil" aria-hidden="true"></span> {{ page.edit_text }}</a>
+                    {% if page.language != site.src_language and page.current %}
+
+                        {% comment %}
+                        Compute crowdin link
+                        {% endcomment %}
+                        {% capture page_path_prefix %}docs/{{ page.language }}/{{ page.version }}{% endcapture %}
+                        {% assign page_path_end = page.path | split:"/" | last %}
+                        {% assign crowdin_path  = page.path | replace:page_path_prefix,"docs/en/dev" | replace:page_path_end,"" %}
+                        {% capture crowdin_link %}https://crowdin.com/project/cordova/{{ page.language }}#/cordova-docs/{{ crowdin_path }}{% endcapture %}
+
+                        {% assign edit_link = base_edit_link | replace:base_language,src_language | replace:base_version,dev_version %}
+
+                        <a class="edit" href="{{ edit_link }}"><span class="glyphicon glyphicon-pencil" aria-hidden="true"></span> {{ page.edit_source_text }}</a>
+                        <a class="edit" href="{{ crowdin_link }}"><span class="glyphicon glyphicon-pencil" aria-hidden="true"></span> {{ page.edit_translation_text }}</a>
 
                     {% comment %}
-                    Otherwise, show editing and translating options.
-
-                    Edit-links obey the following rules:
-
-                    if page in /dev/ or /latest/:
-                        show edit link for /dev/ page in source language
-                        if page not in source language:
-                            show translation link for /dev/ page
-                    else:
-                        show edit link for the page in its version and language
-
+                    Edit-links for all other pages
                     {% endcomment %}
                     {% else %}
 
-                        {% capture base_edit_link %}https://github.com/apache/cordova-docs/tree/master/www/{{ page.path }}{% endcapture %}
-                        {% capture base_version %}/{{ page.version }}/{% endcapture %}
-                        {% capture base_language %}/{{ page.language }}/{% endcapture %}
-                        {% capture dev_version %}/dev/{% endcapture %}
-                        {% capture src_language %}/{{ site.src_language }}/{% endcapture %}
-
                         {% comment %}
-                        Edit-links for current pages in non-source languages
-                        NOTE:
-                             Pages that are under /dev/ or /latest/ (i.e. site.latest_docs_version) have page.current set to "true".
+                        Edit-link for latest version points to dev instead
                         {% endcomment %}
-                        {% if page.language != site.src_language and page.current %}
-
-                            {% comment %}
-                            Compute crowdin link
-                            {% endcomment %}
-                            {% capture page_path_prefix %}docs/{{ page.language }}/{{ page.version }}{% endcapture %}
-                            {% assign page_path_end = page.path | split:"/" | last %}
-                            {% assign crowdin_path  = page.path | replace:page_path_prefix,"docs/en/dev" | replace:page_path_end,"" %}
-                            {% capture crowdin_link %}https://crowdin.com/project/cordova/{{ page.language }}#/cordova-docs/{{ crowdin_path }}{% endcapture %}
-
-                            {% assign edit_link = base_edit_link | replace:base_language,src_language | replace:base_version,dev_version %}
-
-                            <a class="edit" href="{{ edit_link }}"><span class="glyphicon glyphicon-pencil" aria-hidden="true"></span> {{ page.edit_source_text }}</a>
-                            <a class="edit" href="{{ crowdin_link }}"><span class="glyphicon glyphicon-pencil" aria-hidden="true"></span> {{ page.edit_translation_text }}</a>
-
-                        {% comment %}
-                        Edit-links for all other pages
-                        {% endcomment %}
+                        {% if page.version == site.latest_docs_version %}
+                            {% assign edit_link = base_edit_link | replace:base_version,dev_version %}
                         {% else %}
-
-                            {% comment %}
-                            Edit-link for latest version points to dev instead
-                            {% endcomment %}
-                            {% if page.version == site.latest_docs_version %}
-                                {% assign edit_link = base_edit_link | replace:base_version,dev_version %}
-                            {% else %}
-                                {% assign edit_link = base_edit_link %}
-                            {% endif %}
-
-                            <a class="edit" href="{{ edit_link }}"><span class="glyphicon glyphicon-pencil" aria-hidden="true"></span> {{ page.edit_source_text }}</a>
+                            {% assign edit_link = base_edit_link %}
                         {% endif %}
+
+                        <a class="edit" href="{{ edit_link }}"><span class="glyphicon glyphicon-pencil" aria-hidden="true"></span> {{ page.edit_source_text }}</a>
                     {% endif %}
+                {% endif %}
 
-                    <!-- Language dropdown -->
-                    <div class="dropdown">
-                        <button class="btn btn-default dropdown-toggle" type="button" id="languageDropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-                            {{ site.data.docs-versions[page.language].name }}
-                            <span class="caret"></span>
-                        </button>
+                <!-- Language dropdown -->
+                <div class="dropdown">
+                    <button class="btn btn-default dropdown-toggle" type="button" id="languageDropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+                        {{ site.data.docs-versions[page.language].name }}
+                        <span class="caret"></span>
+                    </button>
 
-                        <!-- List all languages -->
-                        <ul class="dropdown-menu" aria-labelledby="languageDropdown">
-                            {% for other_language_entry in site.data.docs-versions %}
+                    <!-- List all languages -->
+                    <ul class="dropdown-menu" aria-labelledby="languageDropdown">
+                        {% for other_language_entry in site.data.docs-versions %}
 
-                            {% assign other_language_id       = other_language_entry[0] %}
-                            {% assign other_language          = other_language_entry[1] %}
-                            {% assign other_language_versions = other_language.versions %}
-                            {% assign other_language_name     = other_language.name %}
+                        {% assign other_language_id       = other_language_entry[0] %}
+                        {% assign other_language          = other_language_entry[1] %}
+                        {% assign other_language_versions = other_language.versions %}
+                        {% assign other_language_name     = other_language.name %}
 
-                            {% capture other_language_root %}/docs/{{ other_language_id }}/{% endcapture %}
+                        {% capture other_language_root %}/docs/{{ other_language_id }}/{% endcapture %}
+
+                        {% comment %}
+                        Replace only the language part of the URI, thereby redirecting to the same page
+                        in the other language. The page will exist because translations are clones of each other.
+                        {% endcomment %}
+                        {% assign other_language_url = page.url | replace:LANGUAGE_ROOT,other_language_root %}
+
+                        <li>
+                            <a href="{{ site.baseurl }}{{ other_language_url }}" class="{% unless other_language_versions contains page.version %}missing-page{% endunless %}">
+                                {% if page.language == other_language_id %}
+                                    <span class="selected">
+                                        {{ other_language_name }}
+                                    </span>
+                                {% else %}
+                                    {{ other_language_name }}
+                                {% endif %}
+                            </a>
+                        </li>
+                        {% endfor %}
+                    </ul>
+                </div>
+
+                <!-- Version dropdown -->
+                <div class="dropdown">
+                    <button class="btn btn-default dropdown-toggle" type="button" id="versionDropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+                        {{ page.version }}
+                        {% if page.version == site.latest_docs_version %}
+                            ({{ page.latest_text }})
+                        {% endif %}
+                        <span class="caret"></span>
+                    </button>
+                    <ul class="dropdown-menu" aria-labelledby="versionDropdown">
+
+                        <!-- List versions available in this language -->
+                        {% for other_version in site.data.docs-versions[page.language].versions reversed %}
+                        <li>
+                            {% comment %}
+                            Name the latest version as "latest" to take advantage of redirects for "/latest/".
+                            {% endcomment %}
+                            {% if other_version == site.latest_docs_version %}
+                                {% assign other_version_string = "latest" %}
+                            {% else %}
+                                {% assign other_version_string = other_version %}
+                            {% endif %}
+
+                            {% capture version_entry_string %}
+                                {{ other_version }}
+                                {% if other_version == site.latest_docs_version %}
+                                    ({{ page.latest_text }})
+                                {% endif %}
+                            {% endcapture %}
 
                             {% comment %}
-                            Replace only the language part of the URI, thereby redirecting to the same page
-                            in the other language. The page will exist because translations are clones of each other.
+                            Replace only the version part of the URI, thereby redirecting to
+                            the same page in the other version.
+
+                            NOTE:
+                                    This page might not exist in the target version because page
+                                    layouts change from version to version
                             {% endcomment %}
-                            {% assign other_language_url = page.url | replace:LANGUAGE_ROOT,other_language_root %}
+                            {% capture other_version_root %}/docs/{{ page.language }}/{{ other_version_string }}/{% endcapture %}
+                            {% assign other_version_url = page.url | replace:VERSION_ROOT,other_version_root %}
 
-                            <li>
-                                <a href="{{ site.baseurl }}{{ other_language_url }}" class="{% unless other_language_versions contains page.version %}missing-page{% endunless %}">
-                                    {% if page.language == other_language_id %}
-                                        <span class="selected">
-                                            {{ other_language_name }}
-                                        </span>
-                                    {% else %}
-                                        {{ other_language_name }}
-                                    {% endif %}
-                                </a>
-                            </li>
-                            {% endfor %}
-                        </ul>
-                    </div>
+                            {% unless ALL_PAGES contains other_version_url %}
+                                {% assign other_version_url = other_version_root %}
+                            {% endunless %}
 
-                    <!-- Version dropdown -->
-                    <div class="dropdown">
-                        <button class="btn btn-default dropdown-toggle" type="button" id="versionDropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-                            {{ page.version }}
-                            {% if page.version == site.latest_docs_version %}
-                                ({{ page.latest_text }})
-                            {% endif %}
-                            <span class="caret"></span>
-                        </button>
-                        <ul class="dropdown-menu" aria-labelledby="versionDropdown">
-
-                            <!-- List versions available in this language -->
-                            {% for other_version in site.data.docs-versions[page.language].versions reversed %}
-                            <li>
-                                {% comment %}
-                                Name the latest version as "latest" to take advantage of redirects for "/latest/".
-                                {% endcomment %}
-                                {% if other_version == site.latest_docs_version %}
-                                    {% assign other_version_string = "latest" %}
-                                {% else %}
-                                    {% assign other_version_string = other_version %}
-                                {% endif %}
-
-                                {% capture version_entry_string %}
-                                    {{ other_version }}
-                                    {% if other_version == site.latest_docs_version %}
-                                        ({{ page.latest_text }})
-                                    {% endif %}
-                                {% endcapture %}
-
-                                {% comment %}
-                                Replace only the version part of the URI, thereby redirecting to
-                                the same page in the other version.
-
-                                NOTE:
-                                     This page might not exist in the target version because page
-                                     layouts change from version to version
-                                {% endcomment %}
-                                {% capture other_version_root %}/docs/{{ page.language }}/{{ other_version_string }}/{% endcapture %}
-                                {% assign other_version_url = page.url | replace:VERSION_ROOT,other_version_root %}
-
-                                {% unless ALL_PAGES contains other_version_url %}
-                                    {% assign other_version_url = other_version_root %}
-                                {% endunless %}
-
-                                <a href="{{ site.baseurl }}{{ other_version_url }}" class="{% unless ALL_PAGES contains other_version_url %}missing-page{% endunless %}">
-                                    {% if page.version == other_version %}
-                                        <span class="selected">
-                                            {{ version_entry_string }}
-                                        </span>
-                                    {% else %}
+                            <a href="{{ site.baseurl }}{{ other_version_url }}" class="{% unless ALL_PAGES contains other_version_url %}missing-page{% endunless %}">
+                                {% if page.version == other_version %}
+                                    <span class="selected">
                                         {{ version_entry_string }}
-                                    {% endif %}
-                                </a>
-                            </li>
-                            {% endfor %}
-                        </ul>
-                    </div>
+                                    </span>
+                                {% else %}
+                                    {{ version_entry_string }}
+                                {% endif %}
+                            </a>
+                        </li>
+                        {% endfor %}
+                    </ul>
                 </div>
+            </div>
 
-                {% comment %}
-                Get URL for this page in the latest version
-                {% endcomment %}
-                {% capture latest_root %}/docs/{{ page.language }}/latest/{% endcapture %}
-                {% assign latest_url = page.url | replace:VERSION_ROOT,latest_root %}
+            {% comment %}
+            Get URL for this page in the latest version
+            {% endcomment %}
+            {% capture latest_root %}/docs/{{ page.language }}/latest/{% endcapture %}
+            {% assign latest_url = page.url | replace:VERSION_ROOT,latest_root %}
 
-                {% comment %}
-                If this page doesn't exist, just use root
-                {% endcomment %}
-                {% unless ALL_PAGES contains latest_url %}
-                    {% assign latest_url = latest_root %}
-                {% endunless %}
+            {% comment %}
+            If this page doesn't exist, just use root
+            {% endcomment %}
+            {% unless ALL_PAGES contains latest_url %}
+                {% assign latest_url = latest_root %}
+            {% endunless %}
 
-                <!-- Show warnings for special versions -->
-                <!-- dev warning -->
-                {% if page.version == 'dev' %}
-                    <div class="alert docs-alert alert-info" role="alert">
-                        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-                            <span aria-hidden="true">&times;</span>
-                        </button>
-                        {{ page.in_development_text }}
-                        <a href="{{ site.baseurl }}{{ latest_url }}">
-                            {{ page.click_here_text }}
-                        </a>
-                    </div>
-                {% endif %}
-
-                <!-- outdated warning -->
-                {% if page.version != 'dev' and page.version != site.latest_docs_version %}
-                    <div class="alert docs-alert alert-danger" role="alert">
-                        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-                            <span aria-hidden="true">&times;</span>
-                        </button>
-                        {{ page.outdated_text }}
-                        <a href="{{ site.baseurl }}{{ latest_url }}">
-                            {{ page.click_here_text }}
-                        </a>
-                    </div>
-                {% endif %}
-
-                <!-- plugin version warning -->
-                {% if page.plugin_name and page.plugin_version %}
-                    <div class="alert alert-warning docs-alert" role="alert">
-                        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-                            <span aria-hidden="true">&times;</span>
-                        </button>
-                        {{ page.plugin_version_text }} {{ page.plugin_version }}.
-                        <a href="https://github.com/apache/{{ page.plugin_name }}/releases">
-                            {{ page.visit_github_text }}
-                        </a>
-                    </div>
-                {% endif %}
-
-                <div id="page-toc-source">
-                    {{ content }}
+            <!-- Show warnings for special versions -->
+            <!-- dev warning -->
+            {% if page.version == 'dev' %}
+                <div class="alert docs-alert alert-info" role="alert">
+                    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                    {{ page.in_development_text }}
+                    <a href="{{ site.baseurl }}{{ latest_url }}">
+                        {{ page.click_here_text }}
+                    </a>
                 </div>
+            {% endif %}
+
+            <!-- outdated warning -->
+            {% if page.version != 'dev' and page.version != site.latest_docs_version %}
+                <div class="alert docs-alert alert-danger" role="alert">
+                    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                    {{ page.outdated_text }}
+                    <a href="{{ site.baseurl }}{{ latest_url }}">
+                        {{ page.click_here_text }}
+                    </a>
+                </div>
+            {% endif %}
+
+            <!-- plugin version warning -->
+            {% if page.plugin_name and page.plugin_version %}
+                <div class="alert alert-warning docs-alert" role="alert">
+                    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                    {{ page.plugin_version_text }} {{ page.plugin_version }}.
+                    <a href="https://github.com/apache/{{ page.plugin_name }}/releases">
+                        {{ page.visit_github_text }}
+                    </a>
+                </div>
+            {% endif %}
+
+            <div id="page-toc-source">
+                {{ content }}
             </div>
         </div>
         <div class="row">

--- a/www/static/css-src/_docs.scss
+++ b/www/static/css-src/_docs.scss
@@ -1,18 +1,30 @@
 .docs {
+    $toc-width: 320px;
+
+    display: flex;
+    justify-content: center;
     width: 100%;
     height: 100%;
-    margin: 0px;
-    padding: 0px;
+    margin: 0;
+    padding: 0;
     font-family: "Raleway", Helvetica, Arial, sans-serif;
+    font-size: 18px;
+    line-height: 1.6;
 
-    /* this is so that wide images don't stick out of their paragraphs */
+    @media (max-width: 991px) {
+        font-size: 16px;
+    }
+
     p {
+        margin-bottom: .8em;
+
         img {
             max-width: 100%;
         }
     }
 
     pre {
+        margin: 15px 0;
         word-wrap: normal;
 
         code {
@@ -69,45 +81,41 @@
     /* outer ToC for the site */
     .site-toc-container {
         position: fixed;
-        height: 100%;
+        top: 50px;
+        left: 0;
+        height: calc(100% - 50px);
+        width: $toc-width;
         overflow-y: scroll;
+        overflow-x: hidden;
         background: $gray-85;
 
         .site-toc {
-
-            /* NOTE: the bottom padding is special because it offsets the header */
-            padding-top: 35px;
-            padding-bottom: 80px;
-            padding-left: 55px;
-            padding-right: 10px;
+            padding: 10px 15px;
 
             li {
                 list-style: none;
             }
+
             > li {
                 font-size: 16px;
-                font-weight: 600;
                 padding-top: 0.05em;
                 line-height: 30px;
                 a {
                     color: white;
+                    display: block;
+                    padding: 0 50%;
+                    margin: 0 -50%;
+
                     &.this-page {
                         font-weight: bold;
+                        background-color: $brand-primary-darker;
                     }
-                }
-                .entry-highlight {
-                    width: 200%;
-                    position: absolute;
-                    height: 31px;
-                    background-color: #d60c3f;
-                    opacity: 0.7;
-                    margin-left: -100%;
-                    z-index: -1;
                 }
             }
             .toc-section-heading {
-                font-size: 30px;
-                font-weight: 300;
+                font-size: 18px;
+                font-weight: 600;
+                text-transform: uppercase;
                 margin: 0.3em 0em 0.3em 0em;
                 display: block;
                 color: $brand-primary;
@@ -115,51 +123,50 @@
 
             /* NOTE: this is not a mistake; .site-toc gets nested inside itself */
             .site-toc {
-                padding-left: 15px;
-                padding-right: 0px;
-                padding-top: 0px;
-                padding-bottom: 0px;
+                padding: 0 0 0 10px;
+
                 .toc-section-heading {
                     font-size: 16px;
                     font-weight: 600;
+                    text-transform: none;
                 }
+            }
+        }
+
+        // Only the top level table of contents
+        > .site-toc {
+            > li {
+                margin-bottom: 1rem;
             }
         }
     }
 
-    /* non-IE scrollbar styling */
-    .site-toc-container::-webkit-scrollbar {
-        width: 13px;  /* for vertical scrollbars */
-        height: 13px; /* for horizontal scrollbars */
-    }
-    .site-toc-container::-webkit-scrollbar-track {
-        background-color: black;
-    }
-    .site-toc-container::-webkit-scrollbar-thumb {
-        background-color: $gray-70;
-    }
-
-    /* IE-only scrollbar styling */
-    .site-toc-container {
-        scrollbar-arrow-color: $gray-70;
-        scrollbar-face-color: $gray-70;
-        scrollbar-highlight-color: black;
-        scrollbar-shadow-color: $gray-70;
-    }
-
     .page-content-container {
-        padding: 0px;
+        margin-left: $toc-width;
+        width: calc(100% - #{$toc-width});
+
+        @media (max-width: 991px) {
+            margin-left: 0;
+            width: 100%;
+        }
+
         .page-content {
-            margin-bottom: 20px;
+            width: 960px;
+            max-width: 100%;
+            margin: 0 auto 50px;
+            padding: 0 50px;
+
+            @media (max-width: 991px) {
+                padding: 0 15px;
+            }
+
             .header-link {
                 position: relative;
                 left: 0.5em;
                 opacity: 0;
                 font-size: 0.7em;
 
-                -webkit-transition: opacity 0.2s ease-in-out 0.1s;
-                -moz-transition: opacity 0.2s ease-in-out 0.1s;
-                -ms-transition: opacity 0.2s ease-in-out 0.1s;
+                transition: opacity 0.2s ease-in-out 0.1s;
             }
             h1:hover .header-link,
             h2:hover .header-link,
@@ -173,7 +180,7 @@
                 color: #2C7185;
             }
             h1 {
-                font-size: 48px;
+                font-size: 42px;
                 font-weight: 300;
             }
             h2 {
@@ -186,6 +193,12 @@
             }
             h3, h4, h5, h6 {
                 font-weight: 600;
+            }
+            h4 {
+                margin-top: 20px;
+            }
+            h5 {
+                margin-top: 16px;
             }
         }
     }
@@ -267,6 +280,7 @@
     table {
         @extend .table;
         @extend .table-bordered;
+        margin: 20px 0;
     }
 
     .docs-alert {
@@ -389,6 +403,10 @@
             width: 240px;
             height: 120px;
         }
+    }
+
+    footer {
+        font-size: 14px;
     }
 }
 

--- a/www/static/js/docs.js
+++ b/www/static/js/docs.js
@@ -32,13 +32,13 @@ var platforms = {
 
 $(document).ready(function () {
 
-    var HEADER_OFFSET  = 56; // in pixels
-    var TOC_TOP_OFFSET = HEADER_OFFSET + 55;
+    var HEADER_OFFSET  = 50; // in pixels
+    var TOC_TOP_OFFSET = HEADER_OFFSET + 40;
 
     // if this page's ToC entry can be found, scroll the ToC to it
-    var thisPageEntry = $(".this-page");
+    var thisPageEntry = $(".site-toc-container .this-page");
     if (thisPageEntry.length > 0) {
-        $(".site-toc-container").scrollTop(thisPageEntry.first().offset().top - TOC_TOP_OFFSET);
+        $(".site-toc-container").scrollTop(thisPageEntry.first().position().top - TOC_TOP_OFFSET);
     }
 
     function slugifyLikeGitHub(originalText) {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Docs

### What does this PR do?
Recently, while using the docs, I've found them difficult to navigate and to read. I've made some minor changes to the design in an attempt to make them more readable and easy to use.

I have made the table of contents less wide on larger screens. Additionally I have reduced its padding and changed the styling of the headers to make separation a bit more obvious.

In the main content area, I have increased the line height and header margins to make things a bit easier to read. I have also set a max width on the content to make the text flow better on larger screens.

I've based the changes on docs for popular frameworks such as the [Vue docs](https://vuejs.org/v2/guide/) and [React docs](https://reactjs.org/docs/hello-world.html), as well as the [Onsen UI docs](https://onsen.io/v2/guide/), which I updated recently.

Below are before and after screenshots taken in Chrome set at 1920x1080 resolution. At this resolution, you can see that the text in the content runs on quite long, making it hard to follow.

Before:
![Android page before, 1920x1080](https://user-images.githubusercontent.com/2932890/41829345-255da514-7875-11e8-806d-fcc348939ebe.png)

After:
![Android page after, 1920x1080](https://user-images.githubusercontent.com/2932890/41881881-cd89b7fe-7920-11e8-9279-b07991d2867d.png)

And at a lower resolution, 1280x720. In this example, you can see the padding in the table of contents is taking up more space than it should be.

Before:
![Android page before, 1280x720](https://user-images.githubusercontent.com/2932890/41829610-b4fdb6ea-7876-11e8-878a-0a3aa2d53941.png)

After:
![Android page after, 1280x720](https://user-images.githubusercontent.com/2932890/41881895-e0d04cba-7920-11e8-8739-e844ae9edfb2.png)

### What testing has been done on this change?
Tested on Chrome, Firefox and Safari on macOS, and Edge on Windows.

### Checklist
- [ ] Commit message follows the format: "GH-3232: (android) Fix bug with resolving file paths", where GH-xxxx is the GitHub issue ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
