### PR TITLE
doc: Remove mentions of keystore password prompts

### DIFF
--- a/www/docs/en/dev/guide/platforms/android/index.md
+++ b/www/docs/en/dev/guide/platforms/android/index.md
@@ -391,9 +391,6 @@ build configuration file:
 }
 ```
 
-For release signing, passwords can be excluded and the build system will issue a
-prompt asking for the password.
-
 There is also support to mix and match command line arguments and parameters in
 `build.json`. Values from the command line arguments will get precedence.
 This can be useful for specifying passwords on the command line.
@@ -413,7 +410,7 @@ keyAlias=DebugSigningKey
 keyPassword=SECRET2
 ```
 
-`storePassword` and `keyPassword` are optional, and will be prompted for if omitted.
+`storePassword` and `keyPassword` are required for automated signing.
 
 ## Debugging
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Docs


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

See https://github.com/apache/cordova-android/issues/1021


### Description
<!-- Describe your changes in detail -->

Should be merged with https://github.com/apache/cordova-android/pull/1048

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
