### PR TITLE
Full android.util.Config class name for Android

### DIFF
--- a/www/docs/en/dev/guide/platforms/android/webview.md
+++ b/www/docs/en/dev/guide/platforms/android/webview.md
@@ -69,7 +69,7 @@ legacy `CordovaActivity` component that pre-dates the 1.9 release.
                 super.onCreate(savedInstanceState);
                 setContentView(R.layout.main);
                 cwv = (CordovaWebView) findViewById(R.id.tutorialView);
-                Config.init(this);
+                android.util.Config.init(this);
                 cwv.loadUrl(Config.getStartUrl());
             }
 


### PR DESCRIPTION
in embedding Android webview doc

to avoid the following potential pitfalls:
- use of "config" with small 'c'
- failure to explicitly import from android.util package

ref:
- <https://stackoverflow.com/questions/45505956/trying-to-embed-cordova-app-into-native-android>
- <https://github.com/apache/cordova-android/issues/494>