### PR TITLE
Changed armv7l architecture name

### DIFF
--- a/www/docs/en/dev/guide/platforms/electron/index.md
+++ b/www/docs/en/dev/guide/platforms/electron/index.md
@@ -310,7 +310,7 @@ The `arch` property is an array list of architectures that each package is built
 
 - ia32
 - x64
-- armv71
+- armv7l
 - arm64
 
 The example above will generate an `x64` `dmg` package.


### PR DESCRIPTION
The armv7l architecture has a L at the end instead of a 1. see https://github.com/electron/electron/releases

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

none

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

It is the wrong name for this architecture. Developers, that are new to electron will have a hard time, figuring this out, if it is wrong.

### Description
<!-- Describe your changes in detail -->

Changed "1" to small "L"

### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [-] I've run the tests to see all new and existing tests pass
- [-] I added automated test coverage as appropriate for this change
- [-] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
