### PR TITLE
[iOS] Add missing information regarding CocoaPods requirements to build iOS and how install ios-deploy tools correctly

### DIFF
--- a/www/docs/en/dev/guide/platforms/ios/index.md
+++ b/www/docs/en/dev/guide/platforms/ios/index.md
@@ -75,6 +75,16 @@ To install it, run the following from command-line terminal:
 $ npm install -g ios-deploy
 ```
 
+### CocoaPods
+
+The [CocoaPods](https://cocoapods.org/) tools is needed to build iOS apps.
+
+To install it, run the following from command-line terminal:
+
+```bash
+$ sudo gem install cocoapods
+```
+
 ## Project Configuration
 
 Installing Xcode will mostly set everything needed to get started with the native side of things.

--- a/www/docs/en/dev/guide/platforms/ios/index.md
+++ b/www/docs/en/dev/guide/platforms/ios/index.md
@@ -77,7 +77,7 @@ $ npm install -g ios-deploy
 
 ### CocoaPods
 
-The [CocoaPods](https://cocoapods.org/) tools is needed to build iOS apps.
+The [CocoaPods](https://cocoapods.org/#install) tools is needed to build iOS apps.
 
 To install it, run the following from command-line terminal:
 

--- a/www/docs/en/dev/guide/platforms/ios/index.md
+++ b/www/docs/en/dev/guide/platforms/ios/index.md
@@ -69,10 +69,10 @@ $ xcode-select --install
 The [ios-deploy](https://www.npmjs.org/package/ios-deploy) tools allow you
 to launch iOS apps on an iOS Device from the command-line.
 
-To install it, run the following from command-line terminal:
+Install ios-deploy via [Homebrew](https://brew.sh/) by running:
 
 ```bash
-$ npm install -g ios-deploy
+$ brew install ios-deploy
 ```
 
 ### CocoaPods


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->
- [CocoaPods] Add missing information requirements to build iOS.
- Update information to how install ios-deploy tools correctly via Homebrew.

### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
- Add the missing information about CocoaPods tool that needed to buil iOS apps.
- Update information to how install ios-deploy tools correctly via Homebrew.


### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
