### PR TITLE
[BUG] Clarify sponsorship in the footer

### DIFF
--- a/www/_includes/footer_contents.html
+++ b/www/_includes/footer_contents.html
@@ -37,6 +37,7 @@
                     </li>
                     <li>
                         <a target="_blank" href="http://www.apache.org/foundation/sponsorship.html">Become a Sponsor</a>
+                        <sup><a href="sponsorship">*</a></sup>
                     </li>
                     <li>
                         <a target="_blank" href="http://www.apache.org/foundation/thanks.html">Thanks</a>
@@ -57,6 +58,11 @@
         </a>
         <p style="padding-top:20px"> <a href="https://twitter.com/apachecordova" class="twitter-follow-button" data-show-count="false">Follow @apachecordova</a></p>
         <script async defer src="https://slack-cordova-io.herokuapp.com/slackin.js"></script>
+        <p style="padding-top:20px">
+            * According to <a target="_blank" href="http://www.apache.org/foundation/sponsorship.html#FundsGo">Become a Sponsor</a>,
+              Apache sponsorship funds would go to non-coding activities. Sustainability through sponsorship of code maintenance activities
+              is under discussion in <a target="_blank" href="https://github.com/apache/cordova/issues/163">apache/cordova#163</a>.
+        </p>
     </div>
 </div>
 <p class="copyright_text">


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

All

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Existing sponsorship link which shows up on every page in our documentation goes to an ASF "sponsorship" page but it is not so clear that the sponsorship would go to non-coding activities. This is not in line with our needs for project sustainability (apache/cordova#163).

I think we should also direct people to the actual project sustainability issue (apache/cordova#163).

I am including "[BUG]" in the description since I think this is something that needs to be fixed in our documentation.

### Description
<!-- Describe your changes in detail -->

- Add a footnote to the Apache "sponsorship" link to *clearly* show the following:
  - that the existing "sponsorship" would go to non-coding activities
  - link to the project sustainability issue (apache/cordova#163)

### Testing
<!-- Please describe in detail how you tested your changes. -->

TODO:

- [ ] check that generated documentation renders correctly

### Checklist

- ~~I've run the tests to see all new and existing tests pass~~
- ~~I added automated test coverage as appropriate for this change~~
- ~~Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)~~
- ~~If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))~~
- [x] I've updated the documentation if necessary
