### PR TITLE
docs(android): Build Tools 28.0.3

### DIFF
--- a/www/docs/en/dev/guide/platforms/android/index.md
+++ b/www/docs/en/dev/guide/platforms/android/index.md
@@ -92,7 +92,7 @@ Open the Android SDK Manager (`Tools > SDK Manager` in Android Studio, or `sdkma
 and make sure the following are installed:
 
 1. Android Platform SDK for your targeted version of Android
-1. Android SDK build-tools version 19.1.0 or higher
+1. Android SDK build-tools version 28.0.3 or higher
 1. Android Support Repository (found under the "SDK Tools" tab)
 
 See Android's documentation on [Installing SDK Packages](https://developer.android.com/studio/intro/update)


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android docs


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Incoming android 9.0.0 release, android gradle plugin was updated to version 3.6.0, which requires build tools 28.0.3 or higher.

https://developer.android.com/studio/releases/gradle-plugin#3-6-0


### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->
Ran `npm test`


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
