### PR TITLE
chore: remove visual studio from tooling (deprecated)

### DIFF
--- a/www/_data/tools.yml
+++ b/www/_data/tools.yml
@@ -40,13 +40,6 @@
         professionally designed multiplatform apps without acquiring additional
         skillset.
 
--   name: Visual Studio
-    image: visual_studio_white.png
-    url: https://www.visualstudio.com/vs/features/cordova/
-    description: >
-        Popular IDE for building cross-platform apps for Android, iOS, and
-        Windows. Complete with advanced build and debugging support.
-
 -   name: App Builder
     image: appbuilder.png
     url: http://www.getappbuilder.com/


### PR DESCRIPTION
The Visual Studio link is broken and also support for Cordova in recent versions is not available.