### PR TITLE
(android) Add required versions to support adaptive icons

### DIFF
--- a/www/docs/en/dev/config_ref/images.md
+++ b/www/docs/en/dev/config_ref/images.md
@@ -54,7 +54,7 @@ different screen resolutions.
 
 ## Android
 
-On Android, instead of using a single image for an icon, you can use two images (background and foreground) to create an **Adaptive Icon**.
+On Android, instead of using a single image for an icon, you can use two images (background and foreground) to create an **Adaptive Icon**. In order to support adaptive icons, you need to have at least version 9.0.0 of **cordova** installed and have at least version 8.0.0 of **cordova-android** installed.
 
 Attributes    | Description
 --------------|--------------------------------------------------------------------------------

--- a/www/docs/en/dev/config_ref/images.md
+++ b/www/docs/en/dev/config_ref/images.md
@@ -54,7 +54,7 @@ different screen resolutions.
 
 ## Android
 
-On Android, instead of using a single image for an icon, you can use two images (background and foreground) to create an **Adaptive Icon**. In order to support adaptive icons, you need to have at least version 9.0.0 of **cordova** installed and have at least version 8.0.0 of **cordova-android** installed.
+On Android, instead of using a single image for an icon, you can use two images (background and foreground) to create an **Adaptive Icon**. To use Adaptive Icons, you need to have installed at least version 9.0.0 of **Cordova** and version 8.0.0 of **Cordova-Android**.
 
 Attributes    | Description
 --------------|--------------------------------------------------------------------------------


### PR DESCRIPTION
In order to support Android 8 adaptive icons, cordova@9.0.0 and cordova-android@8.0.0 are required. Any older version of these two results in build errors or only old-style icons.

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

android

### Motivation and Context
In order to support Android 8 adaptive icons, cordova@9.0.0 and cordova-android@8.0.0 are required. Any older version of these two results in build errors or only old-style icons.

### Description
State in the documentation which versions of cordova and cordova-android are required to support Android adaptive icons.

### Testing
None.

### Checklist
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] I've updated the documentation if necessary
