### PR TITLE
Updated Cordova 9.x Support Platform List

### DIFF
--- a/www/docs/en/9.x/reference/cordova-cli/index.md
+++ b/www/docs/en/9.x/reference/cordova-cli/index.md
@@ -254,16 +254,8 @@ There are a number of ways to specify a platform:
 - Android
 - iOS
 - Windows (8.1, Phone 8.1, UWP - Windows 10)
-- Blackberry10
-- Ubuntu
 - Browser
-
-### Deprecated Platforms
-
-- Amazon-fireos (use Android platform instead)
-- WP8 (use Windows platform instead)
-- Windows 8.0 (use older versions of cordova)
-- Firefox OS (use older versions of cordova)
+- Electron
 
 ### Examples
 


### PR DESCRIPTION
### Platforms affected
none

### Motivation and Context
Updated Cordova 9.x Support Platform List to be current

closes: https://github.com/apache/cordova-electron/issues/49

### Description
Updated Cordova 9.x Support Platform List to be current

### Testing
none

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
