### PR TITLE
Android - cordova-android/issues/1242 emulator is not in Android/sdk/tools directory but in Android/sdk/emulator directory

### DIFF
--- a/www/docs/en/10.x/guide/platforms/android/index.md
+++ b/www/docs/en/10.x/guide/platforms/android/index.md
@@ -116,8 +116,9 @@ should be updated:
    installation
 2. Set the `ANDROID_SDK_ROOT` environment variable to the location of your Android
    SDK installation
-3. It is also recommended that you add the Android SDK's `tools`, `tools/bin`,
+3. It is also recommended that you add the Android SDK's `tools`, `tools/bin`, `emulator`
    and `platform-tools` directories to your `PATH`
+4. For apksigner and zipalign, the Android SDK's `build-tools` must also be added to `PATH`
 
 #### OS X and Linux
 
@@ -133,7 +134,7 @@ To update your `PATH`, add a line resembling the following (substitute the paths
 with your local Android SDK installation's location):
 
 ```bash
-export PATH=${PATH}:/Development/android-sdk/platform-tools:/Development/android-sdk/tools
+export PATH=${PATH}:/Development/android-sdk/platform-tools:/Development/android-sdk/tools/bin:/Development/android-sdk/emulator
 ```
 
 Reload your terminal to see this change reflected or run the following command:
@@ -167,7 +168,8 @@ reopen any command prompt windows after making changes to see them reflected.
 
     ```
     C:\Users\[your user]\AppData\Local\Android\Sdk\platform-tools
-    C:\Users\[your user]\AppData\Local\Android\Sdk\tools
+    C:\Users\[your user]\AppData\Local\Android\Sdk\tools\bin
+    C:\Users\[your user]\AppData\Local\Android\Sdk\tools\emulator
     ```
 
 ## Project Configuration

--- a/www/docs/en/dev/guide/platforms/android/index.md
+++ b/www/docs/en/dev/guide/platforms/android/index.md
@@ -116,8 +116,9 @@ should be updated:
    installation
 2. Set the `ANDROID_SDK_ROOT` environment variable to the location of your Android
    SDK installation
-3. It is also recommended that you add the Android SDK's `tools`, `tools/bin`,
+3. It is also recommended that you add the Android SDK's `tools`, `tools/bin`, `emulator`
    and `platform-tools` directories to your `PATH`
+4. For apksigner and zipalign, the Android SDK's `build-tools` must also be added to `PATH`
 
 #### OS X and Linux
 
@@ -133,7 +134,7 @@ To update your `PATH`, add a line resembling the following (substitute the paths
 with your local Android SDK installation's location):
 
 ```bash
-export PATH=${PATH}:/Development/android-sdk/platform-tools:/Development/android-sdk/tools
+export PATH=${PATH}:/Development/android-sdk/platform-tools:/Development/android-sdk/tools/bin:/Development/android-sdk/emulator
 ```
 
 Reload your terminal to see this change reflected or run the following command:
@@ -167,7 +168,8 @@ reopen any command prompt windows after making changes to see them reflected.
 
     ```
     C:\Users\[your user]\AppData\Local\Android\Sdk\platform-tools
-    C:\Users\[your user]\AppData\Local\Android\Sdk\tools
+    C:\Users\[your user]\AppData\Local\Android\Sdk\tools\bin
+    C:\Users\[your user]\AppData\Local\Android\Sdk\tools\emulator
     ```
 
 ## Project Configuration


### PR DESCRIPTION
The emulator for Android is not in started from Android/sdk/tools directory but is started from Android/sdk/emulator directory.

Docs adjusted. See also: https://ionicframework.com/docs/developing/android#configuring-command-line-tools 

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Fixes apache/cordova-android#1242

### Description
<!-- Describe your changes in detail -->

https://github.com/apache/cordova-android/issues/1242

The command ``cordova emulate android`` keeps hanging.
We did some research in ticket https://github.com/apache/cordova-android/issues/1242, and we solved it by adjusting the path variables. 
The documentation is wrong (deprecated), so it needs to be corrected.

### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
