### PR TITLE
(ios): Document WKUrlSchemeTask

### DIFF
--- a/www/docs/en/dev/guide/platforms/ios/plugin.md
+++ b/www/docs/en/dev/guide/platforms/ios/plugin.md
@@ -225,6 +225,12 @@ terminate and `handleOpenURL` events. See the
 [CDVPlugin.h][CDVPlugin.h] and [CDVPlugin.m][CDVPlugin.m]
 classes for guidance.
 
+### WKURLSchemeTask Hook
+
+The [WKURLSchemeTask](https://developer.apple.com/documentation/webkit/wkurlschemetask) is an interface Cordovas main WKWebView uses to load files from your apps bundle. 
+
+
+
 ## Threading
 
 Plugin methods ordinarily execute in the same thread as the main

--- a/www/docs/en/dev/guide/platforms/ios/plugin.md
+++ b/www/docs/en/dev/guide/platforms/ios/plugin.md
@@ -227,7 +227,7 @@ classes for guidance.
 
 ### WKURLSchemeTask Hook
 
-The [WKURLSchemeTask](https://developer.apple.com/documentation/webkit/wkurlschemetask) is an interface Cordovas main WKWebView uses to load files from your apps bundle. You can create your own custom schemes or custom loading code for the webview by implementing the `- (BOOL) overrideSchemeTask: (id <WKURLSchemeTask>)urlSchemeTask` method in a plugin.
+The [WKURLSchemeTask](https://developer.apple.com/documentation/webkit/wkurlschemetask) is an interface Cordova's main WKWebView uses to load files from your app's bundle. You can create your own custom schemes or custom loading code for the webview by implementing the `- (BOOL) overrideSchemeTask: (id <WKURLSchemeTask>)urlSchemeTask` method in a plugin.
 
 ## Threading
 

--- a/www/docs/en/dev/guide/platforms/ios/plugin.md
+++ b/www/docs/en/dev/guide/platforms/ios/plugin.md
@@ -227,9 +227,7 @@ classes for guidance.
 
 ### WKURLSchemeTask Hook
 
-The [WKURLSchemeTask](https://developer.apple.com/documentation/webkit/wkurlschemetask) is an interface Cordovas main WKWebView uses to load files from your apps bundle. 
-
-
+The [WKURLSchemeTask](https://developer.apple.com/documentation/webkit/wkurlschemetask) is an interface Cordovas main WKWebView uses to load files from your apps bundle. You can create your own custom schemes or custom loading code for the webview by implementing the `- (BOOL) overrideSchemeTask: (id <WKURLSchemeTask>)urlSchemeTask` method in a plugin.
 
 ## Threading
 


### PR DESCRIPTION
This mentions just the method we added in 6.2.0 to hook into the WKWebView loading for plugin developers. Plugin developers might find it and come up with intersting solutions.

Do we want to document this more? Do we want examples? Is it worth mentioning at all?

Closes #1149 