### PR TITLE
Changed the deprecated ANDROID_HOME usages to the newer ANDROID_SDK_ROOT

### DIFF
--- a/www/docs/en/dev/guide/platforms/android/index.md
+++ b/www/docs/en/dev/guide/platforms/android/index.md
@@ -107,7 +107,7 @@ should be updated:
 
 1. Set the `JAVA_HOME` environment variable to the location of your JDK
    installation
-2. Set the `ANDROID_HOME` environment variable to the location of your Android
+2. Set the `ANDROID_SDK_ROOT` environment variable to the location of your Android
    SDK installation
 3. It is also recommended that you add the Android SDK's `tools`, `tools/bin`,
    and `platform-tools` directories to your `PATH`
@@ -119,7 +119,7 @@ On a Mac or Linux, you can use a text editor to create or modify the
 `export` like so (substitute the path with your local installation):
 
 ```bash
-export ANDROID_HOME=/Development/android-sdk/
+export ANDROID_SDK_ROOT=/Development/android-sdk/
 ```
 
 To update your `PATH`, add a line resembling the following (substitute the paths


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Accompanies https://github.com/apache/cordova-android/pull/951


### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
