### PR TITLE
Add myself to the team page, also fix avatar sizing

### DIFF
--- a/www/_members/dpogue.md
+++ b/www/_members/dpogue.md
@@ -1,0 +1,9 @@
+---
+name: Darryl Pogue
+subtitle: "<strong>PMC Member</strong> since Sept. 2016 and Web App developer"
+imageurl: https://avatars.githubusercontent.com/u/241708?s=256&v=4
+twitter: https://twitter.com/dpogue
+homepage: https://dpogue.ca
+---
+
+Building apps with Cordova since 2012, Darryl started contributing patches and bugfixes before joining as a committer in 2016.  He's a self-described "Web Fanatic" who longs to see projects embrace the web platform.  During his free time, he juggles too many unfinished side projects, along with hiking, amateur radio activities, and keeping up with browser developments.

--- a/www/_members/jessemacfadyen.md
+++ b/www/_members/jessemacfadyen.md
@@ -1,7 +1,7 @@
 ---
 name: Jesse MacFadyen
 subtitle:  "<strong>PMC Member</strong> since forever."
-imageurl: https://avatars3.githubusercontent.com/u/46134?s=400&&v=4
+imageurl: https://avatars.githubusercontent.com/u/46134?s=256&v=4
 twitter: https://twitter.com/purplecabbage
 homepage: https://github.com/purplecabbage
 ---

--- a/www/_members/niklasmerz.md
+++ b/www/_members/niklasmerz.md
@@ -1,7 +1,7 @@
 ---
 name: Niklas Merz
 subtitle:  "<strong>PMC Member</strong> since Dec. 2019 and plugin author"
-imageurl: https://avatars1.githubusercontent.com/u/3585860?s=460&v=4
+imageurl: https://avatars.githubusercontent.com/u/3585860?s=256&v=4
 twitter: https://twitter.com/niklasmaerz
 homepage: https://blog.merzlabs.com
 ---

--- a/www/_members/normanbreau.md
+++ b/www/_members/normanbreau.md
@@ -1,7 +1,7 @@
 ---
 name: Norman Breau
 subtitle: "<strong>PMC Member</strong> since Aug. 2019 and App developer"
-imageurl: https://avatars1.githubusercontent.com/u/11200662?s=460&u=9634c6248d969ab6a5927f6c9f9d89cf92a82036&v=4
+imageurl: https://avatars.githubusercontent.com/u/11200662?s=256&v=4
 twitter: https://twitter.com/NormanBreau
 homepage: https://breautek.com
 ---

--- a/www/contribute/team.html
+++ b/www/contribute/team.html
@@ -25,8 +25,8 @@ title: Team
             {{ member.content }}
         </p>
     </div>
-    <div class="col-sm-3 col-sm-offset-1">
-        <img src="{{ member.imageurl }}"><img>
+    <div class="col-sm-3 col-sm-offset-1 team-member-profile">
+        <img height="256" width="256" src="{{ member.imageurl }}"><img>
         {% if member.twitter %}
             <a href="{{ member.twitter }}">Twitter</a>
         {% endif %}

--- a/www/static/css-src/_contribute.scss
+++ b/www/static/css-src/_contribute.scss
@@ -152,3 +152,10 @@
         @extend .table-bordered;
     }
 }
+
+.team-member-profile a + a:before {
+    content: '\2022';
+    color: initial;
+    display: inline-block;
+    padding: 0 0.5em 0 0.25em;
+}


### PR DESCRIPTION
* Added a profile for myself

Also:
* Set all the GitHub avatar URLs to be 256×256 and for added safety/performance added `height` & `width` attributes to the `img` tags
* Added tiny visual separator between the "Twitter" and "Homepage" links on member profiles