### PR TITLE
build: major update to jekyll 3.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
-gem 'jekyll', '= 2.5.3'
+gem 'jekyll', '~> 3.8'
 gem 'redcarpet', '= 3.3.2'
 gem 'rouge', '= 2.1.0'

--- a/www/_includes/analytics.html
+++ b/www/_includes/analytics.html
@@ -3,6 +3,6 @@
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', '{{ page.analytics_id }}', 'auto');
+    ga('create', '{{ layout.analytics_id }}', 'auto');
     ga('send', 'pageview');
 </script>

--- a/www/_includes/header.html
+++ b/www/_includes/header.html
@@ -14,16 +14,16 @@
             <div id="navbar" class="navbar-collapse collapse">
                 <div class="nav_bar_center">
                     <ul class="nav navbar-nav">
-                        <li {% if page.docs_tab %}class="active"{% endif %}>
+                        <li {% if layout.docs_tab %}class="active"{% endif %}>
                             <a href="{{ site.baseurl }}/docs/en/{{ site.default_linked_docs_version }}/">Documentation</a>
                         </li>
-                        <li {% if page.plugins_tab %}class="active"{% endif %}>
+                        <li {% if layout.plugins_tab %}class="active"{% endif %}>
                             <a href="{{ site.baseurl }}/plugins">Plugins</a>
                         </li>
-                        <li {% if page.blog_tab %}class="active"{% endif %}>
+                        <li {% if layout.blog_tab %}class="active"{% endif %}>
                             <a href="{{ site.baseurl }}/blog" id="blog_button">Blog<span class="badge" id="new_blog_count"></span></a>
                         </li>
-                        <li {% if page.contribute_tab %}class="active"{% endif %}>
+                        <li {% if layout.contribute_tab %}class="active"{% endif %}>
                             <a href="{{ site.baseurl }}/contribute">Contribute</a>
                         </li>
                         <li {% if page.team_tab %}class="active"{% endif %}>

--- a/www/_includes/header.html
+++ b/www/_includes/header.html
@@ -26,7 +26,7 @@
                         <li {% if layout.contribute_tab %}class="active"{% endif %}>
                             <a href="{{ site.baseurl }}/contribute">Contribute</a>
                         </li>
-                        <li {% if page.team_tab %}class="active"{% endif %}>
+                        <li {% if layout.team_tab %}class="active"{% endif %}>
                             <a href="{{ site.baseurl }}/contribute/team.html">Team</a>
                         </li>
                         <li>


### PR DESCRIPTION
Fixes after update:
- Fix access to layout variables

Changes in generated site:
- Post dates are converted to build-local TZ
- Irrelevant whitespace changes
- Irrelevant changes to `sitemap.xml` (ordering of entries)

While Jekyll 4 is out already, it necessitates switching from `redcarpet` to `kramdown`. Unfortunately, that causes so many changes in the generated markup that its correctness cannot be verified by simple diffing anymore.