### PR TITLE
iOS support for IndexedDB

### DIFF
--- a/www/docs/en/dev/cordova/storage/storage.md
+++ b/www/docs/en/dev/cordova/storage/storage.md
@@ -166,6 +166,7 @@ IndexedDB is supported by the underlying WebView on the following Cordova platfo
 
 - Windows (with some limitations)
 - Android (4.4 and above)
+- iOS (with Safari 10 and above)
 
 ### Windows Limitations
 
@@ -268,7 +269,6 @@ For more information, see:
 
 ### Disadvantages
 
-- Not supported on iOS.
 - Complex API with nested callbacks.
 - Limited total amount of storage (typically around 5MB).
 


### PR DESCRIPTION
iOS has supported IndexedDB since the release of iOS Safari 10.

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Support for IDB has long been available on iOS. My team recently migrated our db from WebSQL to IDB and are enjoying full support on the iOS platform. We would have gone with IDB from the start but the docs led us to believe there wasn't support. Also, WebSQL is deprecated and IDB is now the best cross-platform solution available, imo. Hopefully this saves some other developers grief.


### Description
<!-- Describe your changes in detail -->
Simply adding iOS to the list of supported platforms, and removing it from the list of disadvantages.


### Testing
<!-- Please describe in detail how you tested your changes. -->
We have IDB in production on iOS and it is working just fine.


### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
