### PR TITLE
(windows) deprecate Windows platform in documentation

### DIFF
--- a/www/docs/en/dev/guide/platforms/windows/index.md
+++ b/www/docs/en/dev/guide/platforms/windows/index.md
@@ -18,10 +18,12 @@ license: >
     under the License.
 
 title: Windows Platform Guide
-toc_title: Windows
+toc_title: Windows (deprecated)
 ---
 
 # Windows Platform Guide
+
+**NOTICE:** The Windows platform is now deprecated and may be removed from a future version of Cordova.
 
 This guide shows how to set up your SDK development environment to build and deploy Cordova apps Windows 10 (Universal Windows Platform [= UWP], formerly known as Universal App Platform [= UAP]), Windows 8.1 and Windows Phone 8.1.  It shows how to use either shell tools to generate and build apps, or the cross-platform Cordova CLI. (See the [Overview](../../overview/index.html#development-paths) for a comparison of these development options.) This section also shows how to modify Cordova apps within Visual Studio. Regardless of [which approach](../../overview/index.html#development-paths) you take, you need to install the Visual Studio SDK, as described below.
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Status

- [ ] pending formal vote

### Platforms affected

Windows

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

see [this discussion in dev@cordova.apache.org](https://lists.apache.org/thread.html/r638f55c4ddeb4aa51bc9d568e72e0d03669b347f5b42051b6be624ad%40%3Cdev.cordova.apache.org%3E) and <https://github.com/apache/cordova-lib/pull/852>

### Description
<!-- Describe your changes in detail -->

- add a note that Windows platform is now deprecated
- show "(deprecated)" in TOC title of Windows platform documentation

### Testing
<!-- Please describe in detail how you tested your changes. -->

Visual inspection

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- ~~I added automated test coverage as appropriate for this change~~
- ~~Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)~~
- ~~If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))~~
- [x] I've updated the documentation if necessary
