### PR TITLE
chore: update the Cordova resource description content

### DIFF
--- a/www/infra/doap_Cordova.rdf
+++ b/www/infra/doap_Cordova.rdf
@@ -31,7 +31,7 @@
     <shortdesc>A tool to create cross-platform apps from standard web technologies (HTML, CSS, and JavaScript).</shortdesc>
     <description>Apache Cordova is a tool to create cross-platform apps from standard web technologies (HTML, CSS, and JavaScript). Its primary purpose is to provide a bridge for native device API access and to bundle for distribution.</description>
     <bug-database rdf:resource="https://github.com/apache/cordova" />
-    <mailing-list rdf:resource="http://cordova.apache.org/#mailing-list" />
+    <mailing-list rdf:resource="https://cordova.apache.org/contact/" />
     <download-page rdf:resource="http://cordova.apache.org/#download" />
     <programming-language>JavaScript</programming-language>
     <programming-language>Java</programming-language>

--- a/www/infra/doap_Cordova.rdf
+++ b/www/infra/doap_Cordova.rdf
@@ -39,8 +39,8 @@
     <programming-language>C++</programming-language>
     <programming-language>C#</programming-language>
     <programming-language>node.js</programming-language>
-    <category rdf:resource="http://projects.apache.org/category/mobile" />
-    <category rdf:resource="http://projects.apache.org/category/library" />
+    <category rdf:resource="https://projects.apache.org/projects.html?category#mobile" />
+    <category rdf:resource="https://projects.apache.org/projects.html?category#library" />
     <release>
        <Version>
            <name>Latest Stable</name>

--- a/www/infra/doap_Cordova.rdf
+++ b/www/infra/doap_Cordova.rdf
@@ -48,9 +48,6 @@
            <revision>10.0.0</revision>
        </Version>
    </release>
-    <!-- at some point we should list the W3C standards we support.
-         See http://projects.apache.org/docs/standards.html
-         and the projects listed in the "Standards" index as example users of standards. -->
     <repository>
       <SVNRepository>
         <location rdf:resource="https://cordova.apache.org/contribute/"/>

--- a/www/infra/doap_Cordova.rdf
+++ b/www/infra/doap_Cordova.rdf
@@ -28,8 +28,8 @@
     <homepage rdf:resource="http://cordova.apache.org" />
     <!-- see the comment at the top of pmc_list.xml that explains asfext:pmc rdf:resource -->
     <asfext:pmc rdf:resource="http://svn.apache.org/repos/asf/cordova/site/public/infra/doap_Cordova_PMC.rdf" />
-    <shortdesc>A platform for building native mobile applications using HTML, CSS and JavaScript.</shortdesc>
-    <description>Apache Cordova is a set of device APIs that allow a mobile app developer to access native device function such as the camera or accelerometer from JavaScript. Combined with an UI framework, this allows a smartphone app to be developed with just HTML, CSS, and JavaScript.</description>
+    <shortdesc>A tool to create cross-platform apps from standard web technologies (HTML, CSS, and JavaScript).</shortdesc>
+    <description>Apache Cordova is a tool to create cross-platform apps from standard web technologies (HTML, CSS, and JavaScript). Its primary purpose is to provide a bridge for native device API access and to bundle for distribution.</description>
     <bug-database rdf:resource="https://issues.apache.org/jira/browse/CB" />
     <mailing-list rdf:resource="http://cordova.apache.org/#mailing-list" />
     <download-page rdf:resource="http://cordova.apache.org/#download" />

--- a/www/infra/doap_Cordova.rdf
+++ b/www/infra/doap_Cordova.rdf
@@ -44,8 +44,8 @@
     <release>
        <Version>
            <name>Latest Stable</name>
-           <created>2016-08-12</created>
-           <revision>6.3.1</revision>
+           <created>2020-08-04</created>
+           <revision>10.0.0</revision>
        </Version>
    </release>
     <!-- at some point we should list the W3C standards we support.

--- a/www/infra/doap_Cordova.rdf
+++ b/www/infra/doap_Cordova.rdf
@@ -23,7 +23,7 @@
 -->
   <Project rdf:about="http://cordova.apache.org/">
     <created>2013-01-11</created>
-    <license rdf:resource="http://usefulinc.com/doap/licenses/asl20" />
+    <license rdf:resource="https://www.apache.org/licenses/LICENSE-2.0.txt" />
     <name>Apache Cordova</name>
     <homepage rdf:resource="http://cordova.apache.org" />
     <!-- see the comment at the top of pmc_list.xml that explains asfext:pmc rdf:resource -->

--- a/www/infra/doap_Cordova.rdf
+++ b/www/infra/doap_Cordova.rdf
@@ -53,8 +53,8 @@
          and the projects listed in the "Standards" index as example users of standards. -->
     <repository>
       <SVNRepository>
-        <location rdf:resource="http://cordova.apache.org/#contribute"/>
-        <browse rdf:resource="http://cordova.apache.org/#contribute"/>
+        <location rdf:resource="https://cordova.apache.org/contribute/"/>
+        <browse rdf:resource="https://cordova.apache.org/contribute/"/>
       </SVNRepository>
     </repository>
   </Project>

--- a/www/infra/doap_Cordova.rdf
+++ b/www/infra/doap_Cordova.rdf
@@ -32,7 +32,7 @@
     <description>Apache Cordova is a tool to create cross-platform apps from standard web technologies (HTML, CSS, and JavaScript). Its primary purpose is to provide a bridge for native device API access and to bundle for distribution.</description>
     <bug-database rdf:resource="https://github.com/apache/cordova" />
     <mailing-list rdf:resource="https://cordova.apache.org/contact/" />
-    <download-page rdf:resource="http://cordova.apache.org/#download" />
+    <download-page rdf:resource="https://cordova.apache.org/#getstarted" />
     <programming-language>JavaScript</programming-language>
     <programming-language>Java</programming-language>
     <programming-language>Objective-C</programming-language>

--- a/www/infra/doap_Cordova.rdf
+++ b/www/infra/doap_Cordova.rdf
@@ -2,8 +2,8 @@
 <?xml-stylesheet type="text/xsl"?>
 <rdf:RDF xml:lang="en"
          xmlns="http://usefulinc.com/ns/doap#"
-         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-         xmlns:asfext="http://projects.apache.org/ns/asfext#"
+         xmlns:rdf="https://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:asfext="https://projects.apache.org/ns/asfext#"
          xmlns:foaf="http://xmlns.com/foaf/0.1/">
 <!--
     Licensed to the Apache Software Foundation (ASF) under one or more
@@ -21,13 +21,13 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-  <Project rdf:about="http://cordova.apache.org/">
+  <Project rdf:about="https://cordova.apache.org/">
     <created>2013-01-11</created>
     <license rdf:resource="https://www.apache.org/licenses/LICENSE-2.0.txt" />
     <name>Apache Cordova</name>
-    <homepage rdf:resource="http://cordova.apache.org" />
+    <homepage rdf:resource="https://cordova.apache.org" />
     <!-- see the comment at the top of pmc_list.xml that explains asfext:pmc rdf:resource -->
-    <asfext:pmc rdf:resource="http://svn.apache.org/repos/asf/cordova/site/public/infra/doap_Cordova_PMC.rdf" />
+    <asfext:pmc rdf:resource="https://svn.apache.org/repos/asf/cordova/site/public/infra/doap_Cordova_PMC.rdf" />
     <shortdesc>A tool to create cross-platform apps from standard web technologies (HTML, CSS, and JavaScript).</shortdesc>
     <description>Apache Cordova is a tool to create cross-platform apps from standard web technologies (HTML, CSS, and JavaScript). Its primary purpose is to provide a bridge for native device API access and to bundle for distribution.</description>
     <bug-database rdf:resource="https://github.com/apache/cordova" />

--- a/www/infra/doap_Cordova.rdf
+++ b/www/infra/doap_Cordova.rdf
@@ -30,7 +30,7 @@
     <asfext:pmc rdf:resource="http://svn.apache.org/repos/asf/cordova/site/public/infra/doap_Cordova_PMC.rdf" />
     <shortdesc>A tool to create cross-platform apps from standard web technologies (HTML, CSS, and JavaScript).</shortdesc>
     <description>Apache Cordova is a tool to create cross-platform apps from standard web technologies (HTML, CSS, and JavaScript). Its primary purpose is to provide a bridge for native device API access and to bundle for distribution.</description>
-    <bug-database rdf:resource="https://issues.apache.org/jira/browse/CB" />
+    <bug-database rdf:resource="https://github.com/apache/cordova" />
     <mailing-list rdf:resource="http://cordova.apache.org/#mailing-list" />
     <download-page rdf:resource="http://cordova.apache.org/#download" />
     <programming-language>JavaScript</programming-language>

--- a/www/infra/doap_Cordova_PMC.rdf
+++ b/www/infra/doap_Cordova_PMC.rdf
@@ -17,12 +17,12 @@
 -->
 <rdf:RDF xml:lang="en"
          xmlns="http://usefulinc.com/ns/doap#"
-         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-         xmlns:asfext="http://projects.apache.org/ns/asfext#"
+         xmlns:rdf="https://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:asfext="https://projects.apache.org/ns/asfext#"
          xmlns:foaf="http://xmlns.com/foaf/0.1/">
   <asfext:pmc rdf:about="cordova">
     <asfext:name>Apache Cordova</asfext:name>
-    <foaf:homepage rdf:resource="http://cordova.apache.org/"/>
+    <foaf:homepage rdf:resource="https://cordova.apache.org/"/>
     <asfext:charter>Apache Cordova is a tool to create cross-platform apps from standard web technologies (HTML, CSS, and JavaScript). Its primary purpose is to provide a bridge for native device API access and to bundle for distribution.</asfext:charter>
     <asfext:chair><foaf:Person><foaf:name>Jesse MacFadyen</foaf:name></foaf:Person></asfext:chair>
   </asfext:pmc>

--- a/www/infra/doap_Cordova_PMC.rdf
+++ b/www/infra/doap_Cordova_PMC.rdf
@@ -23,9 +23,7 @@
   <asfext:pmc rdf:about="cordova">
     <asfext:name>Apache Cordova</asfext:name>
     <foaf:homepage rdf:resource="http://cordova.apache.org/"/>
-    <asfext:charter>
-Apache Cordova is a set of device APIs that allow a mobile app developer to access native device functions such as the camera or accelerometer from JavaScript. Combined with an UI framework, this allows a smartphone app to be developed with just HTML, CSS, and JavaScript.
-    </asfext:charter>
+    <asfext:charter>Apache Cordova is a tool to create cross-platform apps from standard web technologies (HTML, CSS, and JavaScript). Its primary purpose is to provide a bridge for native device API access and to bundle for distribution.</asfext:charter>
     <asfext:chair><foaf:Person><foaf:name>Shazron Abdullah</foaf:name></foaf:Person></asfext:chair>
   </asfext:pmc>
 </rdf:RDF>

--- a/www/infra/doap_Cordova_PMC.rdf
+++ b/www/infra/doap_Cordova_PMC.rdf
@@ -24,6 +24,6 @@
     <asfext:name>Apache Cordova</asfext:name>
     <foaf:homepage rdf:resource="http://cordova.apache.org/"/>
     <asfext:charter>Apache Cordova is a tool to create cross-platform apps from standard web technologies (HTML, CSS, and JavaScript). Its primary purpose is to provide a bridge for native device API access and to bundle for distribution.</asfext:charter>
-    <asfext:chair><foaf:Person><foaf:name>Shazron Abdullah</foaf:name></foaf:Person></asfext:chair>
+    <asfext:chair><foaf:Person><foaf:name>Jesse MacFadyen</foaf:name></foaf:Person></asfext:chair>
   </asfext:pmc>
 </rdf:RDF>


### PR DESCRIPTION
### Motivation, Context & Description

I feel that some of the content written on these files are outdated and incorrect. I also believe the information from these files are used on Apache's website.

The goal of the changes were to:

* Try and point all urls to HTTPS when available.
* Try to make the Apache Cordova's description a bit more accurate to present usage.
  
  **New Description:**
  
  > Apache Cordova is a tool to create cross-platform apps from standard web technologies (HTML, CSS, and JavaScript). Its primary purpose is to provide a bridge for native device API access and to bundle for distribution.

  The old description said `Apache Cordova is a set of device APIs` when it is more then that. It also used words such as "smartphone" and "mobile app developer" when in fact it also supported desktop platforms.

* Updated Issue Tracker Link -> Points to `apache/cordova`
* Updated Download Link -> Points to Install Steps now
* Updated the latest stable version
* Updated the listing of the current PMC VP

And some other small changes.
