### PR TITLE
CB-14139 android: Add jvmargs flag for custom values

### DIFF
--- a/www/docs/en/dev/guide/platforms/android/index.md
+++ b/www/docs/en/dev/guide/platforms/android/index.md
@@ -241,6 +241,16 @@ Instead, these two files should be copied from another location into that folder
 as part of the build command by using the `before_build`
 [hook](../../appdev/hooks/index.html).
 
+#### Configuring Gradle's JVM memory settings
+It is possible to adjust the Gradle's JVM memory by
+[configuring](https://docs.gradle.org/current/userguide/build_environment.html#sec:configuring_jvm_memory) the JVM settings that Cordova exposes.
+
+Cordova's default flag is`-Xmx2048m`. You can change this property by using the `--jvmargs` flag in your Cordova `build` or `run` commands:
+
+```bash
+$ cordova run android -- --jvmargs=-Xmx1024m
+```
+
 #### Extending build.gradle
 
 If you need to customize `build.gradle`, rather than edit it directly, you


### PR DESCRIPTION
### Platforms affected
Android

### What does this PR do?
Updated docs to explain how to customize the Gradle JVM heap size memory settings.

This document change is related to the changes from [cordova-android PR 459](https://github.com/apache/cordova-android/pull/459)

JIRA Ticket: [CB-14139](https://issues.apache.org/jira/browse/CB-14139)

### What testing has been done on this change?
- Built the docs.

### Checklist
- [X] Commit message follows the format: "GH-3232: (android) Fix bug with resolving file paths", where GH-xxxx is the GitHub issue ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
