### PR TITLE
doc: fix events page rendering bug

### DIFF
--- a/www/docs/en/10.x/cordova/events/events.md
+++ b/www/docs/en/10.x/cordova/events/events.md
@@ -85,88 +85,88 @@ The following table lists the cordova events and the supported platforms:
 
 <!-- START HTML -->
 <table class="compat" width="100%">
-<thead>
-    <tr>
-        <th>Supported Platforms/<br/>Events</th>
-        <th>android</th>
-        <th>ios</th>
-        <th>Windows</th>
-    </tr>
-</thead>
-<tbody>
-    <tr>
-        <th><a href="#deviceready">deviceready</a></th>
-        <td data-col="android"    class="y"></td>
-        <td data-col="ios"        class="y"></td>
-        <td data-col="win"       class="y"></td>
-    </tr>
-    <tr>
-        <th><a href="#pause">pause</a></th>
-        <td data-col="android"    class="y"></td>
-        <td data-col="ios"        class="y"></td>
-        <td data-col="win"       class="y"></td>
-    </tr>
-    <tr>
-        <th><a href="#resume">resume</a></th>
-        <td data-col="android"    class="y"></td>
-        <td data-col="ios"        class="y"></td>
-        <td data-col="win"       class="y"></td>
-    </tr>
-    <tr>
-        <th><a href="#backbutton">backbutton</a></th>
-        <td data-col="android"    class="y"></td>
-        <td data-col="ios"        class="n"></td>
-        <td data-col="win"       class="y"></td>
-    </tr>
-    <tr>
-        <th><a href="#menubutton">menubutton</a></th>
-        <td data-col="android"    class="y"></td>
-        <td data-col="ios"        class="n"></td>
-        <td data-col="win"       class="n"></td>
-    </tr>
-    <tr>
-        <th><a href="#searchbutton">searchbutton</a></th>
-        <td data-col="android"    class="y"></td>
-        <td data-col="ios"        class="n"></td>
-        <td data-col="win"       class="n"></td>
-    </tr>
-    <tr>
-        <th><a href="#startcallbutton">startcallbutton</a></th>
-        <td data-col="android"    class="n"></td>
-        <td data-col="ios"        class="n"></td>
-        <td data-col="win"       class="n"></td>
-    </tr>
-    <tr>
-        <th><a href="#endcallbutton">endcallbutton</a></th>
-        <td data-col="android"    class="n"></td>
-        <td data-col="ios"        class="n"></td>
-        <td data-col="win"       class="n"></td>
-    </tr>
-    <tr>
-        <th><a href="#volumedownbutton">volumedownbutton</a></th>
-        <td data-col="android"    class="y"></td>
-        <td data-col="ios"        class="n"></td>
-        <td data-col="win"       class="n"></td>
-    </tr>
-    <tr>
-        <th><a href="#volumeupbutton">volumeupbutton</a></th>
-        <td data-col="android"    class="y"></td>
-        <td data-col="ios"        class="n"></td>
-        <td data-col="win"       class="n"></td>
-    </tr>
-    <tr>
-        <th><a href="#activated">activated</a></th>
-        <td data-col="android"    class="n"></td>
-        <td data-col="ios"        class="n"></td>
-        <td data-col="win"       class="y"></td>
-    </tr>
-    <tr>
-        <th><a href="#cordovacallbackerror">cordovacallbackerror</a></th>
-        <td data-col="android"    class="y"></td>
-        <td data-col="ios"        class="y"></td>
-        <td data-col="win"       class="y"></td>
-    </tr>
-</tbody>
+    <thead>
+        <tr>
+            <th>Supported Platforms/<br/>Events</th>
+            <th>android</th>
+            <th>ios</th>
+            <th>Windows</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <th><a href="#deviceready">deviceready</a></th>
+            <td data-col="android"    class="y"></td>
+            <td data-col="ios"        class="y"></td>
+            <td data-col="win"       class="y"></td>
+        </tr>
+        <tr>
+            <th><a href="#pause">pause</a></th>
+            <td data-col="android"    class="y"></td>
+            <td data-col="ios"        class="y"></td>
+            <td data-col="win"       class="y"></td>
+        </tr>
+        <tr>
+            <th><a href="#resume">resume</a></th>
+            <td data-col="android"    class="y"></td>
+            <td data-col="ios"        class="y"></td>
+            <td data-col="win"       class="y"></td>
+        </tr>
+        <tr>
+            <th><a href="#backbutton">backbutton</a></th>
+            <td data-col="android"    class="y"></td>
+            <td data-col="ios"        class="n"></td>
+            <td data-col="win"       class="y"></td>
+        </tr>
+        <tr>
+            <th><a href="#menubutton">menubutton</a></th>
+            <td data-col="android"    class="y"></td>
+            <td data-col="ios"        class="n"></td>
+            <td data-col="win"       class="n"></td>
+        </tr>
+        <tr>
+            <th><a href="#searchbutton">searchbutton</a></th>
+            <td data-col="android"    class="y"></td>
+            <td data-col="ios"        class="n"></td>
+            <td data-col="win"       class="n"></td>
+        </tr>
+        <tr>
+            <th><a href="#startcallbutton">startcallbutton</a></th>
+            <td data-col="android"    class="n"></td>
+            <td data-col="ios"        class="n"></td>
+            <td data-col="win"       class="n"></td>
+        </tr>
+        <tr>
+            <th><a href="#endcallbutton">endcallbutton</a></th>
+            <td data-col="android"    class="n"></td>
+            <td data-col="ios"        class="n"></td>
+            <td data-col="win"       class="n"></td>
+        </tr>
+        <tr>
+            <th><a href="#volumedownbutton">volumedownbutton</a></th>
+            <td data-col="android"    class="y"></td>
+            <td data-col="ios"        class="n"></td>
+            <td data-col="win"       class="n"></td>
+        </tr>
+        <tr>
+            <th><a href="#volumeupbutton">volumeupbutton</a></th>
+            <td data-col="android"    class="y"></td>
+            <td data-col="ios"        class="n"></td>
+            <td data-col="win"       class="n"></td>
+        </tr>
+        <tr>
+            <th><a href="#activated">activated</a></th>
+            <td data-col="android"    class="n"></td>
+            <td data-col="ios"        class="n"></td>
+            <td data-col="win"       class="y"></td>
+        </tr>
+        <tr>
+            <th><a href="#cordovacallbackerror">cordovacallbackerror</a></th>
+            <td data-col="android"    class="y"></td>
+            <td data-col="ios"        class="y"></td>
+            <td data-col="win"       class="y"></td>
+        </tr>
+    </tbody>
 </table>
 <!-- END HTML -->
 

--- a/www/docs/en/dev/cordova/events/events.md
+++ b/www/docs/en/dev/cordova/events/events.md
@@ -85,88 +85,88 @@ The following table lists the cordova events and the supported platforms:
 
 <!-- START HTML -->
 <table class="compat" width="100%">
-<thead>
-    <tr>
-        <th>Supported Platforms/<br/>Events</th>
-        <th>android</th>
-        <th>ios</th>
-        <th>Windows</th>
-    </tr>
-</thead>
-<tbody>
-    <tr>
-        <th><a href="#deviceready">deviceready</a></th>
-        <td data-col="android"    class="y"></td>
-        <td data-col="ios"        class="y"></td>
-        <td data-col="win"       class="y"></td>
-    </tr>
-    <tr>
-        <th><a href="#pause">pause</a></th>
-        <td data-col="android"    class="y"></td>
-        <td data-col="ios"        class="y"></td>
-        <td data-col="win"       class="y"></td>
-    </tr>
-    <tr>
-        <th><a href="#resume">resume</a></th>
-        <td data-col="android"    class="y"></td>
-        <td data-col="ios"        class="y"></td>
-        <td data-col="win"       class="y"></td>
-    </tr>
-    <tr>
-        <th><a href="#backbutton">backbutton</a></th>
-        <td data-col="android"    class="y"></td>
-        <td data-col="ios"        class="n"></td>
-        <td data-col="win"       class="y"></td>
-    </tr>
-    <tr>
-        <th><a href="#menubutton">menubutton</a></th>
-        <td data-col="android"    class="y"></td>
-        <td data-col="ios"        class="n"></td>
-        <td data-col="win"       class="n"></td>
-    </tr>
-    <tr>
-        <th><a href="#searchbutton">searchbutton</a></th>
-        <td data-col="android"    class="y"></td>
-        <td data-col="ios"        class="n"></td>
-        <td data-col="win"       class="n"></td>
-    </tr>
-    <tr>
-        <th><a href="#startcallbutton">startcallbutton</a></th>
-        <td data-col="android"    class="n"></td>
-        <td data-col="ios"        class="n"></td>
-        <td data-col="win"       class="n"></td>
-    </tr>
-    <tr>
-        <th><a href="#endcallbutton">endcallbutton</a></th>
-        <td data-col="android"    class="n"></td>
-        <td data-col="ios"        class="n"></td>
-        <td data-col="win"       class="n"></td>
-    </tr>
-    <tr>
-        <th><a href="#volumedownbutton">volumedownbutton</a></th>
-        <td data-col="android"    class="y"></td>
-        <td data-col="ios"        class="n"></td>
-        <td data-col="win"       class="n"></td>
-    </tr>
-    <tr>
-        <th><a href="#volumeupbutton">volumeupbutton</a></th>
-        <td data-col="android"    class="y"></td>
-        <td data-col="ios"        class="n"></td>
-        <td data-col="win"       class="n"></td>
-    </tr>
-    <tr>
-        <th><a href="#activated">activated</a></th>
-        <td data-col="android"    class="n"></td>
-        <td data-col="ios"        class="n"></td>
-        <td data-col="win"       class="y"></td>
-    </tr>
-    <tr>
-        <th><a href="#cordovacallbackerror">cordovacallbackerror</a></th>
-        <td data-col="android"    class="y"></td>
-        <td data-col="ios"        class="y"></td>
-        <td data-col="win"       class="y"></td>
-    </tr>
-</tbody>
+    <thead>
+        <tr>
+            <th>Supported Platforms/<br/>Events</th>
+            <th>android</th>
+            <th>ios</th>
+            <th>Windows</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <th><a href="#deviceready">deviceready</a></th>
+            <td data-col="android"    class="y"></td>
+            <td data-col="ios"        class="y"></td>
+            <td data-col="win"       class="y"></td>
+        </tr>
+        <tr>
+            <th><a href="#pause">pause</a></th>
+            <td data-col="android"    class="y"></td>
+            <td data-col="ios"        class="y"></td>
+            <td data-col="win"       class="y"></td>
+        </tr>
+        <tr>
+            <th><a href="#resume">resume</a></th>
+            <td data-col="android"    class="y"></td>
+            <td data-col="ios"        class="y"></td>
+            <td data-col="win"       class="y"></td>
+        </tr>
+        <tr>
+            <th><a href="#backbutton">backbutton</a></th>
+            <td data-col="android"    class="y"></td>
+            <td data-col="ios"        class="n"></td>
+            <td data-col="win"       class="y"></td>
+        </tr>
+        <tr>
+            <th><a href="#menubutton">menubutton</a></th>
+            <td data-col="android"    class="y"></td>
+            <td data-col="ios"        class="n"></td>
+            <td data-col="win"       class="n"></td>
+        </tr>
+        <tr>
+            <th><a href="#searchbutton">searchbutton</a></th>
+            <td data-col="android"    class="y"></td>
+            <td data-col="ios"        class="n"></td>
+            <td data-col="win"       class="n"></td>
+        </tr>
+        <tr>
+            <th><a href="#startcallbutton">startcallbutton</a></th>
+            <td data-col="android"    class="n"></td>
+            <td data-col="ios"        class="n"></td>
+            <td data-col="win"       class="n"></td>
+        </tr>
+        <tr>
+            <th><a href="#endcallbutton">endcallbutton</a></th>
+            <td data-col="android"    class="n"></td>
+            <td data-col="ios"        class="n"></td>
+            <td data-col="win"       class="n"></td>
+        </tr>
+        <tr>
+            <th><a href="#volumedownbutton">volumedownbutton</a></th>
+            <td data-col="android"    class="y"></td>
+            <td data-col="ios"        class="n"></td>
+            <td data-col="win"       class="n"></td>
+        </tr>
+        <tr>
+            <th><a href="#volumeupbutton">volumeupbutton</a></th>
+            <td data-col="android"    class="y"></td>
+            <td data-col="ios"        class="n"></td>
+            <td data-col="win"       class="n"></td>
+        </tr>
+        <tr>
+            <th><a href="#activated">activated</a></th>
+            <td data-col="android"    class="n"></td>
+            <td data-col="ios"        class="n"></td>
+            <td data-col="win"       class="y"></td>
+        </tr>
+        <tr>
+            <th><a href="#cordovacallbackerror">cordovacallbackerror</a></th>
+            <td data-col="android"    class="y"></td>
+            <td data-col="ios"        class="y"></td>
+            <td data-col="win"       class="y"></td>
+        </tr>
+    </tbody>
 </table>
 <!-- END HTML -->
 


### PR DESCRIPTION
### Motivation and Context

This PR is the continuation of #1211.

The Events page fails to render properly because the HTML syntax is broken.

### Description

This PR:
* Fixes the broken HTML syntax 
* Applies HTML formatting to the HTML Table
* Applies the changes to the 10.x docs.

### Testing

Built the docs locally and confirm changes.
