### PR TITLE
doc(electron): fix mas-dev as macOS package

### DIFF
--- a/www/docs/en/10.x/guide/platforms/electron/index.md
+++ b/www/docs/en/10.x/guide/platforms/electron/index.md
@@ -275,7 +275,7 @@ The configuration example below will generate `tar.gz`, `dmg` and `zip` packages
 | default      |    -    | `dmg`<br />`zip` |             -              |
 | dmg          |    -    |     &#9989;      |             -              |
 | mas          |    -    |     &#9989;      |             -              |
-| mas-dev      | &#9989; |        -         |             -              |
+| mas-dev      |    -    |     &#9989;      |             -              |
 | pkg          |    -    |     &#9989;      |             -              |
 | 7z           | &#9989; |     &#9989;      |          &#9989;           |
 | zip          | &#9989; |     &#9989;      |          &#9989;           |

--- a/www/docs/en/9.x/guide/platforms/electron/index.md
+++ b/www/docs/en/9.x/guide/platforms/electron/index.md
@@ -275,7 +275,7 @@ The configuration example below will generate `tar.gz`, `dmg` and `zip` packages
 | default      |    -    | `dmg`<br />`zip` |             -              |
 | dmg          |    -    |     &#9989;      |             -              |
 | mas          |    -    |     &#9989;      |             -              |
-| mas-dev      | &#9989; |        -         |             -              |
+| mas-dev      |    -    |     &#9989;      |             -              |
 | pkg          |    -    |     &#9989;      |             -              |
 | 7z           | &#9989; |     &#9989;      |          &#9989;           |
 | zip          | &#9989; |     &#9989;      |          &#9989;           |

--- a/www/docs/en/dev/guide/platforms/electron/index.md
+++ b/www/docs/en/dev/guide/platforms/electron/index.md
@@ -275,7 +275,7 @@ The configuration example below will generate `tar.gz`, `dmg` and `zip` packages
 | default      |    -    | `dmg`<br />`zip` |             -              |
 | dmg          |    -    |     &#9989;      |             -              |
 | mas          |    -    |     &#9989;      |             -              |
-| mas-dev      | &#9989; |        -         |             -              |
+| mas-dev      |    -    |     &#9989;      |             -              |
 | pkg          |    -    |     &#9989;      |             -              |
 | 7z           | &#9989; |     &#9989;      |          &#9989;           |
 | zip          | &#9989; |     &#9989;      |          &#9989;           |


### PR DESCRIPTION
### Motivation and Context

`mas-dev` target type is a macOS target, not Linux

* [Linux Available Targets](https://www.electron.build/configuration/linux)
* [macOS Available Targets](https://www.electron.build/configuration/mac)

### Description

Updated the docs to correct this mistake.

### Checklist

- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] I've updated the documentation if necessary
