### PR TITLE
Avoid Automatic Code Block for HTML on Events Page

### DIFF
--- a/www/docs/en/dev/cordova/events/events.md
+++ b/www/docs/en/dev/cordova/events/events.md
@@ -84,9 +84,7 @@ window.addEventListener("cordovacallbackerror", function (event) {
 The following table lists the cordova events and the supported platforms:
 
 <!-- START HTML -->
-
 <table class="compat" width="100%">
-
 <thead>
     <tr>
         <th>Supported Platforms/<br/>Events</td>
@@ -95,7 +93,6 @@ The following table lists the cordova events and the supported platforms:
         <th>Windows</th>
     </tr>
 </thead>
-
 <tbody>
     <tr>
         <th><a href="#deviceready">deviceready</a></th>
@@ -103,77 +100,66 @@ The following table lists the cordova events and the supported platforms:
         <td data-col="ios"        class="y"></td>
         <td data-col="win"       class="y"></td>
     </tr>
-
     <tr>
         <th><a href="#pause">pause</a></th>
         <td data-col="android"    class="y"></td>
         <td data-col="ios"        class="y"></td>
         <td data-col="win"       class="y"></td>
     </tr>
-
     <tr>
         <th><a href="#resume">resume</a></th>
         <td data-col="android"    class="y"></td>
         <td data-col="ios"        class="y"></td>
         <td data-col="win"       class="y"></td>
     </tr>
-
     <tr>
         <th><a href="#backbutton">backbutton</a></th>
         <td data-col="android"    class="y"></td>
         <td data-col="ios"        class="n"></td>
         <td data-col="win"       class="y"></td>
     </tr>
-
     <tr>
         <th><a href="#menubutton">menubutton</a></th>
         <td data-col="android"    class="y"></td>
         <td data-col="ios"        class="n"></td>
         <td data-col="win"       class="n"></td>
     </tr>
-
     <tr>
         <th><a href="#searchbutton">searchbutton</a></th>
         <td data-col="android"    class="y"></td>
         <td data-col="ios"        class="n"></td>
         <td data-col="win"       class="n"></td>
     </tr>
-
     <tr>
         <th><a href="#startcallbutton">startcallbutton</a></th>
         <td data-col="android"    class="n"></td>
         <td data-col="ios"        class="n"></td>
         <td data-col="win"       class="n"></td>
     </tr>
-
     <tr>
         <th><a href="#endcallbutton">endcallbutton</a></th>
         <td data-col="android"    class="n"></td>
         <td data-col="ios"        class="n"></td>
         <td data-col="win"       class="n"></td>
     </tr>
-
     <tr>
         <th><a href="#volumedownbutton">volumedownbutton</a></th>
         <td data-col="android"    class="y"></td>
         <td data-col="ios"        class="n"></td>
         <td data-col="win"       class="n"></td>
     </tr>
-
     <tr>
         <th><a href="#volumeupbutton">volumeupbutton</a></th>
         <td data-col="android"    class="y"></td>
         <td data-col="ios"        class="n"></td>
         <td data-col="win"       class="n"></td>
     </tr>
-
     <tr>
         <th><a href="#activated">activated</a></th>
         <td data-col="android"    class="n"></td>
         <td data-col="ios"        class="n"></td>
         <td data-col="win"       class="y"></td>
     </tr>
-
     <tr>
         <th><a href="#cordovacallbackerror">cordovacallbackerror</a></th>
         <td data-col="android"    class="y"></td>
@@ -182,7 +168,6 @@ The following table lists the cordova events and the supported platforms:
     </tr>
 </tbody>
 </table>
-
 <!-- END HTML -->
 
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
 - Online Documentation


### Motivation and Context

It seems that the spacing between the HTML elements on this page caused an automatic code block when converted for render. That code block caused the page content to be mixed up including rendering a heap of the Markdown as straight text in a jumbled, single-paragraph mess.

### Description

This change simply removes some of the whitespace lines between the "td" elements so that the HTML Table summarising the events and their support is treated as a single HTML table and not the start of one with HTML example code after it.

### Testing
I checked these changes improved the view on GitHub via the "Preview" feature.

### Checklist

- [ ] ~I've run the tests to see all new and existing tests pass~ (N/A)
- [ ] ~I added automated test coverage as appropriate for this change~ (N/A)
- [ ] ~Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)~ (N/A)
- [ ] ~If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))~ (N/A)
- [x] I've updated the documentation if necessary
