### PR TITLE
update example on buildConfig

### DIFF
--- a/www/docs/en/dev/guide/platforms/android/index.md
+++ b/www/docs/en/dev/guide/platforms/android/index.md
@@ -345,7 +345,7 @@ build configuration file:
 {
     "android": {
         "debug": {
-            "keystore": "../android.keystore",
+            "keystore": "~/android.keystore",
             "storePassword": "android",
             "alias": "mykey1",
             "password" : "password",
@@ -361,6 +361,7 @@ build configuration file:
     }
 }
 ```
+`~` is relate to `HOME` path enviroment variable.
 
 For release signing, passwords can be excluded and the build system will issue a
 prompt asking for the password.


### PR DESCRIPTION
### Platforms affected
Android

### What does this PR do?
There is no tutorial or any example on google or the docs. I dont event know that `~` can relate to `HOME` path. It take me 5 hours to searching, and finally I have to go to source code to read and find out that can help me. I hope on small change can help people working on multi device can easy locate that home path to point to `.android` folder more easy.

### What testing has been done on this change?


### Checklist
- [ ] Commit message follows the format: "GH-3232: (android) Fix bug with resolving file paths", where GH-xxxx is the GitHub issue ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
