### PR TITLE
fix: broken links

### DIFF
--- a/www/_layouts/docs.html
+++ b/www/_layouts/docs.html
@@ -23,7 +23,7 @@ PATH_TO_ROOT: path from here to version root, replacing all parts except the las
 NOTE:
      the capture is a single line because extraneous whitespace would screw up the URI it produces
 {% endcomment %}
-{% capture PATH_TO_ROOT %}{% for item in my_entry_parts %}{% if forloop.rindex > 1 %}../{% endif %}{% endfor %}{% endcapture %}
+{% capture PATH_TO_ROOT %}{{ VERSION_ROOT }}{% endcapture %}
 
 <div class="docs">
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Documentation

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

At some point, something broke links in the side bar, when viewed from child pages.

fixes https://github.com/apache/cordova-docs/issues/1154

I assume jekyll major upgrade is to blame.

### Description
<!-- Describe your changes in detail -->

`PATH_TO_ROOT` assignment using the loop appears to have been a dumb way to form what root is. Much more simplier (and easier to understand) to just simply use `VERSION_ROOT` that is defined a few lines up.

`VERSION_ROOT` will be `/docs/<language>/<version>`

### Testing
<!-- Please describe in detail how you tested your changes. -->

Build the production site and tested the links manually.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
