### PR TITLE
Fixes https://github.com/apache/cordova-docs/issues/1120 - the density is required for an android icon

### DIFF
--- a/www/docs/en/9.x/config_ref/images.md
+++ b/www/docs/en/9.x/config_ref/images.md
@@ -60,7 +60,7 @@ Attributes    | Description
 --------------|--------------------------------------------------------------------------------
 background    | *Required for Adaptive* <br/> Location of the image (png or vector) relative to your project directory, or color reference
 foreground    | *Required for Adaptive* <br/> Location of the image (png or vector) relative to your project directory, or color reference
-density       | *Optional* <br/> Specified icon density
+density       | *Required* <br/> Specified icon density
 
 ### Adaptive Icons
 

--- a/www/docs/en/dev/config_ref/images.md
+++ b/www/docs/en/dev/config_ref/images.md
@@ -60,7 +60,7 @@ Attributes    | Description
 --------------|--------------------------------------------------------------------------------
 background    | *Required for Adaptive* <br/> Location of the image (png or vector) relative to your project directory, or color reference
 foreground    | *Required for Adaptive* <br/> Location of the image (png or vector) relative to your project directory, or color reference
-density       | *Optional* <br/> Specified icon density
+density       | *Required* <br/> Specified icon density
 
 ### Adaptive Icons
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Cordova Docs

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

In the documentation the density for an Android icon was flagged Optional, but after investigation in issue https://github.com/apache/cordova-docs/issues/1120 it's clear that the density is required.
- Align android icon density documentation with code

Fixes https://github.com/apache/cordova-docs/issues/1120

### Description
<!-- Describe your changes in detail -->

Changed  the Optional text to Required in following versions.

- fixed in 9.x\config_ref
- fixed in dev\config_ref


### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
