### PR TITLE
doc(windows): refactor requirements

### DIFF
--- a/www/docs/en/dev/guide/platforms/windows/index.md
+++ b/www/docs/en/dev/guide/platforms/windows/index.md
@@ -440,10 +440,7 @@ To work around this problem, we implemented two environment variables that you c
 
 You can either set the environment variable on demand manually by executing `set KEY=VALUE` (e.g. `set MSBUILDDIR=C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin`) or [set it permanently via the "System Properties"](https://www.computerhope.com/issues/ch000549.htm).
 
-
-
-
 [1]: https://msdn.microsoft.com/en-us/library/hh446593(v=vs.85).aspx
 [2]: https://technet.microsoft.com/en-us/library/ee624045(v=ws.10).aspx
-[VisualStudio]: https://visualstudio.microsoft.com/downloads/
+[VisualStudio]: https://visualstudio.microsoft.com/vs/older-downloads/
 [Windows]: https://www.microsoft.com/windows

--- a/www/docs/en/dev/guide/platforms/windows/index.md
+++ b/www/docs/en/dev/guide/platforms/windows/index.md
@@ -31,12 +31,17 @@ Cordova Windows on Windows 8.1 and Windows Phone 8.1 rely on Internet Explorer 1
 
 To develop apps for Windows 10 you need:
 
-- Windows 10 (or Windows 8.1), 32- or 64-bit, along with [Visual Studio](http://www.visualstudio.com/downloads) 2015 or Visual Studio 2017. (Cordova Windows is not supported by Visual Studio 2019, see [apache/cordova-windows#327](https://github.com/apache/cordova-windows/issues/327).)
-  
+- [Windows](Windows) 10 or 8.1
+- [Visual Studio](VisualStudio) 2017 or 2015
+
+> &#10071; Visual Studio 2019 does not support Cordova-Windows. See [apache/cordova-windows#327](https://github.com/apache/cordova-windows/issues/327)
+
 To develop apps for Windows 8.1:
 
-- Windows 8.1, 32 or 64-bit, along with [Visual Studio](http://www.visualstudio.com/downloads) 2015 or Visual Studio 2013.
-- For the Windows Phone emulators, Windows 8.1 (x64) Professional edition or higher, and a processor that supports [Client Hyper-V and Second Level Address Translation (SLAT)](https://msdn.microsoft.com/en-us/library/windows/apps/ff626524(v=vs.105).aspx#hyperv)
+- [Windows](Windows) 8.1
+- [Visual Studio](VisualStudio) 2015 or 2013
+
+> &#10071; Windows Phone 8 Emulator requires Windows 8.1 (x64) Professional edition or higher, and a processor that supports [Client Hyper-V and Second Level Address Translation (SLAT)](https://msdn.microsoft.com/en-us/library/windows/apps/ff626524(v=vs.105).aspx#hyperv)
 
 Cordova apps targeting Windows can be developed on a Mac, either by running a
 virtual machine environment or by using Boot Camp to dual-boot a
@@ -440,3 +445,5 @@ You can either set the environment variable on demand manually by executing `set
 
 [1]: https://msdn.microsoft.com/en-us/library/hh446593(v=vs.85).aspx
 [2]: https://technet.microsoft.com/en-us/library/ee624045(v=ws.10).aspx
+[VisualStudio]: https://visualstudio.microsoft.com/downloads/
+[Windows]: https://www.microsoft.com/windows

--- a/www/docs/en/dev/guide/platforms/windows/index.md
+++ b/www/docs/en/dev/guide/platforms/windows/index.md
@@ -31,15 +31,15 @@ Cordova Windows on Windows 8.1 and Windows Phone 8.1 rely on Internet Explorer 1
 
 To develop apps for Windows 10 you need:
 
-- [Windows](Windows) 10 or 8.1
-- [Visual Studio](VisualStudio) 2017 or 2015
+- [Windows] 10 or 8.1
+- [Visual Studio] 2017 or 2015
 
 > &#10071; Visual Studio 2019 does not support Cordova-Windows. See [apache/cordova-windows#327](https://github.com/apache/cordova-windows/issues/327)
 
 To develop apps for Windows 8.1:
 
-- [Windows](Windows) 8.1
-- [Visual Studio](VisualStudio) 2015 or 2013
+- [Windows] 8.1
+- [Visual Studio] 2015 or 2013
 
 > &#10071; Windows Phone 8 Emulator requires Windows 8.1 (x64) Professional edition or higher, and a processor that supports [Client Hyper-V and Second Level Address Translation (SLAT)](https://msdn.microsoft.com/en-us/library/windows/apps/ff626524(v=vs.105).aspx#hyperv)
 
@@ -442,5 +442,5 @@ You can either set the environment variable on demand manually by executing `set
 
 [1]: https://msdn.microsoft.com/en-us/library/hh446593(v=vs.85).aspx
 [2]: https://technet.microsoft.com/en-us/library/ee624045(v=ws.10).aspx
-[VisualStudio]: https://visualstudio.microsoft.com/vs/older-downloads/
+[Visual Studio]: https://visualstudio.microsoft.com/vs/older-downloads/
 [Windows]: https://www.microsoft.com/windows


### PR DESCRIPTION
### Motivation and Context

- Improve requirement visibility
- Removed mentioning of 32bit & 64bit. When both are supported, its required to say cause any version they can choose.
- I only 64bit in the case it is a hard requirement. E.g. Windows Phone 8 Emulator

### Checklist

- [x] I've updated the documentation if necessary
