### PR TITLE
Updated Platform and Plugin Versioning

### DIFF
--- a/www/docs/en/9.x/platform_plugin_versioning_ref/index.md
+++ b/www/docs/en/9.x/platform_plugin_versioning_ref/index.md
@@ -23,224 +23,291 @@ description: How to manage platforms and Cordova CLI versions.
 ---
 
 # Platforms and Plugins Version Management
-From version 4.3.0 onwards, Cordova provides the ability to save and restore platforms and plugins.
+
+Cordova provides the ability to save and restore platforms and plugins.
 
 This feature allows developers to save and restore their app to a known state without having to check in all of the platform and plugin source code.
 
-When adding a platform or plugin, details about the app's platform and plugin versions are automatically saved in config.xml and package.json. It is possible to add a platform or plugin by editing package.json or config.xml directly, assuming you know the right tags + syntax. It is not possible to remove plugins or platforms in this manner. The recommended method of adding and removing plugins and platforms is with the command line cordova commands `cordova plugin add|remove ...` and `cordova platform add|remove ...` to avoid any out of sync issues.
+When adding a platform or plugin, details about the app's platform and plugin versions are automatically saved to the `package.json` file. It is also possible to add a platform or plugin by editing the `package.json` file directly, assuming you know the right tags and syntax. It is not possible to remove plugins or platforms in this manner. The recommended method of adding and removing plugins and platforms is with the Cordova CLI commands `cordova plugin add|remove ...` and `cordova platform add|remove ...` to avoid any out of sync issues.
 
-The 'restore' step happens automatically when a **'cordova prepare'** is issued, making use of information previously saved in the config.xml and package.json files.
+The **restore** step happens automatically when a **`cordova prepare`** is issued, making use of information previously saved in the `package.json` and `config.xml` files.
 
 One scenario where save/restore capabilities come in handy is in large teams that work on an app, with each team member focusing on a platform or plugin. This feature makes it easier to share the project and reduce the amount of redundant code that is checked in the repository.
 
-
 ## Platform Versioning
 
-### Saving platforms
-To save a platform, you issue the following command :
+### Saving Platforms
+
+To save a platform, issue the following command:
 
 ```bash
-$ cordova platform add <platform[@<version>] | directory | git_url>
+cordova platform add <platform[@<version>] | directory | git_url>
 ```
 
-After running the above command, the resulting config.xml looks like :
+After running the above command, the **`package.json`** should contain something as seen below:
 
-```xml
-<?xml version='1.0' encoding='utf-8'?>
-    ...
-    <engine name="android" spec="~4.0.0" />
-    ...
-</xml>
+```json
+"cordova": {
+  "platforms": [
+    "android"
+  ]
+},
+"dependencies": {
+  "cordova-android": "^8.0.0",
+}
 ```
-After running the above command, the resulting package.json looks like :
+
+The `--nosave` flag prevents adding and deleting specified platforms to the `package.json` file. To prevent saving a platform, issue the following command:
 
 ```bash
-"cordova": {"platforms": ["android"]},"dependencies": {"cordova-android": "^4.0.0"}
+cordova platform add <platform[@<version>] | directory | git_url> --nosave
 ```
-The '--nosave' flag prevents adding and deleting specified platforms from config.xml and package.json. To prevent saving a platform, you issue the following command :
+
+Some Examples:
+
+* **`cordova platform add android`** 
+
+  Retrieves the pinned version of `cordova-android` platform from npm, adds it to the project and updates the `package.json` file.
+
+* **`cordova platform add android@7.1.4`**
+
+  Retrieves the `cordova-android` platform version `7.1.4` from npm, adds it to the project and updates the `package.json` file.
+
+* **`cordova platform add https://github.com/apache/cordova-android.git`**
+  
+  **`cordova platform add https://github.com/apache/cordova-android`**
+  
+  **`cordova platform add github:apache/cordova-android`**
+
+  npm retrieves the `cordova-android` platform from the git repository, adds it to the project and updates the `package.json`.
+  
+* **`cordova platform add C:/path/to/android/platform`**
+
+  Retrieves the Android platform from the specified directory, adds it to the project, and updates the `package.json` file.
+
+* **`cordova platform add android --nosave`**
+
+  Retrieves the pinned version of `cordova-android` platform from npm, adds it to the project, but does not add it to the `package.json` file.
+
+### Updating or Removing Platforms
+
+It is possible to update and delete a platform from `config.xml` and `package.json`.
+
+To update a platform, execute the following command:
 
 ```bash
-$ cordova platform add <platform[@<version>] | directory | git_url> --nosave
+cordova platform update <platform[@<version>] | directory | git_url> --save
 ```
 
-Some examples :
-
-  * **'cordova platform add android'** => retrieves the pinned version of the android platform, adds it to the project and then updates config.xml and package.json.
-  * **'cordova platform add android@3.7.0'** => retrieves the android platform, version 3.7.0 from npm, adds it to the project and then updates config.xml and package.json.
-  * **'cordova platform add https://github.com/apache/cordova-android.git'** => npm installs the specified cordova-android from the git repository, adds the android platform to the project, then updates config.xml and package.json and points its version to the specified git-url.
-  * **'cordova platform add C:/path/to/android/platform'** => retrieves the android platform from the specified directory, adds it to the project, then updates config.xml and package.json and points to the directory.
-  * **'cordova platform add android --nosave'** => retrieves the pinned version of the android platform, adds it to the project, but does not add it to config.xml or package.json.
-  * **'cordova platform remove android --nosave'** =>  removes the android platform from the project, but does not remove it from config.xml or package.json.  
-
-### Mass saving platforms on an existing project
-If you have a pre-existing project and you want to save all the currently added platforms in your project, you can use :
+To remove a platform, execute one of the following commands:
 
 ```bash
-$ cordova platform save
+cordova platform remove <platform>
+cordova platform rm <platform>
 ```
 
-### Updating / Removing platforms
-It is also possible to update/delete from config.xml and package.json during the commands 'cordova platform update' and 'cordova platform remove' :
+Some Examples:
 
-```bash
-$ cordova platform update <platform[@<version>] | directory | git_url> --save
-$ cordova platform remove <platform>
-```
+* **`cordova platform update android --save`**
 
-Some examples :
+  In addition to updating the `cordova-android` platform to the pinned version, it updates the `package.json` file.
 
-  * **'cordova platform update android --save'** => In addition to updating the android platform to the pinned version, update config.xml entry
-  * **'cordova platform update android@3.8.0 --save'** => In addition to updating the android platform to version 3.8.0, update config.xml entry
-  * **'cordova platform update /path/to/android/platform --save'** => In addition to updating the android platform to version in the folder, update config.xml entry
-  * **'cordova platform remove android'** => Removes the android platform from the project and deletes its entry from config.xml and package.json.
+* **`cordova platform update android@3.8.0 --save`**
 
+  In addition to updating the `cordova-android` platform to version `3.8.0` it updates the `package.json` file.
 
-### Restoring platforms
+* **`cordova platform update /path/to/android/platform --save`**
 
-Platforms are automatically restored from package.json and config.xml when the **'cordova prepare'** command is run. After prepare is run, package.json and config.xml should contain identical platforms and versions.
+  In addition to updating the `cordova-android` platform to version found in the provided folder, it updates the `package.json` file.
 
-If you add a platform without specifying a version/folder/git_url, the version to install is taken from package.json or config.xml, **if found**. In case of conflicts, package.json is given precedence over config.xml.
+* **`cordova platform remove android`**
+
+  Removes the `cordova-android` platform from the project and removes it from the `package.json` file.
+  
+  _Note: If the platform definition existed in `config.xml` from a previous version of Cordova CLI, it will also be removed from `config.xml`._
+
+* **`cordova platform remove android --nosave`**
+
+  Removes the `cordova-android` platform from the project, but does not remove it from the `package.json` file.
+
+### Restoring Platforms
+
+Platforms are automatically restored from the `package.json` (and `config.xml`) when executing the **`cordova prepare`** command.
+
+If a platform is defined in both files, the information defined in `package.json` is used as the source of truth.
+
+After `prepare`, any platforms restored from `config.xml` will update the `package.json` file to reflect the values taken from `config.xml`.
+
+If you add a platform without specifying a `<version | folder | git_url>`, the version that will be installed is taken from `package.json` or `config.xml`.
+
+**If discovered** in both files, `package.json` is given higher priority over `config.xml`.
 
 Example:
 
-Suppose your config.xml file contains the following entry:
+Suppose your `config.xml` file contains the following entry:
 
 ```xml
 <?xml version='1.0' encoding='utf-8'?>
     ...
-    <engine name="android" spec="3.7.0" />
+    <engine name="android" spec="7.1.4" />
     ...
 </xml>
 ```
 
-If you run the command **'cordova platform add android'** (no version/folder/git_url specified), the platform 'android@3.7.0' (as retrieved from config.xml) will be installed.
+If you run the command **`cordova platform add android`** with no `<version | folder | git_url>` specified, the platform `android@7.1.4` will be retrieved and installed.
 
-**Example for order of precedence for restoring platforms:**
+**Example Order of Priority for Restoring Platforms:**
 
-Suppose your config.xml has this platform and version:
-```bash
-<engine name="android" spec=“1.0.0” />
+Suppose you have defined in `config.xml` and `package.json` a platform and version as follows:
+
+**`config.xml`**:
+
+```xml
+<engine name="android" spec=“7.4.1” />
 ```
 
-Suppose your package.json has this platform and version:
+**`package.json`**:
 
-```bash
-"cordova": {"platforms": ["android"]},"dependencies": {"cordova-android": "4.0.0"}
+```json
+"cordova": {
+  "platforms": [
+    "android"
+  ]
+},
+"dependencies": {
+  "cordova-android": "^8.0.0"
+}
 ```
 
-When prepare is run, package.json’s contents are giving precedence and both config.xml and package.json are updated so that they have identical platforms and variables. Notice how package.json's version (4.0.0) has **replaced** config.xml's version (1.0.0).
+When `prepare` is executed, the version from `package.json` has higher priority over `config.xml` and version `^8.0.0` will be installed.
 
-After running **'cordova prepare'** , the resulting config.xml looks like :
-```bash
-<engine name="android" spec=“4.0.0” />
-```
-
-After running **'cordova prepare'** , the resulting package.json looks like :
-```bash
-"cordova": {"platforms": ["android",]},"dependencies": {"cordova-android": "4.0.0"}
-```
 ---
 
 ## Plugin Versioning
-_(The plugin commands are a mirror of the platform commands)_
 
-### Saving plugins
-To save a plugin, you issue the following command :
+The plugin commands are a mirror of the platform commands:
 
-```bash
-$ cordova plugin add <plugin[@<version>] | directory | git_url>
-```
+### Saving Plugins
 
-After running the above command, the resulting config.xml looks like :
-
-```xml
-<?xml version='1.0' encoding='utf-8'?>
-    ...
-    <plugin name="cordova-plugin-console" spec="~1.0.0" />
-    ...
-</xml>
-```
-
-After running the above command, the resulting package.json looks like :
+To save a plugin, you issue the following command:
 
 ```bash
-"cordova": {"plugins": ["cordova-plugin-console"]},"dependencies": {"cordova-plugin-console": "^1.0.0"}
+cordova plugin add <plugin[@<version>] | directory | git_url>
 ```
 
-The '--nosave' flag prevents adding and deleting specified plugins from config.xml and package.json. To prevent saving a plugin, you issue the following command :
+After running the above command, the **`package.json`** should contain something as seen below:
+
+```json
+"cordova": {
+  "plugins": [
+    "cordova-plugin-device"
+  ]
+},
+"devDependencies": {
+  "cordova-plugin-device": "^1.0.0"
+}
+```
+
+The `--nosave` flag prevents adding and deleting specified plugins from `package.json`. To prevent saving a plugin, you issue the following command:
 
 ```bash
-$ cordova plugin add <plugin[@<version>] | directory | git_url> --nosave
+cordova plugin add <plugin[@<version>] | directory | git_url> --nosave
 ```
 
-Some examples :
+Some Examples:
 
-  * **'cordova plugin add cordova-plugin-console'** => retrieves the pinned version of the console plugin, adds it to the project and then updates config.xml and package.json.
-  * **'cordova plugin add cordova-plugin-console@0.2.13'** => retrieves the android plugin, version 0.2.13 from npm, adds it to the project and then updates config.xml and package.json.
-  * **'cordova plugin add https://github.com/apache/cordova-plugin-console.git'** => npm installs specified console plugin from the git repository, adds the console plugin to the project, then updates config.xml and and package.json and points its version to the specified git-url.
-  * **'cordova plugin add C:/path/to/console/plugin'** => retrieves the console plugin from the specified directory, adds it to the project, then updates config.xml and package.json and points to the directory.
+* **`cordova plugin add cordova-plugin-device`**
 
-### Mass saving plugins on an existing project
-If you have a pre-existing project and you want to save all currently added plugins in the project, you can use :
+  Retrieves the pinned version of the `cordova-plugin-device` plugin from npm, adds it to the project and updates the `package.json` file.
+
+* **`cordova plugin add cordova-plugin-device@2.0.1`**
+
+  Retrieves the `cordova-plugin-device` plugin at version `2.0.1` from npm, adds it to the project and updates the `package.json` file.
+
+* **`cordova plugin add https://github.com/apache/cordova-plugin-device.git`**
+  
+  **`cordova plugin add https://github.com/apache/cordova-plugin-device`**
+  
+  **`cordova plugin add github:apache/cordova-plugin-device`**
+
+  npm retrieves the `cordova-plugin-device` plugin from the git repository, adds it to the project and updates the `package.json`.
+
+* **`cordova plugin add C:/path/to/console/plugin`**
+
+  Retrieves the `cordova-plugin-device` plugin from the specified directory, adds it to the project, and updates the `package.json` file.
+
+### Mass Saving of Plugins on an Existing Project
+
+If you have a pre-existing project and you want to save all currently added plugins in the project, you can use:
 
 ```bash
-$ cordova plugin save
+cordova plugin save
 ```
 
+### Removing Plugins
 
-### Removing plugins
-It is also possible to delete from config.xml and package.json during the command 'cordova plugin remove' :
+It is possible to delete a plugin from `config.xml` and `package.json` with one of the following commands:
 
 ```bash
-$ cordova plugin remove <plugin>
+cordova plugin remove <plugin>
+cordova plugin rm <plugin>
 ```
-For example:
 
-  * **'cordova plugin remove cordova-plugin-console'** => Removes the console plugin from the project and deletes its entry from config.xml and package.json.
+For Example:
 
+* **`cordova plugin remove cordova-plugin-device`**
 
-### Restoring plugins
+  Removes the `cordova-plugin-device` plugin from the project and deletes its entry from `package.json`.
 
-Plugins are automatically restored from package.json and config.xml when the **'cordova prepare'** command is run. After prepare is run, package.json and config.xml should contain identical plugins and versions.
+  _Note: If the plugin definition existed in `config.xml` from a previous version of Cordova CLI, it will also be removed from `config.xml`._
 
-If you add a plugin without specifying a version/folder/git_url, the version to install is taken from package.json or config.xml, **if found**. In case of conflicts, package.json is given precedence over config.xml.
+### Restoring Plugins
+
+Plugins are automatically restored from `package.json` and `config.xml` when executing the **`cordova prepare`** command.
+
+If a plugin is defined in both files, the information defined in `package.json` is used as the source of truth.
+
+After `prepare`, any plugins restored from `config.xml` will update the `package.json` file to reflect the values taken from `config.xml`.
+
+If you add a plugin without specifying a `<version | folder | git_url>`, the version that will be installed is taken from `package.json` or `config.xml`.
+
+**If discovered** in both files, `package.json` is given higher priority over `config.xml`.
 
 Example:
 
-Suppose your config.xml file contains the following entry:
+Suppose your `config.xml` file contains the following entry:
 
 ```xml
 <?xml version='1.0' encoding='utf-8'?>
     ...
-    <plugin name="cordova-plugin-console" spec="0.2.11" />
+    <plugin name="cordova-plugin-device" spec="2.0.1" />
     ...
 </ xml>
 ```
 
-If you run the command **'cordova plugin add cordova-plugin-console'** (no version/folder/git_url specified), the plugin 'cordova-plugin-console@0.2.11' (as retrieved from config.xml) will be installed.
+If you run the command **`cordova plugin add cordova-plugin-device`** with no `<version | folder | git_url>` specified, the platform `cordova-plugin-device@2.0.1` will be retrieved and installed.
 
-**Example for order of precedence for restoring plugins:**
+**Example Order of Priority for Restoring Plugins:**
 
-Supposed your config.xml has this plugin and version:
+Suppose you have defined in `config.xml` and `package.json` a plugin and version as follows:
 
-```bash
+**`config.xml`**:
+
+```xml
 <plugin name="cordova-plugin-splashscreen"/>
 ```
-Suppose your package.json has this plugin and version:
 
-```bash
-"cordova": {"plugins": {"cordova-plugin-splashscreen" : {} } },"dependencies": {"cordova-plugin-splashscreen": "1.0.0"}
+**`package.json`**:
+
+```json
+"cordova": {
+  "plugins": [
+    "cordova-plugin-splashscreen"
+  ]
+},
+"devDependencies": {
+  "cordova-plugin-splashscreen": "1.0.0"
+}
 ```
-When prepare is run, package.json’s contents are giving precedence and both config.xml and package.json are updated so that they have identical plugins and variables. Notice how package.json's version (1.0.0) is now in config.xml.
 
-After running **'cordova prepare'** , the resulting config.xml looks like :
-
-```bash
-<plugin name="cordova-plugin-splashscreen" spec="1.0.0"/>
-```
-
-After running **'cordova prepare'** , the resulting package.json looks like :
-
-```bash
-"cordova": {"plugins": {"cordova-plugin-splashscreen" : {} } },"dependencies": {"cordova-plugin-splashscreen": "1.0.0"}
-```
+When `prepare` is executed, the version from `package.json` has higher priority over `config.xml` and version `1.0.0` will be installed.

--- a/www/docs/en/9.x/platform_plugin_versioning_ref/index.md
+++ b/www/docs/en/9.x/platform_plugin_versioning_ref/index.md
@@ -96,7 +96,7 @@ It is possible to update and delete a platform from `config.xml` and `package.js
 To update a platform, execute the following command:
 
 ```bash
-cordova platform update <platform[@<version>] | directory | git_url> --save
+cordova platform update <platform[@<version>] | directory | git_url>
 ```
 
 To remove a platform, execute one of the following commands:
@@ -108,15 +108,15 @@ cordova platform rm <platform>
 
 Some Examples:
 
-* **`cordova platform update android --save`**
+* **`cordova platform update android`**
 
   In addition to updating the `cordova-android` platform to the pinned version, it updates the `package.json` file.
 
-* **`cordova platform update android@3.8.0 --save`**
+* **`cordova platform update android@3.8.0`**
 
   In addition to updating the `cordova-android` platform to version `3.8.0` it updates the `package.json` file.
 
-* **`cordova platform update /path/to/android/platform --save`**
+* **`cordova platform update /path/to/android/platform`**
 
   In addition to updating the `cordova-android` platform to version found in the provided folder, it updates the `package.json` file.
 

--- a/www/docs/en/dev/platform_plugin_versioning_ref/index.md
+++ b/www/docs/en/dev/platform_plugin_versioning_ref/index.md
@@ -91,7 +91,7 @@ Some Examples:
 
 ### Updating or Removing Platforms
 
-It is also possible to update or delete from `config.xml` and `package.json` during the commands 'cordova platform update' and 'cordova platform remove' :
+It is also possible to update or delete from `config.xml` and `package.json` during the commands `cordova platform update` and `cordova platform remove`:
 
 ```bash
 cordova platform update <platform[@<version>] | directory | git_url> --save
@@ -114,9 +114,9 @@ Some Examples:
 
 * **`cordova platform remove android`**
 
-  Removes the `cordova-android` platform from the project and removes from the `package.json` file.
+  Removes the `cordova-android` platform from the project and removes it from the `package.json` file.
   
-  _Note: If the platform definiton existed in `config.xml` from a previous version of Cordova-CLI, it will also be removed from `config.xml`._
+  _Note: If the platform definiton existed in `config.xml` from a previous version of Cordova CLI, it will also be removed from `config.xml`._
 
 * **`cordova platform remove android --nosave`**
 
@@ -124,11 +124,11 @@ Some Examples:
 
 ### Restoring Platforms
 
-Platforms are automatically restored from the `package.json` and `config.xml` when executing the the **`cordova prepare`** command.
+Platforms are automatically restored from the `package.json` (and `config.xml`) when executing the the **`cordova prepare`** command.
 
-If a platfrom is defined in both files, the information defined in `package.json` is used as the source of truth.
+If a platform is defined in both files, the information defined in `package.json` is used as the source of truth.
 
-After `prepare`, if a platform was restored from `config.xml`, the `package.json` file will updated to reflect the restored platform and will have identical vales from `config.xml`.
+After `prepare`, if a platform was restored from `config.xml`, the `package.json` file will be updated to reflect the restored platform and will have identical values from `config.xml`.
 
 If you add a platform without specifying a `<version | folder | git_url>`, the version that will be installed is taken from `package.json` or `config.xml`.
 
@@ -171,13 +171,13 @@ Suppose you have defined in `config.xml` and `package.json` a platform and versi
 }
 ```
 
-When `prepare` is executed, the version from `package.json` has higher priority over  `config.xml` and version `^8.0.0` will be installed.
+When `prepare` is executed, the version from `package.json` has higher priority over `config.xml` and version `^8.0.0` will be installed.
 
 ---
 
 ## Plugin Versioning
 
-The plugin commands are a mirror of the platform commands
+The plugin commands are a mirror of the platform commands:
 
 ### Saving Plugins
 
@@ -250,7 +250,7 @@ For Example:
 
   Removes the `cordova-plugin-device` plugin from the project and deletes its entry from `package.json`.
 
-  _Note: If the plugin definiton existed in `config.xml` from a previous version of Cordova-CLI, it will also be removed from `config.xml`._
+  _Note: If the plugin definiton existed in `config.xml` from a previous version of Cordova CLI, it will also be removed from `config.xml`._
 
 ### Restoring Plugins
 
@@ -301,4 +301,4 @@ Suppose you have defined in `config.xml` and `package.json` a plugin and version
 }
 ```
 
-When `prepare` is executed, the version from `package.json` has higher priority over  `config.xml` and version `1.0.0` will be installed.
+When `prepare` is executed, the version from `package.json` has higher priority over `config.xml` and version `1.0.0` will be installed.

--- a/www/docs/en/dev/platform_plugin_versioning_ref/index.md
+++ b/www/docs/en/dev/platform_plugin_versioning_ref/index.md
@@ -22,7 +22,7 @@ toc_title: Manage versions and platforms
 description: How to manage platforms and Cordova CLI versions.
 ---
 
-## Platforms and Plugins Version Management
+# Platforms and Plugins Version Management
 
 From version 4.3.0 onwards, Cordova provides the ability to save and restore platforms and plugins.
 
@@ -175,7 +175,7 @@ When `prepare` is executed, the version from `package.json` has higher priority 
 
 The plugin commands are a mirror of the platform commands
 
-### Saving plugins
+### Saving Plugins
 
 To save a plugin, you issue the following command:
 

--- a/www/docs/en/dev/platform_plugin_versioning_ref/index.md
+++ b/www/docs/en/dev/platform_plugin_versioning_ref/index.md
@@ -22,225 +22,276 @@ toc_title: Manage versions and platforms
 description: How to manage platforms and Cordova CLI versions.
 ---
 
-# Platforms and Plugins Version Management
+## Platforms and Plugins Version Management
+
 From version 4.3.0 onwards, Cordova provides the ability to save and restore platforms and plugins.
 
 This feature allows developers to save and restore their app to a known state without having to check in all of the platform and plugin source code.
 
 When adding a platform or plugin, details about the app's platform and plugin versions are automatically saved in config.xml and package.json. It is possible to add a platform or plugin by editing package.json or config.xml directly, assuming you know the right tags + syntax. It is not possible to remove plugins or platforms in this manner. The recommended method of adding and removing plugins and platforms is with the command line cordova commands `cordova plugin add|remove ...` and `cordova platform add|remove ...` to avoid any out of sync issues.
 
-The 'restore' step happens automatically when a **'cordova prepare'** is issued, making use of information previously saved in the config.xml and package.json files.
+The 'restore' step happens automatically when a **`cordova prepare`** is issued, making use of information previously saved in the config.xml and package.json files.
 
 One scenario where save/restore capabilities come in handy is in large teams that work on an app, with each team member focusing on a platform or plugin. This feature makes it easier to share the project and reduce the amount of redundant code that is checked in the repository.
 
-
 ## Platform Versioning
 
-### Saving platforms
-To save a platform, you issue the following command :
+### Saving Platforms
+
+To save a platform, issue the following command:
 
 ```bash
-$ cordova platform add <platform[@<version>] | directory | git_url>
+cordova platform add <platform[@<version>] | directory | git_url>
 ```
 
-After running the above command, the resulting config.xml looks like :
+After running the above command, the **`package.json`** should contain something as seen below:
 
-```xml
-<?xml version='1.0' encoding='utf-8'?>
-    ...
-    <engine name="android" spec="~4.0.0" />
-    ...
-</xml>
+```json
+"cordova": {
+  "platforms": [
+    "android"
+  ]
+},
+"dependencies": {
+  "cordova-android": "^8.0.0",
+}
 ```
-After running the above command, the resulting package.json looks like :
+
+The `--nosave` flag prevents adding and deleting specified platforms to the `package.json` file. To prevent saving a platform, issue the following command:
 
 ```bash
-"cordova": {"platforms": ["android"]},"dependencies": {"cordova-android": "^4.0.0"}
+cordova platform add <platform[@<version>] | directory | git_url> --nosave
 ```
-The '--nosave' flag prevents adding and deleting specified platforms from config.xml and package.json. To prevent saving a platform, you issue the following command :
+
+Some Examples:
+
+* **`cordova platform add android`** 
+
+  Retrieves the pinned version of `cordova-android` platform from NPM, adds it to the project and updates the `package.json` file.
+
+* **`cordova platform add android@7.1.4`**
+
+  Retrieves the `cordova-android` platform version `7.1.4` from NPM, adds it to the project and updates the `package.json` file.
+
+* **`cordova platform add https://github.com/apache/cordova-android.git`**
+
+  NPM retrieves the `cordova-android` platform from the git repository, adds it to the project and updates the `package.json`.
+  
+* **`cordova platform add C:/path/to/android/platform`**
+
+  Retrieves the Android platform from the specified directory, adds it to the project, and updates the `package.json` file.
+
+* **`cordova platform add android --nosave`**
+
+  Retrieves the pinned version of `cordova-android` platform from NPM, adds it to the project, but does not add it to the `package.json` file.
+
+### Updating or Removing Platforms
+
+It is also possible to update or delete from config.xml and `package.json` during the commands 'cordova platform update' and 'cordova platform remove' :
 
 ```bash
-$ cordova platform add <platform[@<version>] | directory | git_url> --nosave
+cordova platform update <platform[@<version>] | directory | git_url> --save
+cordova platform remove <platform>
 ```
 
-Some examples :
+Some Examples:
 
-  * **'cordova platform add android'** => retrieves the pinned version of the android platform, adds it to the project and then updates config.xml and package.json.
-  * **'cordova platform add android@3.7.0'** => retrieves the android platform, version 3.7.0 from npm, adds it to the project and then updates config.xml and package.json.
-  * **'cordova platform add https://github.com/apache/cordova-android.git'** => npm installs the specified cordova-android from the git repository, adds the android platform to the project, then updates config.xml and package.json and points its version to the specified git-url.
-  * **'cordova platform add C:/path/to/android/platform'** => retrieves the android platform from the specified directory, adds it to the project, then updates config.xml and package.json and points to the directory.
-  * **'cordova platform add android --nosave'** => retrieves the pinned version of the android platform, adds it to the project, but does not add it to config.xml or package.json.
-  * **'cordova platform remove android --nosave'** =>  removes the android platform from the project, but does not remove it from config.xml or package.json.  
+* **`cordova platform update android --save`**
 
-### Mass saving platforms on an existing project
-If you have a pre-existing project and you want to save all the currently added platforms in your project, you can use :
+  In addition to updating the `cordova-android` platform to the pinned version, it updates the `package.json` file.
 
-```bash
-$ cordova platform save
-```
+* **`cordova platform update android@3.8.0 --save`**
 
-### Updating / Removing platforms
-It is also possible to update/delete from config.xml and package.json during the commands 'cordova platform update' and 'cordova platform remove' :
+  In addition to updating the `cordova-android` platform to version `3.8.0` it updates the `package.json` file.
 
-```bash
-$ cordova platform update <platform[@<version>] | directory | git_url> --save
-$ cordova platform remove <platform>
-```
+* **`cordova platform update /path/to/android/platform --save`**
 
-Some examples :
+  In addition to updating the `cordova-android` platform to version in the folder it updates the `package.json` file.
 
-  * **'cordova platform update android --save'** => In addition to updating the android platform to the pinned version, update config.xml entry
-  * **'cordova platform update android@3.8.0 --save'** => In addition to updating the android platform to version 3.8.0, update config.xml entry
-  * **'cordova platform update /path/to/android/platform --save'** => In addition to updating the android platform to version in the folder, update config.xml entry
-  * **'cordova platform remove android'** => Removes the android platform from the project and deletes its entry from config.xml and package.json.
+* **`cordova platform remove android`**
 
+  Removes the `cordova-android` platform from the project and removes from the `package.json` file.
+  
+  _Note: If the platform definiton existed in `config.xml` from a previous version of Cordova-CLI, it will also be removed from `config.xml`._
 
-### Restoring platforms
+* **`cordova platform remove android --nosave`**
 
-Platforms are automatically restored from package.json and config.xml when the **'cordova prepare'** command is run. After prepare is run, package.json and config.xml should contain identical platforms and versions.
+  Removes the `cordova-android` platform from the project, but does not remove it from the `package.json` file.
 
-If you add a platform without specifying a version/folder/git_url, the version to install is taken from package.json or config.xml, **if found**. In case of conflicts, package.json is given precedence over config.xml.
+### Restoring Platforms
+
+Platforms are automatically restored from the `package.json` and `config.xml` when executing the the **`cordova prepare`** command.
+
+If a platfrom is defined in both files, the information defined in `package.json` is used as the soruce of truth.
+
+After `prepare`, if a platform was restored from `config.xml`, the `package.json` file will updated to reflect the restored platform and will have identical vales from `config.xml`.
+
+If you add a platform without specifying a `<version | folder | git_url>`, the version that will be installed is taken from `package.json` or `config.xml`.
+
+**If discovered** in both files, `package.json` is given higher priority over `config.xml`.
 
 Example:
 
-Suppose your config.xml file contains the following entry:
+Suppose your `config.xml` file contains the following entry:
 
 ```xml
 <?xml version='1.0' encoding='utf-8'?>
     ...
-    <engine name="android" spec="3.7.0" />
+    <engine name="android" spec="7.1.4" />
     ...
 </xml>
 ```
 
-If you run the command **'cordova platform add android'** (no version/folder/git_url specified), the platform 'android@3.7.0' (as retrieved from config.xml) will be installed.
+If you run the command **`cordova platform add android`** with no `<version | folder | git_url>` specified, the platform `android@7.1.4` will be retrieved and installed.
 
-**Example for order of precedence for restoring platforms:**
+**Example Order of Priorty for Restoring Platforms:**
 
-Suppose your config.xml has this platform and version:
-```bash
-<engine name="android" spec=“1.0.0” />
+Suppose you have defined in `config.xml` and `package.json` a platform and version as follows:
+
+**`config.xml`**:
+
+```xml
+<engine name="android" spec=“7.4.1” />
 ```
 
-Suppose your package.json has this platform and version:
+**`package.json`**:
 
-```bash
-"cordova": {"platforms": ["android"]},"dependencies": {"cordova-android": "4.0.0"}
+```json
+"cordova": {
+  "platforms": [
+    "android"
+  ]
+},
+"dependencies": {
+  "cordova-android": "^8.0.0"
+}
 ```
 
-When prepare is run, package.json’s contents are giving precedence and both config.xml and package.json are updated so that they have identical platforms and variables. Notice how package.json's version (4.0.0) has **replaced** config.xml's version (1.0.0).
+When `prepare` is executed, the version from `package.json` has higher priority over  `config.xml` and version `^8.0.0` will be installed.
 
-After running **'cordova prepare'** , the resulting config.xml looks like :
-```bash
-<engine name="android" spec=“4.0.0” />
-```
-
-After running **'cordova prepare'** , the resulting package.json looks like :
-```bash
-"cordova": {"platforms": ["android",]},"dependencies": {"cordova-android": "4.0.0"}
-```
 ---
 
 ## Plugin Versioning
-_(The plugin commands are a mirror of the platform commands)_
+
+The plugin commands are a mirror of the platform commands
 
 ### Saving plugins
-To save a plugin, you issue the following command :
+
+To save a plugin, you issue the following command:
 
 ```bash
-$ cordova plugin add <plugin[@<version>] | directory | git_url>
+cordova plugin add <plugin[@<version>] | directory | git_url>
 ```
 
-After running the above command, the resulting config.xml looks like :
+After running the above command, the **`package.json`** should contain something as seen below:
 
-```xml
-<?xml version='1.0' encoding='utf-8'?>
-    ...
-    <plugin name="cordova-plugin-console" spec="~1.0.0" />
-    ...
-</xml>
+```json
+"cordova": {
+  "plugins": [
+    "cordova-plugin-device"
+  ]
+},
+"devDependencies": {
+  "cordova-plugin-device": "^1.0.0"
+}
 ```
 
-After running the above command, the resulting package.json looks like :
+The `--nosave` flag prevents adding and deleting specified plugins from `package.json`. To prevent saving a plugin, you issue the following command:
 
 ```bash
-"cordova": {"plugins": ["cordova-plugin-console"]},"dependencies": {"cordova-plugin-console": "^1.0.0"}
+cordova plugin add <plugin[@<version>] | directory | git_url> --nosave
 ```
 
-The '--nosave' flag prevents adding and deleting specified plugins from config.xml and package.json. To prevent saving a plugin, you issue the following command :
+Some Examples:
+
+* **`cordova plugin add cordova-plugin-device`**
+
+  Retrieves the pinned version of the `cordova-plugin-device` plugin from NPM, adds it to the project and updates the `package.json` file.
+
+* **`cordova plugin add cordova-plugin-device@2.0.1`**
+
+  Retrieves the `cordova-plugin-device` plugin at version `2.0.1` from NPM, adds it to the project and updates the `package.json` file.
+
+* **`cordova plugin add https://github.com/apache/cordova-plugin-device.git`**
+
+  NPM retrieves the `cordova-plugin-device` plugin from the git repository, adds it to the project and updates the `package.json`.
+
+* **`cordova plugin add C:/path/to/console/plugin`**
+
+  Retrieves the `cordova-plugin-device` plugin from the specified directory, adds it to the project, and updates the `package.json` file.
+
+### Mass Saving of Plugins on an Existing Project
+
+If you have a pre-existing project and you want to save all currently added plugins in the project, you can use:
 
 ```bash
-$ cordova plugin add <plugin[@<version>] | directory | git_url> --nosave
+cordova plugin save
 ```
 
-Some examples :
+### Removing Plugins
 
-  * **'cordova plugin add cordova-plugin-console'** => retrieves the pinned version of the console plugin, adds it to the project and then updates config.xml and package.json.
-  * **'cordova plugin add cordova-plugin-console@0.2.13'** => retrieves the android plugin, version 0.2.13 from npm, adds it to the project and then updates config.xml and package.json.
-  * **'cordova plugin add https://github.com/apache/cordova-plugin-console.git'** => npm installs specified console plugin from the git repository, adds the console plugin to the project, then updates config.xml and and package.json and points its version to the specified git-url.
-  * **'cordova plugin add C:/path/to/console/plugin'** => retrieves the console plugin from the specified directory, adds it to the project, then updates config.xml and package.json and points to the directory.
-
-### Mass saving plugins on an existing project
-If you have a pre-existing project and you want to save all currently added plugins in the project, you can use :
+It is also possible to delete from config.xml and package.json during the command `cordova plugin remove`:
 
 ```bash
-$ cordova plugin save
+cordova plugin remove <plugin>
 ```
 
+For Example:
 
-### Removing plugins
-It is also possible to delete from config.xml and package.json during the command 'cordova plugin remove' :
+* **`cordova plugin remove cordova-plugin-device`**
 
-```bash
-$ cordova plugin remove <plugin>
-```
-For example:
+  Removes the `cordova-plugin-device` plugin from the project and deletes its entry from `package.json`.
 
-  * **'cordova plugin remove cordova-plugin-console'** => Removes the console plugin from the project and deletes its entry from config.xml and package.json.
+  _Note: If the plugin definiton existed in `config.xml` from a previous version of Cordova-CLI, it will also be removed from `config.xml`._
+
+### Restoring Plugins
 
 
-### Restoring plugins
+Plugins are automatically restored from the `package.json` and `config.xml` when executing the the **`cordova prepare`** command.
 
-Plugins are automatically restored from package.json and config.xml when the **'cordova prepare'** command is run. After prepare is run, package.json and config.xml should contain identical plugins and versions.
+If a plugin is defined in both files, the information defined in `package.json` is used as the soruce of truth.
 
-If you add a plugin without specifying a version/folder/git_url, the version to install is taken from package.json or config.xml, **if found**. In case of conflicts, package.json is given precedence over config.xml.
+After `prepare`, if a plugin was restored from `config.xml`, the `package.json` file will updated to reflect the restored plugin and will have identical vales from `config.xml`.
+
+If you add a plugin without specifying a `<version | folder | git_url>`, the version that will be installed is taken from `package.json` or `config.xml`.
+
+**If discovered** in both files, `package.json` is given higher priority over `config.xml`.
 
 Example:
 
-Suppose your config.xml file contains the following entry:
+Suppose your `config.xml` file contains the following entry:
 
 ```xml
 <?xml version='1.0' encoding='utf-8'?>
     ...
-    <plugin name="cordova-plugin-console" spec="0.2.11" />
+    <plugin name="cordova-plugin-device" spec="2.0.1" />
     ...
 </ xml>
 ```
 
-If you run the command **'cordova plugin add cordova-plugin-console'** (no version/folder/git_url specified), the plugin 'cordova-plugin-console@0.2.11' (as retrieved from config.xml) will be installed.
+If you run the command **`cordova plugin add cordova-plugin-device`** with no `<version | folder | git_url>` specified, the platform `cordova-plugin-device@2.0.1` will be retrieved and installed.
 
-**Example for order of precedence for restoring plugins:**
+**Example Order of Priorty for Restoring Plugins:**
 
-Supposed your config.xml has this plugin and version:
+Suppose you have defined in `config.xml` and `package.json` a plugin and version as follows:
 
-```bash
+**`config.xml`**:
+
+```xml
 <plugin name="cordova-plugin-splashscreen"/>
 ```
-Suppose your package.json has this plugin and version:
 
-```bash
-"cordova": {"plugins": {"cordova-plugin-splashscreen" : {} } },"dependencies": {"cordova-plugin-splashscreen": "1.0.0"}
+**`package.json`**:
+
+```json
+"cordova": {
+  "plugins": [
+    "cordova-plugin-splashscreen"
+  ]
+},
+"devDependencies": {
+  "cordova-plugin-splashscreen": "1.0.0"
+}
 ```
-When prepare is run, package.json’s contents are giving precedence and both config.xml and package.json are updated so that they have identical plugins and variables. Notice how package.json's version (1.0.0) is now in config.xml.
 
-After running **'cordova prepare'** , the resulting config.xml looks like :
-
-```bash
-<plugin name="cordova-plugin-splashscreen" spec="1.0.0"/>
-```
-
-After running **'cordova prepare'** , the resulting package.json looks like :
-
-```bash
-"cordova": {"plugins": {"cordova-plugin-splashscreen" : {} } },"dependencies": {"cordova-plugin-splashscreen": "1.0.0"}
-```
+When `prepare` is executed, the version from `package.json` has higher priority over  `config.xml` and version `1.0.0` will be installed.

--- a/www/docs/en/dev/platform_plugin_versioning_ref/index.md
+++ b/www/docs/en/dev/platform_plugin_versioning_ref/index.md
@@ -73,7 +73,11 @@ Some Examples:
 
   Retrieves the `cordova-android` platform version `7.1.4` from npm, adds it to the project and updates the `package.json` file.
 
-* **`cordova platform add https://github.com/apache/cordova-android.git`**, **`cordova platform add https://github.com/apache/cordova-android`** or **`cordova platform add github:apache/cordova-android`**
+* **`cordova platform add https://github.com/apache/cordova-android.git`**
+  
+  **`cordova platform add https://github.com/apache/cordova-android`**
+  
+  **`cordova platform add github:apache/cordova-android`**
 
   npm retrieves the `cordova-android` platform from the git repository, adds it to the project and updates the `package.json`.
   
@@ -213,6 +217,10 @@ Some Examples:
   Retrieves the `cordova-plugin-device` plugin at version `2.0.1` from npm, adds it to the project and updates the `package.json` file.
 
 * **`cordova plugin add https://github.com/apache/cordova-plugin-device.git`**
+  
+  **`cordova plugin add https://github.com/apache/cordova-plugin-device`**
+  
+  **`cordova plugin add github:apache/cordova-plugin-device`**
 
   npm retrieves the `cordova-plugin-device` plugin from the git repository, adds it to the project and updates the `package.json`.
 
@@ -230,7 +238,7 @@ cordova plugin save
 
 ### Removing Plugins
 
-It is also possible to delete from config.xml and package.json during the command `cordova plugin remove`:
+It is also possible to delete from `config.xml` and `package.json` during the command `cordova plugin remove`:
 
 ```bash
 cordova plugin remove <plugin>

--- a/www/docs/en/dev/platform_plugin_versioning_ref/index.md
+++ b/www/docs/en/dev/platform_plugin_versioning_ref/index.md
@@ -24,7 +24,7 @@ description: How to manage platforms and Cordova CLI versions.
 
 # Platforms and Plugins Version Management
 
-From version 4.3.0 onwards, Cordova provides the ability to save and restore platforms and plugins.
+Cordova provides the ability to save and restore platforms and plugins.
 
 This feature allows developers to save and restore their app to a known state without having to check in all of the platform and plugin source code.
 

--- a/www/docs/en/dev/platform_plugin_versioning_ref/index.md
+++ b/www/docs/en/dev/platform_plugin_versioning_ref/index.md
@@ -73,7 +73,7 @@ Some Examples:
 
   Retrieves the `cordova-android` platform version `7.1.4` from npm, adds it to the project and updates the `package.json` file.
 
-* **`cordova platform add https://github.com/apache/cordova-android.git`**
+* **`cordova platform add https://github.com/apache/cordova-android.git`**, **`cordova platform add https://github.com/apache/cordova-android`** or **`cordova platform add github:apache/cordova-android`**
 
   npm retrieves the `cordova-android` platform from the git repository, adds it to the project and updates the `package.json`.
   
@@ -87,7 +87,7 @@ Some Examples:
 
 ### Updating or Removing Platforms
 
-It is also possible to update or delete from config.xml and `package.json` during the commands 'cordova platform update' and 'cordova platform remove' :
+It is also possible to update or delete from `config.xml` and `package.json` during the commands 'cordova platform update' and 'cordova platform remove' :
 
 ```bash
 cordova platform update <platform[@<version>] | directory | git_url> --save
@@ -144,7 +144,7 @@ Suppose your `config.xml` file contains the following entry:
 
 If you run the command **`cordova platform add android`** with no `<version | folder | git_url>` specified, the platform `android@7.1.4` will be retrieved and installed.
 
-**Example Order of Priorty for Restoring Platforms:**
+**Example Order of Priority for Restoring Platforms:**
 
 Suppose you have defined in `config.xml` and `package.json` a platform and version as follows:
 
@@ -270,7 +270,7 @@ Suppose your `config.xml` file contains the following entry:
 
 If you run the command **`cordova plugin add cordova-plugin-device`** with no `<version | folder | git_url>` specified, the platform `cordova-plugin-device@2.0.1` will be retrieved and installed.
 
-**Example Order of Priorty for Restoring Plugins:**
+**Example Order of Priority for Restoring Plugins:**
 
 Suppose you have defined in `config.xml` and `package.json` a plugin and version as follows:
 

--- a/www/docs/en/dev/platform_plugin_versioning_ref/index.md
+++ b/www/docs/en/dev/platform_plugin_versioning_ref/index.md
@@ -91,11 +91,19 @@ Some Examples:
 
 ### Updating or Removing Platforms
 
-It is also possible to update or delete from `config.xml` and `package.json` during the commands `cordova platform update` and `cordova platform remove`:
+It is possible to update and delete a platform from `config.xml` and `package.json`.
+
+To update a platform, execute the following command:
 
 ```bash
 cordova platform update <platform[@<version>] | directory | git_url> --save
+```
+
+To remove a platform, execute one of the following commands:
+
+```bash
 cordova platform remove <platform>
+cordova platform rm <platform>
 ```
 
 Some Examples:
@@ -110,13 +118,13 @@ Some Examples:
 
 * **`cordova platform update /path/to/android/platform --save`**
 
-  In addition to updating the `cordova-android` platform to version in the folder it updates the `package.json` file.
+  In addition to updating the `cordova-android` platform to version found in the provided folder, it updates the `package.json` file.
 
 * **`cordova platform remove android`**
 
   Removes the `cordova-android` platform from the project and removes it from the `package.json` file.
   
-  _Note: If the platform definiton existed in `config.xml` from a previous version of Cordova CLI, it will also be removed from `config.xml`._
+  _Note: If the platform definition existed in `config.xml` from a previous version of Cordova CLI, it will also be removed from `config.xml`._
 
 * **`cordova platform remove android --nosave`**
 
@@ -124,11 +132,11 @@ Some Examples:
 
 ### Restoring Platforms
 
-Platforms are automatically restored from the `package.json` (and `config.xml`) when executing the the **`cordova prepare`** command.
+Platforms are automatically restored from the `package.json` (and `config.xml`) when executing the **`cordova prepare`** command.
 
 If a platform is defined in both files, the information defined in `package.json` is used as the source of truth.
 
-After `prepare`, if a platform was restored from `config.xml`, the `package.json` file will be updated to reflect the restored platform and will have identical values from `config.xml`.
+After `prepare`, any platforms restored from `config.xml` will update the `package.json` file to reflect the values taken from `config.xml`.
 
 If you add a platform without specifying a `<version | folder | git_url>`, the version that will be installed is taken from `package.json` or `config.xml`.
 
@@ -238,10 +246,11 @@ cordova plugin save
 
 ### Removing Plugins
 
-It is also possible to delete from `config.xml` and `package.json` during the command `cordova plugin remove`:
+It is possible to delete a plugin from `config.xml` and `package.json` with one of the following commands:
 
 ```bash
 cordova plugin remove <plugin>
+cordova plugin rm <plugin>
 ```
 
 For Example:
@@ -250,15 +259,15 @@ For Example:
 
   Removes the `cordova-plugin-device` plugin from the project and deletes its entry from `package.json`.
 
-  _Note: If the plugin definiton existed in `config.xml` from a previous version of Cordova CLI, it will also be removed from `config.xml`._
+  _Note: If the plugin definition existed in `config.xml` from a previous version of Cordova CLI, it will also be removed from `config.xml`._
 
 ### Restoring Plugins
 
-Plugins are automatically restored from `package.json` and `config.xml` when executing the the **`cordova prepare`** command.
+Plugins are automatically restored from `package.json` and `config.xml` when executing the **`cordova prepare`** command.
 
 If a plugin is defined in both files, the information defined in `package.json` is used as the source of truth.
 
-After `prepare`, if a plugin was restored from `config.xml`, the `package.json` file will updated to reflect the restored plugin and will have identical vales from `config.xml`.
+After `prepare`, any plugins restored from `config.xml` will update the `package.json` file to reflect the values taken from `config.xml`.
 
 If you add a plugin without specifying a `<version | folder | git_url>`, the version that will be installed is taken from `package.json` or `config.xml`.
 

--- a/www/docs/en/dev/platform_plugin_versioning_ref/index.md
+++ b/www/docs/en/dev/platform_plugin_versioning_ref/index.md
@@ -28,9 +28,9 @@ From version 4.3.0 onwards, Cordova provides the ability to save and restore pla
 
 This feature allows developers to save and restore their app to a known state without having to check in all of the platform and plugin source code.
 
-When adding a platform or plugin, details about the app's platform and plugin versions are automatically saved in config.xml and package.json. It is possible to add a platform or plugin by editing package.json or config.xml directly, assuming you know the right tags + syntax. It is not possible to remove plugins or platforms in this manner. The recommended method of adding and removing plugins and platforms is with the command line cordova commands `cordova plugin add|remove ...` and `cordova platform add|remove ...` to avoid any out of sync issues.
+When adding a platform or plugin, details about the app's platform and plugin versions are automatically saved to the `package.json` file. It is also possible to add a platform or plugin by editing the `package.json` file directly, assuming you know the right tags and syntax. It is not possible to remove plugins or platforms in this manner. The recommended method of adding and removing plugins and platforms is with the Cordova CLI commands `cordova plugin add|remove ...` and `cordova platform add|remove ...` to avoid any out of sync issues.
 
-The 'restore' step happens automatically when a **`cordova prepare`** is issued, making use of information previously saved in the config.xml and package.json files.
+The **restore** step happens automatically when a **`cordova prepare`** is issued, making use of information previously saved in the `package.json` and `config.xml` files.
 
 One scenario where save/restore capabilities come in handy is in large teams that work on an app, with each team member focusing on a platform or plugin. This feature makes it easier to share the project and reduce the amount of redundant code that is checked in the repository.
 
@@ -67,15 +67,15 @@ Some Examples:
 
 * **`cordova platform add android`** 
 
-  Retrieves the pinned version of `cordova-android` platform from NPM, adds it to the project and updates the `package.json` file.
+  Retrieves the pinned version of `cordova-android` platform from npm, adds it to the project and updates the `package.json` file.
 
 * **`cordova platform add android@7.1.4`**
 
-  Retrieves the `cordova-android` platform version `7.1.4` from NPM, adds it to the project and updates the `package.json` file.
+  Retrieves the `cordova-android` platform version `7.1.4` from npm, adds it to the project and updates the `package.json` file.
 
 * **`cordova platform add https://github.com/apache/cordova-android.git`**
 
-  NPM retrieves the `cordova-android` platform from the git repository, adds it to the project and updates the `package.json`.
+  npm retrieves the `cordova-android` platform from the git repository, adds it to the project and updates the `package.json`.
   
 * **`cordova platform add C:/path/to/android/platform`**
 
@@ -83,7 +83,7 @@ Some Examples:
 
 * **`cordova platform add android --nosave`**
 
-  Retrieves the pinned version of `cordova-android` platform from NPM, adds it to the project, but does not add it to the `package.json` file.
+  Retrieves the pinned version of `cordova-android` platform from npm, adds it to the project, but does not add it to the `package.json` file.
 
 ### Updating or Removing Platforms
 
@@ -122,7 +122,7 @@ Some Examples:
 
 Platforms are automatically restored from the `package.json` and `config.xml` when executing the the **`cordova prepare`** command.
 
-If a platfrom is defined in both files, the information defined in `package.json` is used as the soruce of truth.
+If a platfrom is defined in both files, the information defined in `package.json` is used as the source of truth.
 
 After `prepare`, if a platform was restored from `config.xml`, the `package.json` file will updated to reflect the restored platform and will have identical vales from `config.xml`.
 
@@ -206,15 +206,15 @@ Some Examples:
 
 * **`cordova plugin add cordova-plugin-device`**
 
-  Retrieves the pinned version of the `cordova-plugin-device` plugin from NPM, adds it to the project and updates the `package.json` file.
+  Retrieves the pinned version of the `cordova-plugin-device` plugin from npm, adds it to the project and updates the `package.json` file.
 
 * **`cordova plugin add cordova-plugin-device@2.0.1`**
 
-  Retrieves the `cordova-plugin-device` plugin at version `2.0.1` from NPM, adds it to the project and updates the `package.json` file.
+  Retrieves the `cordova-plugin-device` plugin at version `2.0.1` from npm, adds it to the project and updates the `package.json` file.
 
 * **`cordova plugin add https://github.com/apache/cordova-plugin-device.git`**
 
-  NPM retrieves the `cordova-plugin-device` plugin from the git repository, adds it to the project and updates the `package.json`.
+  npm retrieves the `cordova-plugin-device` plugin from the git repository, adds it to the project and updates the `package.json`.
 
 * **`cordova plugin add C:/path/to/console/plugin`**
 
@@ -246,10 +246,9 @@ For Example:
 
 ### Restoring Plugins
 
+Plugins are automatically restored from `package.json` and `config.xml` when executing the the **`cordova prepare`** command.
 
-Plugins are automatically restored from the `package.json` and `config.xml` when executing the the **`cordova prepare`** command.
-
-If a plugin is defined in both files, the information defined in `package.json` is used as the soruce of truth.
+If a plugin is defined in both files, the information defined in `package.json` is used as the source of truth.
 
 After `prepare`, if a plugin was restored from `config.xml`, the `package.json` file will updated to reflect the restored plugin and will have identical vales from `config.xml`.
 

--- a/www/docs/en/dev/platform_plugin_versioning_ref/index.md
+++ b/www/docs/en/dev/platform_plugin_versioning_ref/index.md
@@ -96,7 +96,7 @@ It is possible to update and delete a platform from `config.xml` and `package.js
 To update a platform, execute the following command:
 
 ```bash
-cordova platform update <platform[@<version>] | directory | git_url> --save
+cordova platform update <platform[@<version>] | directory | git_url>
 ```
 
 To remove a platform, execute one of the following commands:
@@ -108,15 +108,15 @@ cordova platform rm <platform>
 
 Some Examples:
 
-* **`cordova platform update android --save`**
+* **`cordova platform update android`**
 
   In addition to updating the `cordova-android` platform to the pinned version, it updates the `package.json` file.
 
-* **`cordova platform update android@3.8.0 --save`**
+* **`cordova platform update android@3.8.0`**
 
   In addition to updating the `cordova-android` platform to version `3.8.0` it updates the `package.json` file.
 
-* **`cordova platform update /path/to/android/platform --save`**
+* **`cordova platform update /path/to/android/platform`**
 
   In addition to updating the `cordova-android` platform to version found in the provided folder, it updates the `package.json` file.
 


### PR DESCRIPTION
### Platforms affected
none

### Motivation and Context
Platform and Plugin versioning information does not reflect Cordova CLI 9.x.

### Description
Updated Docs

### Testing
none

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
