### PR TITLE
Feb 2019 Cordova Browser 6.0.0 Release Blog Post

### DIFF
--- a/www/_posts/2019-02-04-cordova-browser-6.0.0.md
+++ b/www/_posts/2019-02-04-cordova-browser-6.0.0.md
@@ -1,0 +1,29 @@
+---
+layout: post
+author:
+    name: Bryan Ellis
+title:  "Cordova Browser 6.0.0 Released!"
+categories: announcements
+tags: news releases
+---
+
+We are happy to announce that we have just released `Cordova Browser 6.0.0`! This is one of Cordova's supported platforms for building browser targeted applications.
+
+* [cordova-browser@6.0.0](https://www.npmjs.com/package/cordova-browser)
+
+## Release Highlights
+
+As NodeJS 4.x support has been dropped by the NodeJS team on April 30th, 2018, we have raised the minimum required NodeJS version for this release to 6.x.
+
+Please report any issues you find at [issues.cordova.io](http://issues.cordova.io/)!
+
+<!--more-->
+# Changes include:
+
+* [GH-70](https://github.com/apache/cordova-browser/pull/70) Browser Platform Release Preparation (Cordova 9)
+* [CB-13740](https://issues.apache.org/jira/browse/CB-13740) Return expected promise resolving with array
+* [GH-59](https://github.com/apache/cordova-browser/pull/59) Remove Bundled Dependencies
+* [CB-14073](https://issues.apache.org/jira/browse/CB-14073) **Browser**: Drop Node 4, Added Node 10
+* [CB-14252](https://issues.apache.org/jira/browse/CB-14252) Allow to send --silent arg to run command to disable output (#57)
+* [CB-13999](https://issues.apache.org/jira/browse/CB-13999) (browser) - Reading `config.xml` respects base href (#52)
+* [GH-50](https://github.com/apache/cordova-browser/pull/50) corrected path for `config.xml`


### PR DESCRIPTION
### Platforms affected
none

### What does this PR do?
Adds Cordova Browser 6.0.0 Release Blog Post

### What testing has been done on this change?
none