### PR TITLE
doc(CONTRIBUTING): Remove text about JIRA and ICLA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ ruby_modules
 Gemfile.lock
 
 .*.swp
+.vscode/settings.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,10 +27,7 @@ contribute code.
 For instructions on this, start with the
 [contribution overview](http://cordova.apache.org/contribute/).
 
-The details are explained there, but the important items are:
- - Sign and submit an Apache ICLA (Contributor License Agreement).
- - Have a Jira issue open that corresponds to your contribution.
- - Run the tests so your patch doesn't break existing functionality.
+The details are explained there and make sure to run the tests so your patch doesn't break existing functionality.
 
 We look forward to your contributions!
 


### PR DESCRIPTION
...add .vscode for users to avoid checking that in

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Contributing docs


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This PR removes old information from the Contributing doc. AFAIK an ICLA is not required for trivial contributions, JIRA has been discontinued for Cordova. @purplecabbage Correct ?


### Testing
<!-- Please describe in detail how you tested your changes. -->
npm test


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
