### PR TITLE
chore: remove adobe phonegap from tooling (deprecated)

### DIFF
--- a/www/_data/tools.yml
+++ b/www/_data/tools.yml
@@ -5,16 +5,6 @@
 #         A description that can
 #         span multiple lines.
 
--   name: Adobe PhoneGap
-    image: phonegap.svg
-    url: http://phonegap.com/
-    description: >
-        PhoneGap is the original and most popular distribution of Apache
-        Cordova. Turn your HTML, CSS and JavaScript into an app on your
-        device in minutes using our simple <a href="http://docs.phonegap.com/getting-started/1-install-phonegap/desktop/">
-        desktop</a> and <a href="http://docs.phonegap.com/references/developer-app/">
-        developer</a> apps.
-
 -   name: Ionic Framework
     image: ionic.png
     url: http://ionicframework.com/


### PR DESCRIPTION
Adobe PhoneGap service has ended.