### PR TITLE
Fix typerror in plugin search

### DIFF
--- a/www/static/plugins/plugin.jsx
+++ b/www/static/plugins/plugin.jsx
@@ -102,13 +102,13 @@ var Plugin = createClass({
         )
     },
     componentDidMount: function() {
-        this.setClipboardText();
+        this.copyText();
         if(this.props.plugin) {
             $(this.getDOMNode()).find(".plugins-copy-to-clipboard").tooltip();
         }
     },
     componentDidUpdate: function() {
-        this.setClipboardText();
+        this.copyText();
     }
 });
 


### PR DESCRIPTION
"setClipboardText" was renamed to "copyText" in #1032. This fixes two method calls for a new issue #1047.