### PR TITLE
Prefer local cordova CLI with npx

### DIFF
--- a/www/contribute/issues.md
+++ b/www/contribute/issues.md
@@ -32,15 +32,27 @@ If you aren't sure about the priority, leave the default (major) selected. Pleas
 
 You can quickly find out versions of platforms/plugins you're using by running:
 
-    cordova platform ls
+```bash
+$ npx cordova platform ls
+```
 
 or
 
-    cordova plugin ls
+```bash
+$ npx cordova plugin ls
+```
 
 in your project respectively. You can find out the version of the Cordova CLI you're using by running:
 
-    cordova --version
+```bash
+$ npx cordova --version
+```
+
+If you have installed `cordova` globally (which is an alternative way to use Cordova), you just invoke the same commands without `npx`:
+
+```bash
+$ cordova --version
+```
 
 # Generating CLI logs
 

--- a/www/contribute/nightly_builds.md
+++ b/www/contribute/nightly_builds.md
@@ -25,14 +25,14 @@ The nightly builds are untested and may contain known and unknown defects, undec
 To try out the latest nightly version you can do:
 
 ```bash
-npm install cordova@nightly
-./node_modules/.bin/cordova --version
+$ npm install cordova@nightly
+$ npx cordova --version
 ```
 
-You can supply the `--global` option to NPM to install the nightly version globally. _Note_ that this will replace your main Cordova distribution.
+You can supply the `--global` option to NPM to install the nightly version globally. _Note_ that it is generally discouraged to install `cordova` globally.
 
 ```bash
-npm install --global cordova@nightly
+$ npm install --global cordova@nightly
 ```
 
 ## Submitting issues
@@ -42,5 +42,5 @@ Please let us know about any issues in the nightly builds so we can fix them as 
 When submitting an issue, please add a note that the issue was reproduced using a nightly build, and provide the nightly version that you are using. You can get this via:
 
 ```bash
-cordova --version
+$ npx cordova --version
 ```

--- a/www/docs/en/dev/config_ref/images.md
+++ b/www/docs/en/dev/config_ref/images.md
@@ -260,7 +260,7 @@ One icon can be used for the application and installer, but this icon should be 
 
 _Notice: If a customized icon is not provided, the Apache Cordova default icons are used._
 
-_Notice: macOS does not display custom icons when using `cordova run`. It defaults to the Electron's icon._
+_Notice: macOS does not display custom icons when using `npx cordova run`. It defaults to the Electron's icon._
 
 ```xml
 <platform name="electron">

--- a/www/docs/en/dev/guide/appdev/hooks/index.md
+++ b/www/docs/en/dev/guide/appdev/hooks/index.md
@@ -427,10 +427,10 @@ for more details.
 
 You can now add android platform and execute build.
 
-```
-cordova platform add android
+```bash 
+$ npx cordova platform add android
 ..
-cordova build
+$ npx cordova build
 ..
 Size of path\to\app\platforms\android\build\outputs\apk\android-debug.apk is 1821193 bytes
 ```

--- a/www/docs/en/dev/guide/cli/index.md
+++ b/www/docs/en/dev/guide/cli/index.md
@@ -35,59 +35,22 @@ The Cordova command-line tool is distributed as an npm package.
 To install the `cordova` command-line tool, follow these steps:
 
 1. Download and install [Node.js](https://nodejs.org/en/download/). On
-   installation you should be able to invoke `node` and `npm` on your
+   installation you should be able to invoke `node`, `npm` and `npx` on your
    command line.
 
 1. (Optional) Download and install a [git client](http://git-scm.com/downloads), if you don't
    already have one. Following installation, you should be able to invoke `git`
    on your command line. The CLI uses it to download assets when they are referenced using a url to a git repo.
 
-1. Install the `cordova` module using `npm` utility of Node.js. The `cordova`
-   module will automatically be downloaded by the `npm` utility.
-
-   * on OS X and Linux:
-       ```bash
-       $ sudo npm install -g cordova
-       ```
-
-       On OS X and Linux, prefixing the `npm` command with
-       `sudo` may be necessary to install this development utility in
-       otherwise restricted directories such as
-       `/usr/local/share`. If you are using the optional
-       nvm/nave tool or have write access to the install directory,
-       you may be able to omit the `sudo` prefix. There are
-       [more tips](http://justjs.com/posts/npm-link-developing-your-own-npm-modules-without-tears)
-       available on using `npm` without `sudo`, if you desire to do that.
-
-   * on Windows:
-       ```
-       C:\>npm install -g cordova
-       ```
-
-   The `-g` flag above tells `npm` to install `cordova` globally. Otherwise
-   it will be installed in the `node_modules` subdirectory of the current
-   working directory.
-
-   Following installation, you should be able to run
-   `cordova` on the command line with no arguments and it should
-   print help text.
-
 ## Create the App
 
 Go to the directory where you maintain your source code, and create a cordova project:
 
 ```bash
-$ cordova create hello com.example.hello HelloWorld
+$ npx cordova create hello com.example.hello HelloWorld
 ```
 
 This creates the required directory structure for your cordova app. By default, the `cordova create` script generates a skeletal web-based application whose home page is the project's `www/index.html` file.
-
-###See Also
-- [Cordova create command reference documentation][cdv_create]
-- [Cordova project directory structure][cdv_dir]
-- [Cordova project templates][cdv_template]
-
-## Add Platforms
 
 All subsequent commands need to be run within the project's directory,
 or any subdirectories:
@@ -96,17 +59,30 @@ or any subdirectories:
 $ cd hello
 ```
 
+Until necessary adjustments have been made to Cordova to do this for your automatically, you're going to want to install the current version of Cordova into your new project:
+
+```bash
+$ npm --save-dev cordova
+```
+
+###See Also
+- [Cordova create command reference documentation][cdv_create]
+- [Cordova project directory structure][cdv_dir]
+- [Cordova project templates][cdv_template]
+
+## Add Platforms
+
 Add the platforms that you want to target your app. We will add the 'ios' and 'android' platform and ensure they get saved to `config.xml` and `package.json`:
 
 ```bash
-$ cordova platform add ios
-$ cordova platform add android
+$ npx cordova platform add ios
+$ npx cordova platform add android
 ```
 
 To check your current set of platforms:
 
 ```bash
-$ cordova platform ls
+$ npx cordova platform ls
 ```
 
 Running commands to add or remove platforms affects the contents of
@@ -126,8 +102,8 @@ To build and run apps, you need to install SDKs for each platform you wish to ta
 
 To check if you satisfy requirements for building the platform:
 
-```
-$ cordova requirements
+```bash
+$ npx cordova requirements
 Requirements check results for android:
 Java JDK: installed .
 Android SDK: installed
@@ -147,19 +123,19 @@ Error: Some of requirements check failed
 
 ## Build the App
 
-By default, `cordova create` script generates a skeletal web-based application whose start page is the project's `www/index.html` file. Any
+By default, the `cordova create` script generates a skeletal web-based application whose start page is the project's `www/index.html` file. Any
 initialization should be specified as part of the [deviceready][DeviceReadyEvent] event handler defined in `www/js/index.js`.
 
 Run the following command to build the project for _all_ platforms:
 
 ```bash
-$ cordova build
+$ npx cordova build
 ```
 
 You can optionally limit the scope of each build to specific platforms - 'ios' in this case:
 
 ```bash
-$ cordova build ios
+$ npx cordova build ios
 ```
 
 ###See Also
@@ -174,12 +150,12 @@ command such as the following to rebuild the app and view it within a
 specific platform's emulator:
 
 ```bash
-$ cordova emulate android
+$ npx cordova emulate android
 ```
 
 ![]({{ site.baseurl }}/static/img/guide/cli/android_emulate_init.png)
 
-Following up with the `cordova emulate` command refreshes the emulator
+Following up with the `npx cordova emulate` command refreshes the emulator
 image to display the latest application, which is now available for
 launch from the home screen:
 
@@ -189,7 +165,7 @@ Alternately, you can plug the handset into your computer and test the
 app directly:
 
 ```bash
-$ cordova run android
+$ npx cordova run android
 ```
 
 Before running this command, you need to set up the device for
@@ -209,13 +185,13 @@ A _plugin_ exposes a Javascript API for native SDK functionality. Plugins are ty
 npm and you can search for them on the [plugin search page](/plugins/). Some key APIs are provided by the Apache Cordova open source project and these are referred to as [Core Plugin APIs]. You can also use the CLI to launch the search page:
 
 ```bash
-$ cordova plugin search camera
+$ npx cordova plugin search camera
 ```
 
 To add and save the camera plugin to `config.xml` and `package.json`, we will specify the npm package name for the camera plugin:
 
 ```
-$ cordova plugin add cordova-plugin-camera
+$ npx cordova plugin add cordova-plugin-camera
 Fetching plugin "cordova-plugin-camera@~2.1.0" via npm
 Installing "cordova-plugin-camera" for android
 Installing "cordova-plugin-camera" for ios
@@ -232,8 +208,8 @@ add plugins separately for each platform. (For more information, see
 Use `plugin ls` (or `plugin list`, or `plugin` by itself) to view
 currently installed plugins. Each displays by its identifier:
 
-```
-$ cordova plugin ls
+```bash
+$ npx cordova plugin ls
 cordova-plugin-camera 2.1.0 "Camera"
 cordova-plugin-whitelist 1.2.1 "Whitelist"
 ```
@@ -294,16 +270,16 @@ After installing the `cordova` utility, you can always update it to
 the latest version by running the following command:
 
 ```bash
-$ sudo npm update -g cordova
+$ npm update cordova
 ```
 
 Use this syntax to install a specific version:
 
 ```bash
-$ sudo npm install -g cordova@3.1.0-0.2.0
+$ npm install cordova@3.1.0-0.2.0
 ```
 
-Run `cordova -v` to see which version is currently running. To find the latest released cordova version, you can run:
+Run `npx cordova -v` to see which version is currently running. To find the latest released cordova version, you can run:
 
 ```bash
 $ npm info cordova version
@@ -312,8 +288,8 @@ $ npm info cordova version
 To update platform that you're targeting:
 
 ```bash
-$ cordova platform update android --save
-$ cordova platform update ios --save
+$ npx cordova platform update android --save
+$ npx cordova platform update ios --save
 ...etc.
 ```
 

--- a/www/docs/en/dev/guide/cli/template.md
+++ b/www/docs/en/dev/guide/cli/template.md
@@ -36,10 +36,10 @@ Find a template to create your app from by seaching for the keyword `cordova:tem
 After locating a template you wish to use. Create your project using that template, by specifying the `--template` flag during the `create` command, followed by your template source.
 
 Creating a cordova project from an NPM package, Git repository, or local path:
-```
-$ cordova create hello com.example.hello HelloWorld --template <npm-package-name>
-$ cordova create hello com.example.hello HelloWorld --template <git-remote-url>
-$ cordova create hello com.example.hello HelloWorld --template <path-to-template>
+```bash
+$ npx cordova create hello com.example.hello HelloWorld --template <npm-package-name>
+$ npx cordova create hello com.example.hello HelloWorld --template <git-remote-url>
+$ npx cordova create hello com.example.hello HelloWorld --template <path-to-template>
 ```
 
 After succesfully using a template to create your project, you'll want to indicate the platforms that you intend to target with your app. Go into your project folder and [add platforms](http://cordova.apache.org/docs/en/latest/guide/cli/index.html#add-platforms).

--- a/www/docs/en/dev/guide/hybrid/plugins/index.md
+++ b/www/docs/en/dev/guide/hybrid/plugins/index.md
@@ -56,7 +56,7 @@ argument to that command is the URL for a _git_ repository containing
 the plugin code.  This example implements Cordova's Device API:
 
 ```bash
-cordova plugin add https://git-wip-us.apache.org/repos/asf/cordova-plugin-device.git
+$ npx cordova plugin add https://git-wip-us.apache.org/repos/asf/cordova-plugin-device.git
 ```
 
 The plugin repository must feature a top-level `plugin.xml` manifest

--- a/www/docs/en/dev/guide/next/index.md
+++ b/www/docs/en/dev/guide/next/index.md
@@ -78,9 +78,9 @@ Note that the online and offline events, as well as the Network Connection API, 
 
 There is no upgrade command for Cordova projects. Instead, remove the platform from your project, and re-add it to get the latest version:
 
-```
-cordova platform rm android
-cordova platform add android
+```bash
+$ npx cordova platform rm android
+$ npx cordova platform add android
 ```
 
 It is absolutely critical that you read up on what was changed in the updated version, as the update may break your code. The best place to find this information will be in the release notes published both in the repositories and on the Cordova blog. You will want to test your app thoroughly in order to verify that it is working correctly after you perform the update.
@@ -90,9 +90,9 @@ Note: some plugins may not be compatible with the new version of Cordova. If a p
 ## Plugin Upgrades
 Upgrading plugins involves the same process as platforms - remove it, then re-add it.
 
-```
-cordova plugin rm some-plugin
-cordova plugin add some-plugin
+```bash
+$ npx cordova plugin rm some-plugin
+$ npx cordova plugin add some-plugin
 ```
 Refer to [Manage versions and platforms](../../platform_plugin_versioning_ref/index.html) for more details.
 

--- a/www/docs/en/dev/guide/platforms/android/index.md
+++ b/www/docs/en/dev/guide/platforms/android/index.md
@@ -54,7 +54,7 @@ cordova-android Version | Supported Android API-Levels | Equivalent Android Vers
 Please note that the versions listed here are for Cordova's Android package,
 [cordova-android](https://github.com/apache/cordova-android), and not for the
 Cordova CLI. To determine what version of Cordova's Android package is installed
-in your Cordova project, run the command `cordova platform ls` in the directory
+in your Cordova project, run the command `npx cordova platform ls` in the directory
 that holds your project.
 
 As a general rule, Android versions become unsupported by Cordova as
@@ -177,7 +177,7 @@ Once your AVD is configured correctly, you should be able to deploy your Cordova
 application to the emulator by running:
 
 ```bash
-$ cordova run --emulator
+$ npx cordova run --emulator
 ```
 
 ### Configuring Gradle
@@ -209,13 +209,13 @@ You can set these properties in one of four ways:
 
       ```bash
       $ export ORG_GRADLE_PROJECT_cdvMinSdkVersion=20
-      $ cordova build android
+      $ npx cordova build android
       ```
 
   2. By using the `--gradleArg` flag in your Cordova `build` or `run` commands:
 
       ```bash
-      $ cordova run android -- --gradleArg=-PcdvMinSdkVersion=20
+      $ npx cordova run android -- --gradleArg=-PcdvMinSdkVersion=20
       ```
 
   3. By placing a file called `gradle.properties` in your Android platform
@@ -334,7 +334,9 @@ the [Cordova CLI][cli_reference] `build` or `run` commands.
 
 __Note__: You should use double `--` to indicate that these are platform-specific arguments, for example:
 
-`cordova run android --release -- --keystore=../my-release-key.keystore --storePassword=password --alias=alias_name --password=password`.
+```bash
+$ npx cordova run android --release -- --keystore=../my-release-key.keystore --storePassword=password --alias=alias_name --password=password
+```
 
 ### Using build.json
 
@@ -404,10 +406,10 @@ debugging/profiling tools or if you are developing Android plugins. Please note
 that when opening your project in Android studio, it is recommended that you do
 NOT edit your code in the IDE. This will edit the code in the `platforms` folder
 of your project (not `www`), and changes are liable to be overwritten. Instead,
-edit the `www` folder and copy over your changes by running `cordova build`.
+edit the `www` folder and copy over your changes by running `npx cordova build`.
 
 Plugin developers wishing to edit their native code in the IDE should use the
-`--link` flag when adding their plugin to the project via `cordova plugin add`.
+`--link` flag when adding their plugin to the project via `npx cordova plugin add`.
 This will link the files so that changes to the plugin files in the `platforms`
 folder are reflected in your plugin's source folder (and vice versa).
 
@@ -445,7 +447,7 @@ you must still configure the Android SDK environment as described in
 For each of the scripts discussed below, refer to [Cordova CLI Reference][cli_reference]
 for more information on their arguments and usage. Each script has a name that
 matches the corresponding CLI command. For example, `cordova-android/bin/create`
-is equivalent to `cordova create`.
+is equivalent to `npx cordova create`.
 
 To get started, either download the cordova-android package from
 [npm](https://www.npmjs.com/package/cordova-android) or

--- a/www/docs/en/dev/guide/platforms/android/upgrade.md
+++ b/www/docs/en/dev/guide/platforms/android/upgrade.md
@@ -34,8 +34,8 @@ The best way to upgrade to 7.X.X is to simply remove the Android platform from
 your project and re-add it with the new version. For example,
 
 ```bash
-cordova platform remove android
-cordova platform add android@7.X.X
+$ npx cordova platform remove android
+$ npx cordova platform add android@7.X.X
 ```
 
 If you use the above method, be aware that any changes you made to the android
@@ -52,8 +52,8 @@ The best way to upgrade to 6.X.X is to simply remove the Android platform from
 your project and re-add it with the new version. For example,
 
 ```bash
-cordova platform remove android
-cordova platform add android@6.X.X
+$ npx cordova platform remove android
+$ npx cordova platform add android@6.X.X
 ```
 
 If you use the above method, be aware that any changes you made to the android
@@ -75,8 +75,8 @@ The best way to upgrade to 5.X.X is to simply remove the Android platform from
 your project and re-add it with the new version. For example,
 
 ```bash
-cordova platform remove android
-cordova platform add android@5.X.X
+$ npx cordova platform remove android
+$ npx cordova platform add android@5.X.X
 ```
 
 If you use the above method, be aware that any changes you made to the android
@@ -94,7 +94,7 @@ For CLI projects:
 
 1. Update the `cordova` CLI version. See [The Command-Line Interface](../../cli/index.html).
 
-2. Run `cordova platform update android@5.0.0` in your existing projects.
+2. Run `npx cordova platform update android@5.0.0` in your existing projects.
 
 ### Upgrading Plugins for Android Marshmallow
 
@@ -147,7 +147,7 @@ For CLI projects:
 
 1. Update the `cordova` CLI version. See [The Command-Line Interface](../../cli/index.html).
 
-2. Run `cordova platform update android@4.0.0` in your existing projects.
+2. Run `npx cordova platform update android@4.0.0` in your existing projects.
 
 ### Upgrading the Whitelist
 All whitelist functionality is now implemented via plugin.  Without a plugin,
@@ -174,7 +174,7 @@ device.  If you wish to use the Crosswalk WebView instead, simply add the
 Crosswalk plugin:
 
 ```bash
-cordova plugin add cordova-plugin-crosswalk-webview
+$ npx cordova plugin add cordova-plugin-crosswalk-webview
 ```
 
 Upon adding the plugin, your app will get the Crosswalk WebView installed and
@@ -186,7 +186,7 @@ a plugin.  The configuration options for splash screens are unchanged.  The only
 upgrade step required is to add the plugin:
 
 ```bash
-cordova plugin add cordova-plugin-splashscreen
+$ npx cordova plugin add cordova-plugin-splashscreen
 ```
 
 ## Upgrading to 3.7.1 from 3.6.0
@@ -201,7 +201,7 @@ For CLI projects:
 
 1. Update the `cordova` CLI version. See [The Command-Line Interface](../../cli/index.html).
 
-2. Run `cordova platform update android` in your existing projects.
+2. Run `npx cordova platform update android` in your existing projects.
 
 
 ## Upgrading to 3.3.0 from 3.2.0
@@ -219,11 +219,13 @@ For projects that were created with the cordova CLI:
 
 1. Update the `cordova` CLI version. See [The Command-Line Interface](../../cli/index.html).
 
-2. Run `cordova platform update android`
+2. Run `npx cordova platform update android`
 
 For projects not created with the cordova CLI, run:
 
-        bin/update <project_path>
+```
+bin/update <project_path>
+```
 
 **WARNING:**  On Android 4.4 - Android 4.4.3, creating a file input element with type="file" will not open the file picker dialog.
 This is a regression with Chromium on Android and the problem can be reproduced in the standalone Chrome browser on Android (see http://code.google.com/p/android/issues/detail?id=62220)  The suggested workaround is to use the FileTransfer and File plugins for Android 4.4. You can listen for an onClick event from the input type="file" and then pop up a file picker UI. In order to tie the form data with the upload, you can use JavaScript to attach form values to the multi-part POST request that FileTransfer makes.
@@ -235,18 +237,20 @@ For projects that were created with the cordova CLI:
 
 1. Update the `cordova` CLI version. See [The Command-Line Interface](../../cli/index.html).
 
-2. Run `cordova platform update android`
+2. Run `npx cordova platform update android`
 
 For projects not created with the cordova CLI, run:
 
-        bin/update <project_path>
+```
+bin/update <project_path>
+```
 
 ## Upgrade to the CLI (3.0.0) from 2.9.0
 
 1. Create a new Apache Cordova 3.0.0 project using the cordova CLI, as
    described in [The Command-Line Interface](../../cli/index.html).
 
-2. Add your platforms the cordova project, for example: `cordova
+2. Add your platforms the cordova project, for example: `npx cordova
    platform add android`.
 
 3. Copy the contents of your project's `www` directory to the `www` directory

--- a/www/docs/en/dev/platform_plugin_versioning_ref/index.md
+++ b/www/docs/en/dev/platform_plugin_versioning_ref/index.md
@@ -37,13 +37,13 @@ One scenario where save/restore capabilities come in handy is in large teams tha
 ## Platform Versioning
 
 ### Saving platforms
-To save a platform, you issue the following command :
+To save a platform, you issue the following command:
 
 ```bash
-$ cordova platform add <platform[@<version>] | directory | git_url>
+$ npx cordova platform add <platform[@<version>] | directory | git_url>
 ```
 
-After running the above command, the resulting config.xml looks like :
+After running the above command, the resulting config.xml looks like:
 
 ```xml
 <?xml version='1.0' encoding='utf-8'?>
@@ -52,18 +52,18 @@ After running the above command, the resulting config.xml looks like :
     ...
 </xml>
 ```
-After running the above command, the resulting package.json looks like :
+After running the above command, the resulting package.json looks like:
 
-```bash
+```json
 "cordova": {"platforms": ["android"]},"dependencies": {"cordova-android": "^4.0.0"}
 ```
-The '--nosave' flag prevents adding and deleting specified platforms from config.xml and package.json. To prevent saving a platform, you issue the following command :
+The '--nosave' flag prevents adding and deleting specified platforms from config.xml and package.json. To prevent saving a platform, you issue the following command:
 
 ```bash
-$ cordova platform add <platform[@<version>] | directory | git_url> --nosave
+$ npx cordova platform add <platform[@<version>] | directory | git_url> --nosave
 ```
 
-Some examples :
+Some examples:
 
   * **'cordova platform add android'** => retrieves the pinned version of the android platform, adds it to the project and then updates config.xml and package.json.
   * **'cordova platform add android@3.7.0'** => retrieves the android platform, version 3.7.0 from npm, adds it to the project and then updates config.xml and package.json.
@@ -73,21 +73,21 @@ Some examples :
   * **'cordova platform remove android --nosave'** =>  removes the android platform from the project, but does not remove it from config.xml or package.json.  
 
 ### Mass saving platforms on an existing project
-If you have a pre-existing project and you want to save all the currently added platforms in your project, you can use :
+If you have a pre-existing project and you want to save all the currently added platforms in your project, you can use:
 
 ```bash
-$ cordova platform save
+$ npx cordova platform save
 ```
 
 ### Updating / Removing platforms
-It is also possible to update/delete from config.xml and package.json during the commands 'cordova platform update' and 'cordova platform remove' :
+It is also possible to update/delete from config.xml and package.json during the commands 'cordova platform update' and 'cordova platform remove':
 
 ```bash
-$ cordova platform update <platform[@<version>] | directory | git_url> --save
-$ cordova platform remove <platform>
+$ npx cordova platform update <platform[@<version>] | directory | git_url> --save
+$ npx cordova platform remove <platform>
 ```
 
-Some examples :
+Some examples:
 
   * **'cordova platform update android --save'** => In addition to updating the android platform to the pinned version, update config.xml entry
   * **'cordova platform update android@3.8.0 --save'** => In addition to updating the android platform to version 3.8.0, update config.xml entry
@@ -113,30 +113,30 @@ Suppose your config.xml file contains the following entry:
 </xml>
 ```
 
-If you run the command **'cordova platform add android'** (no version/folder/git_url specified), the platform 'android@3.7.0' (as retrieved from config.xml) will be installed.
+If you run the command **'npx cordova platform add android'** (no version/folder/git_url specified), the platform 'android@3.7.0' (as retrieved from config.xml) will be installed.
 
 **Example for order of precedence for restoring platforms:**
 
 Suppose your config.xml has this platform and version:
-```bash
+```xml
 <engine name="android" spec=“1.0.0” />
 ```
 
 Suppose your package.json has this platform and version:
 
-```bash
+```json
 "cordova": {"platforms": ["android"]},"dependencies": {"cordova-android": "4.0.0"}
 ```
 
 When prepare is run, package.json’s contents are giving precedence and both config.xml and package.json are updated so that they have identical platforms and variables. Notice how package.json's version (4.0.0) has **replaced** config.xml's version (1.0.0).
 
-After running **'cordova prepare'** , the resulting config.xml looks like :
-```bash
+After running **'cordova prepare'** , the resulting config.xml looks like:
+```xml
 <engine name="android" spec=“4.0.0” />
 ```
 
-After running **'cordova prepare'** , the resulting package.json looks like :
-```bash
+After running **'cordova prepare'** , the resulting package.json looks like:
+```json
 "cordova": {"platforms": ["android",]},"dependencies": {"cordova-android": "4.0.0"}
 ```
 ---
@@ -145,13 +145,13 @@ After running **'cordova prepare'** , the resulting package.json looks like :
 _(The plugin commands are a mirror of the platform commands)_
 
 ### Saving plugins
-To save a plugin, you issue the following command :
+To save a plugin, you issue the following command:
 
 ```bash
-$ cordova plugin add <plugin[@<version>] | directory | git_url>
+$ npx cordova plugin add <plugin[@<version>] | directory | git_url>
 ```
 
-After running the above command, the resulting config.xml looks like :
+After running the above command, the resulting config.xml looks like:
 
 ```xml
 <?xml version='1.0' encoding='utf-8'?>
@@ -161,19 +161,19 @@ After running the above command, the resulting config.xml looks like :
 </xml>
 ```
 
-After running the above command, the resulting package.json looks like :
+After running the above command, the resulting package.json looks like:
 
-```bash
+```json
 "cordova": {"plugins": ["cordova-plugin-console"]},"dependencies": {"cordova-plugin-console": "^1.0.0"}
 ```
 
-The '--nosave' flag prevents adding and deleting specified plugins from config.xml and package.json. To prevent saving a plugin, you issue the following command :
+The '--nosave' flag prevents adding and deleting specified plugins from config.xml and package.json. To prevent saving a plugin, you issue the following command:
 
 ```bash
-$ cordova plugin add <plugin[@<version>] | directory | git_url> --nosave
+$ npx cordova plugin add <plugin[@<version>] | directory | git_url> --nosave
 ```
 
-Some examples :
+Some examples:
 
   * **'cordova plugin add cordova-plugin-console'** => retrieves the pinned version of the console plugin, adds it to the project and then updates config.xml and package.json.
   * **'cordova plugin add cordova-plugin-console@0.2.13'** => retrieves the android plugin, version 0.2.13 from npm, adds it to the project and then updates config.xml and package.json.
@@ -181,18 +181,18 @@ Some examples :
   * **'cordova plugin add C:/path/to/console/plugin'** => retrieves the console plugin from the specified directory, adds it to the project, then updates config.xml and package.json and points to the directory.
 
 ### Mass saving plugins on an existing project
-If you have a pre-existing project and you want to save all currently added plugins in the project, you can use :
+If you have a pre-existing project and you want to save all currently added plugins in the project, you can use:
 
 ```bash
-$ cordova plugin save
+$ npx cordova plugin save
 ```
 
 
 ### Removing plugins
-It is also possible to delete from config.xml and package.json during the command 'cordova plugin remove' :
+It is also possible to delete from config.xml and package.json during the command 'cordova plugin remove':
 
 ```bash
-$ cordova plugin remove <plugin>
+$ npx cordova plugin remove <plugin>
 ```
 For example:
 
@@ -223,24 +223,24 @@ If you run the command **'cordova plugin add cordova-plugin-console'** (no versi
 
 Supposed your config.xml has this plugin and version:
 
-```bash
+```xml
 <plugin name="cordova-plugin-splashscreen"/>
 ```
 Suppose your package.json has this plugin and version:
 
-```bash
+```json
 "cordova": {"plugins": {"cordova-plugin-splashscreen" : {} } },"dependencies": {"cordova-plugin-splashscreen": "1.0.0"}
 ```
 When prepare is run, package.json’s contents are giving precedence and both config.xml and package.json are updated so that they have identical plugins and variables. Notice how package.json's version (1.0.0) is now in config.xml.
 
-After running **'cordova prepare'** , the resulting config.xml looks like :
+After running **'cordova prepare'** , the resulting config.xml looks like:
 
-```bash
+```xml
 <plugin name="cordova-plugin-splashscreen" spec="1.0.0"/>
 ```
 
-After running **'cordova prepare'** , the resulting package.json looks like :
+After running **'cordova prepare'** , the resulting package.json looks like:
 
-```bash
+```json
 "cordova": {"plugins": {"cordova-plugin-splashscreen" : {} } },"dependencies": {"cordova-plugin-splashscreen": "1.0.0"}
 ```

--- a/www/docs/en/dev/plugin_ref/plugman.md
+++ b/www/docs/en/dev/plugin_ref/plugman.md
@@ -106,8 +106,8 @@ Plugman features a global help command which may help you if you get stuck or ar
 a list of all available Plugman commands and their syntax:
 
 ```bash
-plugman -help
-plugman  # same as above
+$ plugman -help
+$ plugman  # same as above
 ```
 
 **NOTE**: `plugman -help` may show some additional registry-related commands. These commands are for plugin developers and may not be implemented on third-party plugin registries.
@@ -118,13 +118,13 @@ any internal debugging messages as they are emitted and may help you track down 
 
 ```bash
 # Adding Android battery-status plugin to "myProject":
-plugman -d install --platform android --project myProject --plugin cordova-plugin-battery-status
+$ plugman -d install --platform android --project myProject --plugin cordova-plugin-battery-status
 ```
 
 Finally, you can use the `--version|-v` flag to see which version of Plugman you are using.
 
 ```bash
-plugman -v
+$ plugman -v
 ```
 
 ## Registry Actions
@@ -138,7 +138,7 @@ third-party plugin registries.
 You can use Plugman to search the [Plugin registry](http://plugins.cordova.io) for plugin id's that match the given space separated list of keywords.
 
 ```bash
-plugman search <plugin keywords>
+$ plugman search <plugin keywords>
 ```
 
 ### Changing the Plugin Registry
@@ -146,8 +146,8 @@ plugman search <plugin keywords>
 You can get or set the URL of the current plugin registry that plugman is using. Generally you should leave this set at http://registry.cordova.io unless you want to use a third party plugin registry.
 
 ```bash
-plugman config set registry <url-to-registry>
-plugman config get registry
+$ plugman config set registry <url-to-registry>
+$ plugman config get registry
 ```
 
 ### Get Plugin Information
@@ -155,7 +155,7 @@ plugman config get registry
 You can get information about any specific plugin stored in the plugin repository with:
 
 ```bash
-plugman info <id>
+$ plugman info <id>
 ```
 
 This will contact the plugin registry and fetch information such as the plugin's version number.
@@ -170,107 +170,107 @@ platform, and reference the platform's project directory.
 * cordova-plugin-battery-status
 
     ```bash
-    plugman install --platform <ios|android> --project <directory> --plugin cordova-plugin-battery-status
+    $ plugman install --platform <ios|android> --project <directory> --plugin cordova-plugin-battery-status
     ```
 
 * cordova-plugin-camera
 
     ```bash
-    plugman install --platform <ios|android> --project <directory> --plugin cordova-plugin-camera
+    $ plugman install --platform <ios|android> --project <directory> --plugin cordova-plugin-camera
     ```
 
 * cordova-plugin-console
 
     ```bash
-    plugman install --platform <ios|android> --project <directory> --plugin cordova-plugin-console
+    $ plugman install --platform <ios|android> --project <directory> --plugin cordova-plugin-console
     ```
 
 * cordova-plugin-contacts
 
     ```bash
-    plugman install --platform <ios|android> --project <directory> --plugin cordova-plugin-contacts
+    $ plugman install --platform <ios|android> --project <directory> --plugin cordova-plugin-contacts
     ```
 
 * cordova-plugin-device
 
     ```bash
-    plugman install --platform <ios|android> --project <directory> --plugin cordova-plugin-device
+    $ plugman install --platform <ios|android> --project <directory> --plugin cordova-plugin-device
     ```
 
 * cordova-plugin-device-motion (accelerometer)
 
     ```bash
-    plugman install --platform <ios|android> --project <directory> --plugin cordova-plugin-device-motion
+    $ plugman install --platform <ios|android> --project <directory> --plugin cordova-plugin-device-motion
     ```
 
 * cordova-plugin-device-orientation (compass)
 
     ```bash
-    plugman install --platform <ios|android> --project <directory> --plugin cordova-plugin-device-orientation
+    $ plugman install --platform <ios|android> --project <directory> --plugin cordova-plugin-device-orientation
     ```
 
 * cordova-plugin-dialogs
 
     ```bash
-    plugman install --platform <ios|android> --project <directory> --plugin cordova-plugin-dialogs
+    $ plugman install --platform <ios|android> --project <directory> --plugin cordova-plugin-dialogs
     ```
 
 * cordova-plugin-file
 
     ```bash
-    plugman install --platform <ios|android> --project <directory> --plugin cordova-plugin-file
+    $ plugman install --platform <ios|android> --project <directory> --plugin cordova-plugin-file
     ```
 
 * cordova-plugin-file-transfer
 
     ```bash
-    plugman install --platform <ios|android> --project <directory> --plugin cordova-plugin-file-transfer
+    $ plugman install --platform <ios|android> --project <directory> --plugin cordova-plugin-file-transfer
     ```
 
 * cordova-plugin-geolocation
 
     ```bash
-    plugman install --platform <ios|android> --project <directory> --plugin cordova-plugin-geolocation
+    $ plugman install --platform <ios|android> --project <directory> --plugin cordova-plugin-geolocation
     ```
 
 * cordova-plugin-globalization
 
     ```bash
-    plugman install --platform <ios|android> --project <directory> --plugin cordova-plugin-globalization
+    $ plugman install --platform <ios|android> --project <directory> --plugin cordova-plugin-globalization
     ```
 
 * cordova-plugin-inappbrowser
 
     ```bash
-    plugman install --platform <ios|android> --project <directory> --plugin cordova-plugin-inappbrowser
+    $ plugman install --platform <ios|android> --project <directory> --plugin cordova-plugin-inappbrowser
     ```
 
 * cordova-plugin-media
 
     ```bash
-    plugman install --platform <ios|android> --project <directory> --plugin cordova-plugin-media
+    $ plugman install --platform <ios|android> --project <directory> --plugin cordova-plugin-media
     ```
 
 * cordova-plugin-media-capture
 
     ```bash
-    plugman install --platform <ios|android> --project <directory> --plugin cordova-plugin-media-capture
+    $ plugman install --platform <ios|android> --project <directory> --plugin cordova-plugin-media-capture
     ```
 
 * cordova-plugin-network-information
 
     ```bash
-    plugman install --platform <ios|android> --project <directory> --plugin cordova-plugin-network-information
+    $ plugman install --platform <ios|android> --project <directory> --plugin cordova-plugin-network-information
     ```
 
 * cordova-plugin-splashscreen
 
     ```bash
-    plugman install --platform <ios|android> --project <directory> --plugin cordova-plugin-splashscreen
+    $ plugman install --platform <ios|android> --project <directory> --plugin cordova-plugin-splashscreen
     ```
 
 * cordova-plugin-vibration
 
     ```bash
-    plugman install --platform <ios|android> --project <directory> --plugin cordova-plugin-vibration
+    $ plugman install --platform <ios|android> --project <directory> --plugin cordova-plugin-vibration
     ```

--- a/www/docs/en/dev/plugin_ref/spec.md
+++ b/www/docs/en/dev/plugin_ref/spec.md
@@ -627,7 +627,7 @@ options | Pod options declared in raw format. If declared, the other Pod options
 
 Examples:
 
-```
+```xml
     <podspec>
       <config>
         <source url="https://github.com/brightcove/BrightcoveSpecs.git" />
@@ -710,7 +710,7 @@ The CLI replaces variable references with the specified value, or the empty stri
 Plugman can request users to specify a plugin's required variables. For example, API keys for C2M and Google Maps can be specified as a command-line argument:
 
 ```bash
-plugman --platform android --project /path/to/project --plugin name|git-url|path --variable API_KEY=!@CFATGWE%^WGSFDGSDFW$%^#$%YTHGsdfhsfhyer56734
+$ plugman --platform android --project /path/to/project --plugin name|git-url|path --variable API_KEY=!@CFATGWE%^WGSFDGSDFW$%^#$%YTHGsdfhsfhyer56734
 ```
 
 Certain variable names should be reserved, like `$PACKAGE_NAME`. This is the reverse-domain style unique identifier for the package, corresponding to the `CFBundleIdentifier` on iOS or the `package` attribute of the top-level `manifest` element in an `AndroidManifest.xml` file.

--- a/www/plugins/faq.md
+++ b/www/plugins/faq.md
@@ -15,7 +15,7 @@ To start using plugins from npm, Cordova CLI version 5.0.0 or higher is required
 
 ## How do I install plugins from npm?
 
-Cordova team decided to change official plugin IDs from org.apache.cordova.* to cordova-plugin-* to better fit within the npm ecosystem. Developers can install a plugin using the command `cordova plugin add [PLUGIN ID]`.
+Cordova team decided to change official plugin IDs from org.apache.cordova.* to cordova-plugin-* to better fit within the npm ecosystem. Developers can install a plugin using the command `npx cordova plugin add [PLUGIN ID]`.
 
 ## How do I know which platforms are supported for a plugin?
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

None

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

See #838 for discussion about this change.

### Description
<!-- Describe your changes in detail -->

This changes the documentation to recommend using a project-local installation of `cordova`, instead of relying on a global installation.

The thinking that went into this change was:

- When a command or script is simply mentioned, to refer to the task it handles, no `npx` should **not** be prefixed.
- If the given command is an example of invocation, `npx` should be prefixed.

I tried to be consistent with this, hopefully, I didn't fail.

I also tried to bring more consistency to syntax highlighting and prefixing CLI usages with `$`. I hope that wasn't completely out of scope for this change.

### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
