### PR TITLE
Blog: Cordova's Timeline for Node 6.x & 8.x Deprecation & Node 12.x Support

### DIFF
--- a/www/_posts/2019-04-11-nodejs-6.x-8.x-deprecation-timeline.md
+++ b/www/_posts/2019-04-11-nodejs-6.x-8.x-deprecation-timeline.md
@@ -1,0 +1,47 @@
+---
+layout: post
+author:
+    name: Bryan Ellis
+title: "Node 6.x and 8.x Deprecation Timeline for Apache Cordova"
+categories: news
+tags: deprecation timeline node
+---
+
+Currently, all of the latest released platforms, tools, and core libraries require a minimum version of `node 6.x` to be installed. Additionally, we have added support for `node 10.x`.
+
+The Node.js Foundation has reported that the End-of-Life (EOL) for version 6.x will be April 30th, 2019. Looking ahead, the Node.JS Foundation has also scheduled the deprecation of 8.x on December 31, 2019 to be aligned with the scheduled End-of-Life of OpenSSL-1.0.2.
+
+Since October 30th, 2018, `node 10.x` has started its active Long Term Support ([LTS][1]) period. Thus, as `node 10.x` is the default download from [Node.js](https://nodejs.org/en/), we also recommend users to upgrade to the current LTS (10.x) before/by the time 8.x has reached EOL.
+
+During these two distinct deprecation periods, we will prepare our tools, platforms, core libraries, and plugins to follow the Node.js Foundation reported EOL schedule.
+
+We will also plan to add `node 12.x` support. Currently, `node 12.x` is pending for release on April 23rd, 2019.
+
+JavaScript files in plugins themselves are unaffected since the JavaScript support for them is dependent on platform browser support. For the Electron platform, if using Node.js APIs there is a possibility of experience an effect.  
+
+<!--more-->
+
+## Cordova Timeline
+
+### **March 2019**
+
+* All AppVeyor/Travis CI builds will continue to test on Node.js 6.x, 8.x, and 10.x.
+
+### **April 30th, 2019**
+
+* All AppVeyor/Travis CI builds will test on Node.js 6.x, 8.x, 10.x, and 12.x.
+* Update requirement check and notify users that using Node.js 6.x, was deprecated by the Node team and is not recommended to use and should upgrade to the minimum LTS (10.x).
+
+### **September 2019**
+
+* Update requirement check and notify deprecation warning if the user is using Node.js 6.x and 8.x and recommend to upgrade to the minimum LTS (10.x).
+
+### **December 31st, 2019**
+
+* Deprecate use of Node.js 6.x
+* Deprecate use of Node.js 8.x
+* Officially Add support for Node.js 12.x
+* Platforms, tools, and core libraries to bump up a major version.
+* All AppVeyor/Travis CI builds will test on Node.js 10.x, and 12.x.
+
+[![Cordova Dode Deprecation Timeline](https://github.com/nodejs/Release/blob/2bf2ea36a162571c0aee21f813f51de790c08feb/schedule.svg)](https://github.com/nodejs/Release/blob/2bf2ea36a162571c0aee21f813f51de790c08feb/schedule.svg)

--- a/www/_posts/2019-04-11-nodejs-6.x-8.x-deprecation-timeline.md
+++ b/www/_posts/2019-04-11-nodejs-6.x-8.x-deprecation-timeline.md
@@ -27,20 +27,20 @@ JavaScript files in plugins themselves are unaffected since the JavaScript suppo
 
 * All AppVeyor/Travis CI builds will continue to test on Node.js 6.x, 8.x, and 10.x.
 
-### **April 30th, 2019**
+### **April 2019**
 
 * All AppVeyor/Travis CI builds will test on Node.js 6.x, 8.x, 10.x, and 12.x.
-* Update requirement check and notify users that using Node.js 6.x, was deprecated by the Node team and is not recommended to use and should upgrade to the minimum LTS (10.x).
+* Update requirement check and notify users: `Warning: Node.js 6.x has been deprecated. Please upgrade to the latest Node.js version available (LTS version recommended).`
 
-### **September 2019**
+### **Fall 2019**
 
-* Update requirement check and notify deprecation warning if the user is using Node.js 6.x and 8.x and recommend to upgrade to the minimum LTS (10.x).
+* Update requirement check and notify users: `Warning: Node.js 8.x has been deprecated. Please upgrade to the latest Node.js version available (LTS version recommended).`
 
-### **December 31st, 2019**
+### **Winter 2019**
 
-* Deprecate use of Node.js 6.x
-* Deprecate use of Node.js 8.x
-* Officially Add support for Node.js 12.x
+* Removed Node.js 6.x support.
+* Removed Node.js 8.x support.
+* Added Node.js 12.x  support.
 * Platforms, tools, and core libraries to bump up a major version.
 * All AppVeyor/Travis CI builds will test on Node.js 10.x, and 12.x.
 


### PR DESCRIPTION
### Platforms affected
none

### Motivation and Context
Old node deprecation and new version release.

### Description
Blog post about Cordova's timeline with node version support.

### Testing
none

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
