### PR TITLE
Node12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-node_js: 8
+node_js: 12
 sudo: false
 
 install:

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "classnames": "^2.1.2",
     "envify": "^3.4.0",
     "fs-extra": "^0.11.1",
-    "gulp": "^3.9.0",
+    "gulp": "^4.0.2",
     "gulp-footer": "^1.0.5",
     "gulp-header": "1.2.2",
     "gulp-less": "^3.0.3",
@@ -39,7 +39,7 @@
     "preact": "^8.2.5",
     "preact-compat": "^3.17.0",
     "vinyl-buffer": "^1.0.0",
-    "vinyl-source-stream": "^1.1.0"
+    "vinyl-source-stream": "^2.0.0"
   },
   "devDependencies": {
     "babel-plugin-transform-react-jsx": "^6.24.1",


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Documentation

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Build tools stopped working on Node 12. This PR updates the build scripts to so that we can use modern Node (current LTS).

Closes #1034 

### Description
<!-- Describe your changes in detail -->

Gulp was the culprit that was breaking the build on Node12. `gulp` and `vinyl-source-stream` both had a major upgrade to support Node12. These dependencies were bumped and refactors were made as necessary.

For `gulp`, this involved removing the `gulp.task` usage. It is no longer the recommended way to define tasks, and it's behaviour has changed in a breaking way (no 3 argument task functions anymore). All task functions were refactored to `module.exports` functions e.g: `css` task -> `module.exports.css = function ...`

Additionally, all task functions must now either return a stream, or use a callback function.

### Testing
<!-- Please describe in detail how you tested your changes. -->

Ran `npm test` and varies of gulp tasks and the provided npm scripts.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
