### PR TITLE
Added Cordova Android to API/Android version support

### DIFF
--- a/www/docs/en/9.x/guide/platforms/android/index.md
+++ b/www/docs/en/9.x/guide/platforms/android/index.md
@@ -37,12 +37,13 @@ the CLI, see [Cordova CLI Reference][cli_reference].
 Cordova for Android requires the Android SDK which can be installed
 on OS X, Linux or Windows. See the Android SDK's
 [System Requirements](http://developer.android.com/sdk/index.html#Requirements).
-Cordova's latest Android package supports up to Android [API Level](http://developer.android.com/guide/topics/manifest/uses-sdk-element.html#ApiLevels) 27.
+Cordova's latest Android package supports up to Android [API Level](http://developer.android.com/guide/topics/manifest/uses-sdk-element.html#ApiLevels) 28.
 The supported Android API Levels and Android Versions for the past
 few cordova-android releases can be found in this table:
 
 cordova-android Version | Supported Android API-Levels | Equivalent Android Version
 ------------------------|------------------------------|-----------------------------
+8.X.X                   | 19 - 28                      | 4.4 - 9.0.0
 7.X.X                   | 19 - 27                      | 4.4 - 8.1
 6.X.X                   | 16 - 26                      | 4.1 - 8.0.0
 5.X.X                   | 14 - 23                      | 4.0 - 6.0.1

--- a/www/docs/en/dev/guide/platforms/android/index.md
+++ b/www/docs/en/dev/guide/platforms/android/index.md
@@ -37,12 +37,13 @@ the CLI, see [Cordova CLI Reference][cli_reference].
 Cordova for Android requires the Android SDK which can be installed
 on OS X, Linux or Windows. See the Android SDK's
 [System Requirements](http://developer.android.com/sdk/index.html#Requirements).
-Cordova's latest Android package supports up to Android [API Level](http://developer.android.com/guide/topics/manifest/uses-sdk-element.html#ApiLevels) 27.
+Cordova's latest Android package supports up to Android [API Level](http://developer.android.com/guide/topics/manifest/uses-sdk-element.html#ApiLevels) 28.
 The supported Android API Levels and Android Versions for the past
 few cordova-android releases can be found in this table:
 
 cordova-android Version | Supported Android API-Levels | Equivalent Android Version
 ------------------------|------------------------------|-----------------------------
+8.X.X                   | 19 - 28                      | 4.4 - 9.0.0
 7.X.X                   | 19 - 27                      | 4.4 - 8.1
 6.X.X                   | 16 - 26                      | 4.1 - 8.0.0
 5.X.X                   | 14 - 23                      | 4.0 - 6.0.1


### PR DESCRIPTION
### Platforms affected
none

### Motivation and Context
Update docs with latest and accurate information.

### Description
Added information about the API and Android version support on `cordova-android@8.x`.

### Testing
none

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
