### PR TITLE
Adding Android SDK Tools info

### DIFF
--- a/www/docs/en/dev/guide/platforms/android/index.md
+++ b/www/docs/en/dev/guide/platforms/android/index.md
@@ -95,7 +95,7 @@ and make sure the following are installed:
 1. Android SDK build-tools version 19.1.0 or higher
 1. Android Support Repository (found under the "SDK Tools" tab)
 
-#### Android SDK Tools: 
+#### Android SDK Tools:
 In Android Studio 3.6 or later, you need to manually add the old version of the Android SDK Tools. To do this:
 
 1. Open the Android Studio SDK Manager

--- a/www/docs/en/dev/guide/platforms/android/index.md
+++ b/www/docs/en/dev/guide/platforms/android/index.md
@@ -98,9 +98,9 @@ and make sure the following are installed:
 #### Android SDK Tools:
 In Android Studio 3.6 or later, you need to manually add the old version of the Android SDK Tools. To do this:
 
-1. Open the Android Studio SDK Manager
-2. In the Android SDK tab, uncheck `Hide Obsolete Packages`
-3. Check Android SDK Tools (Obsolete)
+1. Open the Android Studio **SDK Manager**
+2. In the Android **SDK Tools** tab, uncheck `Hide Obsolete Packages`
+3. Check `Android SDK Tools (Obsolete)`
 
 See Android's documentation on [Installing SDK Packages](https://developer.android.com/studio/intro/update)
 for more details.

--- a/www/docs/en/dev/guide/platforms/android/index.md
+++ b/www/docs/en/dev/guide/platforms/android/index.md
@@ -99,7 +99,7 @@ and make sure the following are installed:
 In Android Studio 3.6 or later, you need to manually add the old version of the Android SDK Tools. To do this:
 
 1. Open the Android Studio SDK Manager
-2. In the Android SDK tab, uncheck 'Hide Obsolete Packages'
+2. In the Android SDK tab, uncheck `Hide Obsolete Packages`
 3. Check Android SDK Tools (Obsolete)
 
 See Android's documentation on [Installing SDK Packages](https://developer.android.com/studio/intro/update)

--- a/www/docs/en/dev/guide/platforms/android/index.md
+++ b/www/docs/en/dev/guide/platforms/android/index.md
@@ -95,6 +95,13 @@ and make sure the following are installed:
 1. Android SDK build-tools version 19.1.0 or higher
 1. Android Support Repository (found under the "SDK Tools" tab)
 
+#### Android SDK Tools: 
+In Android Studio 3.6 or later, you need to manually add the old version of the Android SDK Tools. To do this:
+
+1. Open the Android Studio SDK Manager
+2. In the Android SDK tab, uncheck 'Hide Obsolete Packages'
+3. Check Android SDK Tools (Obsolete)
+
 See Android's documentation on [Installing SDK Packages](https://developer.android.com/studio/intro/update)
 for more details.
 


### PR DESCRIPTION
In newer versions of Android Studio, you need to explicitly install the Obsolete Android SDK's `tools` before you can set the path variable.

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
All

### Motivation and Context
When following the current docs, you are instructed to set a path variable for android sdk tools.
If you are doing a fresh install of the latest android studio, you will not have the android sdk tools directory. 

Closes #1065 

### Description
Added short instructions about how to show obsolete packages and install android sdk tools.



### Testing
- Performed a fresh install of Android Studio 3.6.1; the tools directory was not created
- Installed Android SDK Tools after revealing obsolete packages ; the directory was created

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [xx] I've updated the documentation if necessary
