### PR TITLE
fix: Replaced hard-coded copyright year with a generated timestamp

### DIFF
--- a/www/_includes/footer_contents.html
+++ b/www/_includes/footer_contents.html
@@ -60,7 +60,7 @@
     </div>
 </div>
 <p class="copyright_text">
-    Copyright &copy; 2012, 2013, 2015 The Apache Software Foundation, Licensed under the <a target="_blank" href="http://www.apache.org/licenses/LICENSE-2.0">Apache License, Version 2.0</a>.<br/>
+    Copyright &copy; {{ 'now' | date: "%Y" }} The Apache Software Foundation, Licensed under the <a target="_blank" href="http://www.apache.org/licenses/LICENSE-2.0">Apache License, Version 2.0</a>.<br/>
     Apache and the Apache feather logos are <a target="_blank" href="http://www.apache.org/foundation/marks/list/">trademarks</a> of The Apache Software Foundation.
     <br/>
     "Raleway" font used under license. For details see the <a href="{{ site.baseurl }}/attributions/">attributions page</a>.


### PR DESCRIPTION

Replaced the hard-coded copyright year to use a generated timestamp during build.