### PR TITLE
(osx) deprecate OSX platform in documentation

### DIFF
--- a/www/docs/en/dev/guide/platforms/osx/index.md
+++ b/www/docs/en/dev/guide/platforms/osx/index.md
@@ -18,7 +18,7 @@ license: >
     under the License.
 
 title: OS X Platform Guide
-toc_title: OS X
+toc_title: OS X (deprecated)
 ---
 
 # OS X Platform Guide

--- a/www/docs/en/dev/guide/platforms/osx/index.md
+++ b/www/docs/en/dev/guide/platforms/osx/index.md
@@ -23,7 +23,7 @@ toc_title: OS X (deprecated)
 
 # OS X Platform Guide
 
-**NOTICE:** The OS X platform is now deprecated and may be removed from a new version of Cordova.
+**NOTICE:** The OS X platform is now deprecated and may be removed from a future version of Cordova.
 
 This guide shows how to set up your SDK development environment to
 deploy Cordova apps for OS X computers. See the

--- a/www/docs/en/dev/guide/platforms/osx/index.md
+++ b/www/docs/en/dev/guide/platforms/osx/index.md
@@ -23,6 +23,8 @@ toc_title: OS X
 
 # OS X Platform Guide
 
+**NOTICE:** The OS X platform is now deprecated and may be removed from a new version of Cordova.
+
 This guide shows how to set up your SDK development environment to
 deploy Cordova apps for OS X computers. See the
 following for more detailed platform-specific information:


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Status

- [ ] pending formal vote

### Platforms affected

"osx" (macOS)

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

see [this discussion in dev@cordova.apache.org](https://lists.apache.org/thread.html/r638f55c4ddeb4aa51bc9d568e72e0d03669b347f5b42051b6be624ad%40%3Cdev.cordova.apache.org%3E) and <https://github.com/apache/cordova-lib/pull/851>


### Description
<!-- Describe your changes in detail -->

- add a note that the OSX platform is now deprecated

### Testing
<!-- Please describe in detail how you tested your changes. -->

Visual inspection

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- ~~I added automated test coverage as appropriate for this change~~
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- ~~If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))~~
- [x] I've updated the documentation if necessary
