### PR TITLE
Updated License with a Valid SPDX License

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "eslint": "eslint tools/lib tools/spec"
   },
   "author": "Apache Software Foundation",
-  "license": "Apache Version 2.0",
+  "license": "Apache-2.0",
   "dependencies": {
     "baconjs": "^0.7.70",
     "browser-sync": "^2.8.0",


### PR DESCRIPTION
### Platforms affected
none

### What does this PR do?
Fixes the NPM's invalid license warning message. The `package.json` contains an invalid SPDX license expression.

**Warning Message**
```
npm WARN ... license should be a valid SPDX license expression
```
**Changes**
`"license": "Apache Version 2.0",` becomes `"license": "Apache-2.0",`

### What testing has been done on this change?
- `npm i`