### PR TITLE
docs(ios): Improve "Using Flags" and "Using build.json"

### DIFF
--- a/www/docs/en/dev/guide/platforms/ios/index.md
+++ b/www/docs/en/dev/guide/platforms/ios/index.md
@@ -162,11 +162,15 @@ To sign an app, you need the following parameters:
 | Code Sign Resource Rules | `--codesignResourceRules`| (Optional) Used to control which files in a bundle should be sealed by a code signature. For more details, read [The OS X Code Signing In Depth article](https://developer.apple.com/library/mac/technotes/tn2206/_index.html#//apple_ref/doc/uid/DTS40007919-CH1-TNTAG206)
 | Automatic Provisioning   | `--automaticProvisioning`| (Optional) Enable to allow Xcode to automatically manage provisioning profiles. Valid options are `false` (the default) and `true`.
 
+These parameters can be specified using the command line arguments above to the Cordova CLI `build` or `run` commands.
+
+**Note**: You should use double `--` to indicate that these are platform-specific arguments, for example:
+
+`cordova run ios --release -- --codeSignIdentity="iPhone Developer" --developmentTeam=FG35JLLMXX4A --packageType=development`.
+
 ### Using build.json
 
-Alternatively, you could specify them in a build configuration file (`build.json`)
-using the `--buildConfig` argument to the same commands. Here's a sample of a
-build configuration file:
+Alternatively, you could specify these flags in a build configuration file (default: `build.json` or add the `--buildConfig` flag to the same commands, e.g. `cordova build ios --buildConfig=..build.json`). Here's a sample of a build configuration file:
 
 For automatic signing, where provisioning profiles are managed automatically by Xcode (recommended):
 

--- a/www/docs/en/dev/guide/platforms/ios/index.md
+++ b/www/docs/en/dev/guide/platforms/ios/index.md
@@ -170,7 +170,7 @@ These parameters can be specified using the command line arguments above to the 
 
 ### Using build.json
 
-Alternatively, you could specify these flags in a build configuration file (default: `build.json` or add the `--buildConfig` flag to the same commands, e.g. `cordova build ios --buildConfig=..build.json`). Here's a sample of a build configuration file:
+Alternatively, you could specify these flags in a build configuration file (default: `build.json` or add the `--buildConfig` flag to the same commands, so you can also use other file names e.g. `cordova build ios --buildConfig=../customBuild.json`). Here's a sample of a build configuration file:
 
 For automatic signing, where provisioning profiles are managed automatically by Xcode (recommended):
 

--- a/www/docs/en/dev/guide/platforms/ios/index.md
+++ b/www/docs/en/dev/guide/platforms/ios/index.md
@@ -224,6 +224,8 @@ For manual signing, specifying the provisioning profiles by UUID:
 }
 ```
 
+There is also support to mix and match command line arguments and parameters in `build.json`. Values from the command line arguments will get precedence.
+
 ## Xcode Build Flags
 
 If you have a custom situation where you need to pass additional build flags to Xcode you would use one or more `--buildFlag` options to pass these flags to `xcodebuild`. If you use an `xcodebuild` built-in flag, it will show a warning.


### PR DESCRIPTION
### Platforms affected

iOS


### Motivation and Context

When reading up on the usage of `build.json` I found some missing information for iOS.

### Description

- Add information what commands these flags can be used on
- Add example of their usage
- Describe how `build.json` is actually used: by default, or via other file name as param buildConfig
- Add info about mix and match (via Android)

#### Open questions

- Is "**Note**: You should use double `--` to indicate that these are platform-specific arguments, for example:" actually correct?
- Is "There is also support to mix and match command line arguments and parameters in build.json. Values from the command line arguments will get precedence. " actually true?

---

If this PR is merged, we should probably check if some of the changes can/should also be applied to Android at https://cordova.apache.org/docs/en/latest/guide/platforms/android/index.html