### PR TITLE
(ios) Add small@3x icon to list of iOS icon resources

### DIFF
--- a/www/docs/en/dev/config_ref/images.md
+++ b/www/docs/en/dev/config_ref/images.md
@@ -174,6 +174,7 @@ Icons are not applicable to the Browser platform.
         <!-- iPhone Spotlight and Settings Icon -->
         <icon src="res/ios/icon-small.png" width="29" height="29" />
         <icon src="res/ios/icon-small@2x.png" width="58" height="58" />
+        <icon src="res/ios/icon-small@3x.png" width="87" height="87" />
         <!-- iPad Spotlight and Settings Icon -->
         <icon src="res/ios/icon-50.png" width="50" height="50" />
         <icon src="res/ios/icon-50@2x.png" width="100" height="100" />


### PR DESCRIPTION
In cordova-ios 4.5.x, if the other sizes are defined but this previously-undocumented
one is not, the default Cordova icon seems to be dropped in place for it.

That seems unlikely to be the result anyone using custom icons will actually want, so
I added it to the list.

### Platforms affected

Documentation (iOS)

### What does this PR do?

Adds small@3x icon to list of iOS icon resources in the docs.

### What testing has been done on this change?

None.

### Checklist
- [X] Commit message follows the format: "GH-3232: (android) Fix bug with resolving file paths", where GH-xxxx is the GitHub issue ID & "android" is the platform affected.
- [X] Added automated test coverage as appropriate for this change.
