### PR TITLE
Update to latest gulp-sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "gulp-less": "^3.0.3",
     "gulp-rename": "^1.2.2",
     "gulp-replace": "^0.5.4",
-    "gulp-sass": "^2.0.4",
+    "gulp-sass": "^4.0.2",
     "gulp-uglify": "^1.2.0",
     "gulp-util": "^3.0.5",
     "jodoc": "git+https://github.com/kant2002/jodoc-js.git",


### PR DESCRIPTION
This has the following benefits:

- Uses a node-sass version that officially supports Node.js 8
- Speeds up installation because we do not need to compile node-sass
- Fixes some npm security audit warnings

This slightly changes the _formatting_ of the website's generated CSS.
Other than that, this does not change the build output.