### PR TITLE
CB-14203 fix cordova-android@7.1.1 blog post

### DIFF
--- a/www/_posts/2018-07-18-cordova-android-7.1.1.md
+++ b/www/_posts/2018-07-18-cordova-android-7.1.1.md
@@ -25,9 +25,9 @@ To add it explicitly:
 
 ## Curated Changelog
 
-* Fix unsafe property access in run.js (#445)
-* Emit log event instead of logging directly (#452)
-* [CB-14101](https://issues.apache.org/jira/browse/CB-14101) Fix Java version check for Java >= 9 (#446)
+* [CB-14101](https://issues.apache.org/jira/browse/CB-14101) Fix Java version check for Java >= 9 ([GH-446](https://github.com/apache/cordova-android/pull/446))
+* [GH-445](https://github.com/apache/cordova-android/pull/445): Fix unsafe property access in run.js
+* [GH-452](https://github.com/apache/cordova-android/pull/452): Emit log event instead of logging directly
 * [CB-14127](https://issues.apache.org/jira/browse/CB-14127) (android) Move google maven repo ahead of jcenter
 * [CB-13923](https://issues.apache.org/jira/browse/CB-13923) (android) fix -1 length for compressed files
 * [CB-14145](https://issues.apache.org/jira/browse/CB-14145) use cordova-common@2.2.5 and update other dependencies to resolve `npm audit` warnings


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android

### What does this PR do?

Use cordova-android GH links for PR references, as requested by @dpogue in GH-843.

Also using cordova-android GH link for CB-14101 (fix Java version check for Java >= 9), which was not originally part of GH-843.

Root cause: I had already fixed as requested by @dpogue on web interface, but then renamed the post on my local machine which was the old version.

Thanks to @janpio for pointing this out.

### What testing has been done on this change?

- [x] Visual inspection
- [x] Check results of preview on GitHub

### Checklist

- [x] Commit message follows the format: "GH-3232: (android) Fix bug with resolving file paths", where GH-xxxx is the GitHub issue ID & "android" is the platform affected.
- ~~Added automated test coverage as appropriate for this change.~~