### PR TITLE
Android: App Bundle Documentation

### DIFF
--- a/www/docs/en/dev/guide/platforms/android/index.md
+++ b/www/docs/en/dev/guide/platforms/android/index.md
@@ -328,7 +328,7 @@ To sign an app, you need the following parameters:
 | Alias                 | `--alias`         | The id specifying the private key used for signing
 | Password              | `--password`      | Password for the private key specified
 | Type of the Keystore  | `--keystoreType`  | *Default: auto-detect based on file extension*<br>Either pkcs12 or jks
-| Package Type          | `--packageType`   | *Default: apk*<br>Builds an APK or a bundle (.aab) file.<br>Accepts either `apk` or `bundle`
+| Package Type          | `--packageType`   | *Default: apk*<br>Specify whether to build an APK or an [Android App Bundle] (https://developer.android.com/guide/app-bundle) (.aab) file.<br>Accepts either `apk` or `bundle`
 
 These parameters can be specified using the command line arguments above to
 the [Cordova CLI][cli_reference] `build` or `run` commands.

--- a/www/docs/en/dev/guide/platforms/android/index.md
+++ b/www/docs/en/dev/guide/platforms/android/index.md
@@ -328,13 +328,14 @@ To sign an app, you need the following parameters:
 | Alias                 | `--alias`         | The id specifying the private key used for signing
 | Password              | `--password`      | Password for the private key specified
 | Type of the Keystore  | `--keystoreType`  | *Default: auto-detect based on file extension*<br>Either pkcs12 or jks
+| Package Type          | `--packageType`   | *Default: apk*<br>Builds an APK or a bundle (.aab) file.<br>Accepts either `apk` or `bundle`
 
 These parameters can be specified using the command line arguments above to
 the [Cordova CLI][cli_reference] `build` or `run` commands.
 
 __Note__: You should use double `--` to indicate that these are platform-specific arguments, for example:
 
-`cordova run android --release -- --keystore=../my-release-key.keystore --storePassword=password --alias=alias_name --password=password`.
+`cordova run android --release -- --keystore=../my-release-key.keystore --storePassword=password --alias=alias_name --password=password --packageType=bundle`.
 
 ### Using build.json
 
@@ -350,14 +351,16 @@ build configuration file:
             "storePassword": "android",
             "alias": "mykey1",
             "password" : "password",
-            "keystoreType": ""
+            "keystoreType": "",
+            "packageType": "apk"
         },
         "release": {
             "keystore": "../android.keystore",
             "storePassword": "",
             "alias": "mykey2",
             "password" : "password",
-            "keystoreType": ""
+            "keystoreType": "",
+            "packageType": "bundle"
         }
     }
 }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
This PR is a brother PR of https://github.com/apache/cordova-android/pull/764 that adds documentation related to the new app bundle feature.



### Description
Documented the new acceptable key in `build.json` or via command line, `--packageType`, which accepts a value of `apk` or `bundle`. Defaults to `apk`.



### Testing
I ran `npm serve` to generate the website, and observed my changes locally.
I also ran `npm test`, which builds successfully with "Possible 404 in ToC" warnings. The warnings however appears in master and because they are warnings I did ignore them.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
