### PR TITLE
Fix markdown headings by adding a space between # and the text

### DIFF
--- a/www/_posts/2015-06-03-windows-release.md
+++ b/www/_posts/2015-06-03-windows-release.md
@@ -10,19 +10,19 @@ tags: news releases
 
 We are happy to announce that Cordova Windows 4.0.0 has been released!
 
-##Key features
+## Key features
 * The default Windows target version is now 8.1. Windows 8.0 support is deprecated and a warning will be issued when building for Windows 8.0. The support for Windows 8.0 will be removed in 6 months. If you have `windows-target-version` preference in config.xml set to 8.0, you will see this warning and you should consider changing it to 8.1.
 * `windows8` platform keyword is deprecated. For all plugins, use `windows` as the platform keyword.  
 * Support for Windows 10 Insider Preview and building using Visual Studio 2015 RC. More details can be found below. This support will evolve as Windows 10 release comes along.
 * Support for specifying parameters for signing Windows apps - like signing certificate, publisher identity etc. More details can be found in [docs](http://cordova.apache.org/docs/en/dev/guide_platforms_win8_packaging.md.html#Windows%20Plugins)
 
-##What's new in Windows 10
+## What's new in Windows 10
 * Windows 10 Insider Preview introduces the [Universal Windows Platform (UWP)](https://msdn.microsoft.com/en-us/library/windows/apps/dn894631.aspx) which provides a guaranteed core API layer across devices. You can create a single app package that can be installed onto a wide range of devices. A single store makes it easy to publish apps across all device types - desktop, mobile, Xbox, iOT.
 * In Windows 8 and 8.1, the app was loaded in the ms-appx  context. In Windows 10 for Cordova, by default the app is loaded in ms-appx-web  and have access to most Windows Runtime APIs. This allows you to [host remote content](https://msdn.microsoft.com/en-us/library/windows/apps/dn705792.aspx) in your Windows Cordova app. More details on how to customize this behavior can be found [here](http://cordova.apache.org/docs/en/dev/guide_platforms_win8_win10-support.md.html#Cordova%20for%20Windows%2010).
 * Some JavaScript libraries could not run in Windows 8/8.1 due to the safeHTML restriction and we needed to use winstore-jscompat. In Windows 10 Cordova apps, the security can be applied using [Content Security Policies](http://content-security-policy.com/).
 
 <!--more-->
-##Install
+## Install
 You will need to update to cordova-cli 5.1.1 or higher to use this version of the Windows platform:
 
 To add it to an existing project:
@@ -50,7 +50,7 @@ Alternatively, to add it to a new project:
 * [CB-8307](https://issues.apache.org/jira/browse/CB-8307): Adding a 25-year expiration temporary certificate.
 * [CB-8760](https://issues.apache.org/jira/browse/CB-8760) platform list doesn't show version for windows platform.
 
-##Known Issues with 4.0.0 and Windows 10
+## Known Issues with 4.0.0 and Windows 10
 
 * Windows 10 Insider Preview does not have a command-line compatible emulator deployment scenario.  To deploy to an emulator, open your solution file in Visual Studio.
 * The Windows SDK included with Visual Studio 2015 RC does not include a tool to deploy to a Windows 10 Phone.  To deploy to a phone, open your solution file in Visual Studio.

--- a/www/docs/en/10.x/guide/cli/index.md
+++ b/www/docs/en/10.x/guide/cli/index.md
@@ -82,7 +82,7 @@ $ cordova create hello com.example.hello HelloWorld
 
 This creates the required directory structure for your cordova app. By default, the `cordova create` script generates a skeletal web-based application whose home page is the project's `www/index.html` file.
 
-###See Also
+### See Also
 - [Cordova create command reference documentation][cdv_create]
 - [Cordova project directory structure][cdv_dir]
 - [Cordova project templates][cdv_template]
@@ -118,10 +118,10 @@ _not_ edit any files in the `/platforms/` directory. The files
 in this directory are routinely overwritten when preparing
 applications for building, or when plugins are re-installed.
 
-###See Also
+### See Also
 - [Cordova platform command reference documentation][cdv_platform]
 
-##Install pre-requisites for building
+## Install pre-requisites for building
 To build and run apps, you need to install SDKs for each platform you wish to target. Alternatively, if you are using browser for development you can use `browser` platform which does not require any platform SDKs.
 
 To check if you satisfy requirements for building the platform:
@@ -162,10 +162,10 @@ You can optionally limit the scope of each build to specific platforms - 'ios' i
 $ cordova build ios
 ```
 
-###See Also
+### See Also
 - [Cordova build command reference documentation][cdv_build]
 
-##Test the App
+## Test the App
 
 SDKs for mobile platforms often come bundled with emulators that
 execute a device image, so that you can launch the app from the home
@@ -195,7 +195,7 @@ $ cordova run android
 Before running this command, you need to set up the device for
 testing, following procedures that vary for each platform.
 
-###See Also
+### See Also
 - [Setting up Android emulator](../../guide/platforms/android/index.html#setting-up-an-emulator)
 - [Cordova run command reference documentation][cdv_run]
 - [Cordova emulate command reference documentation][cdv_emulate]
@@ -238,7 +238,7 @@ cordova-plugin-camera 2.1.0 "Camera"
 cordova-plugin-whitelist 1.2.1 "Whitelist"
 ```
 
-###See Also
+### See Also
 - [Cordova plugin command reference documentation][cdv_plugin]
 - [Cordova plugin search page](/plugins/)
 - [Core Plugin APIs]

--- a/www/docs/en/2.0.0/guide/upgrading/android/index.md
+++ b/www/docs/en/2.0.0/guide/upgrading/android/index.md
@@ -112,7 +112,7 @@ getContext() or getActivity().  If you are not an experienced Android developer,
 7. Replace the res/xml/phonegap.xml with res/xml/cordova.xml so that it is the same as the one found in framework/res/xml/cordova.xml
 
 
-## Upgrade to 1.5.0 from 1.4.0##
+## Upgrade to 1.5.0 from 1.4.0 ##
 1. Remove phonegap-1.4.0.jar from the libs directory in your project
 2. Add cordova-1.5.0.jar to the libs directory in your project
 3. If you are using Eclipse, please refresh your eclipse project and do a clean

--- a/www/docs/en/2.1.0/guide/upgrading/android/index.md
+++ b/www/docs/en/2.1.0/guide/upgrading/android/index.md
@@ -122,7 +122,7 @@ getContext() or getActivity().  If you are not an experienced Android developer,
 7. Replace the res/xml/phonegap.xml with res/xml/cordova.xml so that it is the same as the one found in framework/res/xml/cordova.xml
 
 
-## Upgrade to 1.5.0 from 1.4.0##
+## Upgrade to 1.5.0 from 1.4.0 ##
 1. Remove phonegap-1.4.0.jar from the libs directory in your project
 2. Add cordova-1.5.0.jar to the libs directory in your project
 3. If you are using Eclipse, please refresh your eclipse project and do a clean

--- a/www/docs/en/2.2.0/guide/upgrading/android/index.md
+++ b/www/docs/en/2.2.0/guide/upgrading/android/index.md
@@ -132,7 +132,7 @@ getContext() or getActivity().  If you are not an experienced Android developer,
 7. Replace the res/xml/phonegap.xml with res/xml/cordova.xml so that it is the same as the one found in framework/res/xml/cordova.xml
 
 
-## Upgrade to 1.5.0 from 1.4.0##
+## Upgrade to 1.5.0 from 1.4.0 ##
 1. Remove phonegap-1.4.0.jar from the libs directory in your project
 2. Add cordova-1.5.0.jar to the libs directory in your project
 3. If you are using Eclipse, please refresh your eclipse project and do a clean

--- a/www/docs/en/2.3.0/guide/getting-started/ios/index.md
+++ b/www/docs/en/2.3.0/guide/getting-started/ios/index.md
@@ -283,7 +283,7 @@ Determine where on your system you will locate the Xcode project files for your 
         .....
 
 
-###Code Your Application
+### Code Your Application
 
   Replace the sample code in the www directory of a new project with the HTML, JavaScript and CSS code for your application.  The name of the initial file to load when the app is launched should be index.html (advanced users can change this if necessary).  As demonstrated in the HelloWorld sample application, subdirectories within the www directory are permitted.  Note that the www directory is readonly, you can not write information to this directory during app execution.  If you need to store information use the Cordova [File](../../../cordova/file/fileobj/fileobj.html) or [Storage](../../../cordova/storage/storage.html) APIs.
 

--- a/www/docs/en/2.3.0/guide/upgrading/android/index.md
+++ b/www/docs/en/2.3.0/guide/upgrading/android/index.md
@@ -141,7 +141,7 @@ getContext() or getActivity().  If you are not an experienced Android developer,
 7. Replace the res/xml/phonegap.xml with res/xml/cordova.xml so that it is the same as the one found in framework/res/xml/cordova.xml
 
 
-## Upgrade to 1.5.0 from 1.4.0##
+## Upgrade to 1.5.0 from 1.4.0 ##
 1. Remove phonegap-1.4.0.jar from the libs directory in your project
 2. Add cordova-1.5.0.jar to the libs directory in your project
 3. If you are using Eclipse, please refresh your eclipse project and do a clean

--- a/www/docs/en/2.4.0/guide/getting-started/ios/index.md
+++ b/www/docs/en/2.4.0/guide/getting-started/ios/index.md
@@ -283,7 +283,7 @@ Determine where on your system you will locate the Xcode project files for your 
         .....
 
 
-###Code Your Application
+### Code Your Application
 
   Replace the sample code in the www directory of a new project with the HTML, JavaScript and CSS code for your application.  The name of the initial file to load when the app is launched should be index.html (advanced users can change this if necessary).  As demonstrated in the HelloWorld sample application, subdirectories within the www directory are permitted.  Note that the www directory is readonly, you can not write information to this directory during app execution.  If you need to store information use the Cordova [File](../../../cordova/file/fileobj/fileobj.html) or [Storage](../../../cordova/storage/storage.html) APIs.
 

--- a/www/docs/en/2.4.0/guide/upgrading/android/index.md
+++ b/www/docs/en/2.4.0/guide/upgrading/android/index.md
@@ -150,7 +150,7 @@ getContext() or getActivity().  If you are not an experienced Android developer,
 7. Replace the res/xml/phonegap.xml with res/xml/cordova.xml so that it is the same as the one found in framework/res/xml/cordova.xml
 
 
-## Upgrade to 1.5.0 from 1.4.0##
+## Upgrade to 1.5.0 from 1.4.0 ##
 1. Remove phonegap-1.4.0.jar from the libs directory in your project
 2. Add cordova-1.5.0.jar to the libs directory in your project
 3. If you are using Eclipse, please refresh your eclipse project and do a clean

--- a/www/docs/en/2.5.0/guide/getting-started/ios/index.md
+++ b/www/docs/en/2.5.0/guide/getting-started/ios/index.md
@@ -283,7 +283,7 @@ Determine where on your system you will locate the Xcode project files for your 
         .....
 
 
-###Code Your Application
+### Code Your Application
 
   Replace the sample code in the www directory of a new project with the HTML, JavaScript and CSS code for your application.  The name of the initial file to load when the app is launched should be index.html (advanced users can change this if necessary).  As demonstrated in the HelloWorld sample application, subdirectories within the www directory are permitted.  Note that the www directory is readonly, you can not write information to this directory during app execution.  If you need to store information use the Cordova [File](../../../cordova/file/fileobj/fileobj.html) or [Storage](../../../cordova/storage/storage.html) APIs.
 

--- a/www/docs/en/2.5.0/guide/upgrading/android/index.md
+++ b/www/docs/en/2.5.0/guide/upgrading/android/index.md
@@ -160,7 +160,7 @@ getContext() or getActivity().  If you are not an experienced Android developer,
 7. Replace the res/xml/phonegap.xml with res/xml/cordova.xml so that it is the same as the one found in framework/res/xml/cordova.xml
 
 
-## Upgrade to 1.5.0 from 1.4.0##
+## Upgrade to 1.5.0 from 1.4.0 ##
 1. Remove phonegap-1.4.0.jar from the libs directory in your project
 2. Add cordova-1.5.0.jar to the libs directory in your project
 3. If you are using Eclipse, please refresh your eclipse project and do a clean

--- a/www/docs/en/2.6.0/guide/getting-started/ios/index.md
+++ b/www/docs/en/2.6.0/guide/getting-started/ios/index.md
@@ -283,7 +283,7 @@ Determine where on your system you will locate the Xcode project files for your 
         .....
 
 
-###Code Your Application
+### Code Your Application
 
   Replace the sample code in the www directory of a new project with the HTML, JavaScript and CSS code for your application.  The name of the initial file to load when the app is launched should be index.html (advanced users can change this if necessary).  As demonstrated in the HelloWorld sample application, subdirectories within the www directory are permitted.  Note that the www directory is readonly, you can not write information to this directory during app execution.  If you need to store information use the Cordova [File](../../../cordova/file/fileobj/fileobj.html) or [Storage](../../../cordova/storage/storage.html) APIs.
 

--- a/www/docs/en/2.6.0/guide/upgrading/android/index.md
+++ b/www/docs/en/2.6.0/guide/upgrading/android/index.md
@@ -170,7 +170,7 @@ getContext() or getActivity().  If you are not an experienced Android developer,
 7. Replace the res/xml/phonegap.xml with res/xml/cordova.xml so that it is the same as the one found in framework/res/xml/cordova.xml
 
 
-## Upgrade to 1.5.0 from 1.4.0##
+## Upgrade to 1.5.0 from 1.4.0 ##
 1. Remove phonegap-1.4.0.jar from the libs directory in your project
 2. Add cordova-1.5.0.jar to the libs directory in your project
 3. If you are using Eclipse, please refresh your eclipse project and do a clean

--- a/www/docs/en/2.7.0/guide/getting-started/ios/index.md
+++ b/www/docs/en/2.7.0/guide/getting-started/ios/index.md
@@ -283,7 +283,7 @@ Determine where on your system you will locate the Xcode project files for your 
         .....
 
 
-###Code Your Application
+### Code Your Application
 
   Replace the sample code in the www directory of a new project with the HTML, JavaScript and CSS code for your application.  The name of the initial file to load when the app is launched should be index.html (advanced users can change this if necessary).  As demonstrated in the HelloWorld sample application, subdirectories within the www directory are permitted.  Note that the www directory is readonly, you can not write information to this directory during app execution.  If you need to store information use the Cordova [File](../../../cordova/file/fileobj/fileobj.html) or [Storage](../../../cordova/storage/storage.html) APIs.
 

--- a/www/docs/en/2.7.0/guide/upgrading/android/index.md
+++ b/www/docs/en/2.7.0/guide/upgrading/android/index.md
@@ -174,7 +174,7 @@ getContext() or getActivity().  If you are not an experienced Android developer,
 7. Replace the res/xml/phonegap.xml with res/xml/cordova.xml so that it is the same as the one found in framework/res/xml/cordova.xml
 
 
-## Upgrade to 1.5.0 from 1.4.0##
+## Upgrade to 1.5.0 from 1.4.0 ##
 1. Remove phonegap-1.4.0.jar from the libs directory in your project
 2. Add cordova-1.5.0.jar to the libs directory in your project
 3. If you are using Eclipse, please refresh your eclipse project and do a clean

--- a/www/docs/en/2.8.0/guide/command-line/index.md
+++ b/www/docs/en/2.8.0/guide/command-line/index.md
@@ -271,13 +271,13 @@ by holding down the ALT key from the home screen and hitting "lglg"
 keys.
 
 
-##BlackBerry 10
+## BlackBerry 10
 
 Command-line tools are based on shell scripts. If you need help with a command, type the command with the `-h` or `-help` arguments, which are supported by all commands and which will provide descriptions for each of the available arguments.
 
 The following commands are available:
 
-##create
+## create
 
 The 'create' command creates a new project:
 
@@ -285,11 +285,11 @@ The 'create' command creates a new project:
 bin/create <path-to-project>
 ```
 
-##target
+## target
 
 The `target` command allows you to manage the BlackBerry device(s) or simulator that you will use to test your app. You can add or remove a target, or set a target as the default target.
 
-###Add a target
+### Add a target
 
 ```
 <path-to-project>/cordova/target  add  <name>  <ip-address>  <device | simulator>  [-p | --password <password>]  [--pin <device-pin>]
@@ -302,23 +302,23 @@ where
 -   `-p|--password <password>`  specifies the password for the device or simulator. This is required only if the device or simulator is password protected.
 -   `--pin <device-pin>`  specifies the PIN of the BlackBerry device, which identifies that device as a valid host for the debug token. This argument is required only if you are creating a debug token.
 
-###Remove a target
+### Remove a target
 
 ```
 <path-to-project>/cordova/target  remove  <name>
 ```
 
-###Set a target as the default
+### Set a target as the default
 
 ```
 <path-to-project>/cordova/target  default  <name>
 ```
 
-##build
+## build
 
 The `build` command builds the project as a .bar file. You can build your app in either release mode (which produces a signed .bar file) or in debug mode (which produces an unsigned .bar file).
 
-###Build your project in release mode
+### Build your project in release mode
 
 ```
 <path-to-project>/cordova/build  release  -k|--keystorepass <password>  [-b|--buildId <number>]  [-p|--params <params-JSON-file>]
@@ -329,7 +329,7 @@ where
 -   `-b|--buildId <number>`  specifies the build version number of your application. Typically, this number should be incremented from the previous signed version. This argument is optional.
 -   `-p|--params <params-JSON-file>`  specifies a JSON file containing additional parameters to pass to downstream tools. This argument is optional.
 
-###Build your project in debug mode
+### Build your project in debug mode
 
 ```
 <path-to-project>/cordova/build  debug  [<target>]  [-k|--keystorepass <password>]  [-p|--params <params-JSON-file>]  [-ll|--loglevel <error|warn|verbose>]
@@ -348,7 +348,7 @@ If you have previously defined a default target (and previously installed a debu
 <path-to-project>/cordova/build debug
 ```
 
-##run
+## run
 
 The `run` command deploys the app on the specified BlackBerry device or a simulator. Before deploying your app, you must first create a target for the device or simulator you want to deploy your app to. The deploy script will deploy the most recent build of your app.
 
@@ -359,30 +359,30 @@ The `run` command deploys the app on the specified BlackBerry device or a simula
 where
 -   `<target> `specifies the name of a previously added target. If `<target> `is a device, then that device must be connected to your computer by USB connection or be connected to the same Wi-Fi network as your computer.
 
-##plugin
+## plugin
 
 The `target` command allows you to add and remove plugins
 
-###Fetch a locally-hosted plugin
+### Fetch a locally-hosted plugin
 
 
 ```
 <path-to-project>/cordova/plugin fetch <path-to-plugin>
 ```
 
-###View a list of installed plugins
+### View a list of installed plugins
 
 ```
 <path-to-project>/cordova/plugin ls
 ```
 
-###Add a plugin
+### Add a plugin
 
 ```
 <path-to-project>/cordova/plugin add <name>
 ```
 
-###Remove a plugin
+### Remove a plugin
 
 ```
 <path-to-project>/cordova/plugin rm <name>

--- a/www/docs/en/2.8.0/guide/getting-started/blackberry10/index.md
+++ b/www/docs/en/2.8.0/guide/getting-started/blackberry10/index.md
@@ -61,7 +61,7 @@ Adding and managing targets
 
 A target refers to a BlackBerry device or simulator that you will use to test your app. Targets are added directly to your project; you can add multiple targets to your project, each with a unique name. Then, when you want to deploy your app to a particular target, you can simply refer to that target by name when you run your script.
 
-###Add a target
+### Add a target
 
 To add a target, on the command line, type the following command:
 
@@ -77,7 +77,7 @@ where
 -   `-p|--password <password>`  specifies the password for the device or simulator. This is required only if the device or simulator is password protected.
 -   `--pin <device-pin>`  specifies the PIN of the BlackBerry device, which identifies that device as a valid host for the debug token. This argument is required only if you are creating a debug token.
 
-###Remove a target
+### Remove a target
 
 To remove a target, on the command line, type the following command:
 
@@ -85,7 +85,7 @@ To remove a target, on the command line, type the following command:
 <path-to-project>/cordova/target  remove  <name>
 ```
 
-###Set a target as the default
+### Set a target as the default
 
 To specify a specific target as the default, on the command line, type the following command:
 
@@ -103,7 +103,7 @@ To build your app, run the build script. You can build the app in either release
 
     Debug mode also enables Web Inspector for the app, which allows you to remotely inspect the source code. A prompt displays the URL that you can use to connect to and inspect your app. For more information on using Web Inspector, see [Debugging using Web Inspector](http://developer.blackberry.com/html5/documentation/web_inspector_overview_1553586_11.html).
 
-###Build your app in release mode
+### Build your app in release mode
 
 To build your app in release mode, on the command line, type the following command:
 
@@ -117,7 +117,7 @@ where
 -   `-b|--buildId <number>`  specifies the build version number of your application. Typically, this number should be incremented from the previous signed version. This argument is optional.
 -   `-p|--params <params-JSON-file>`  specifies a JSON file containing additional parameters to pass to downstream tools. This argument is optional.
 
-###Build your app in debug mode
+### Build your app in debug mode
 
 To build your app in release mode, on the command line, type the following command:
 
@@ -163,7 +163,7 @@ To add additional functionality that is outside of the core features of Cordova,
 
 In order to use a plugin, you must first add it into your project. Once added into your project, the plugin will be bundled with your project during the build process, to ensure that your app has access to all the APIs it needs.
 
-###Add a plugin
+### Add a plugin
 
 To add a plugin, on the command line, type the following command:
 
@@ -171,7 +171,7 @@ To add a plugin, on the command line, type the following command:
 <path-to-project>/cordova/plugin add <path to plugin>
 ```
 
-###Remove a plugin
+### Remove a plugin
 
 To remove a plugin, on the command line, type the following command:
 
@@ -179,7 +179,7 @@ To remove a plugin, on the command line, type the following command:
 <path-to-project>/cordova/plugin rm <name>
 ```
 
-###View a list of installed plugins
+### View a list of installed plugins
 
 To view a list of installed plugins, on the command line, type the following command:
 

--- a/www/docs/en/2.8.0/guide/getting-started/ios/index.md
+++ b/www/docs/en/2.8.0/guide/getting-started/ios/index.md
@@ -283,7 +283,7 @@ Determine where on your system you will locate the Xcode project files for your 
         .....
 
 
-###Code Your Application
+### Code Your Application
 
   Replace the sample code in the www directory of a new project with the HTML, JavaScript and CSS code for your application.  The name of the initial file to load when the app is launched should be index.html (advanced users can change this if necessary).  As demonstrated in the HelloWorld sample application, subdirectories within the www directory are permitted.  Note that the www directory is readonly, you can not write information to this directory during app execution.  If you need to store information use the Cordova [File](../../../cordova/file/fileobj/fileobj.html) or [Storage](../../../cordova/storage/storage.html) APIs.
 

--- a/www/docs/en/2.8.0/guide/plugin-development/blackberry10/index.md
+++ b/www/docs/en/2.8.0/guide/plugin-development/blackberry10/index.md
@@ -116,7 +116,7 @@ The `onCreateObject ` function takes two parameters. The first parameter is the 
         return NULL;
     }
 
-## Creating the JavaScript part of your plugin##
+## Creating the JavaScript part of your plugin ##
 
 The JavaScript portion of your plugin must contain the following files:
 
@@ -174,7 +174,7 @@ You can place the artifacts of the plugin, which includes the plugin.xml file, t
 
 (The list shows the hierarchical relationship among the top level folders. The parenthesis shows the contents of a given folder. All folder names appear in bold text. [File](../../../cordova/file/fileobj/fileobj.html) names are preceded by the '>' sign.)
 
-## Contents of the plugin.xml file##
+## Contents of the plugin.xml file ##
 The plugin.xml file contains the namespace of the extension and other metadata. Define the namespace and specify other metadata for the Echo plugin as follows:
 
     <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"

--- a/www/docs/en/2.8.0/guide/plugin-development/blackberry10/index.md
+++ b/www/docs/en/2.8.0/guide/plugin-development/blackberry10/index.md
@@ -116,7 +116,7 @@ The `onCreateObject ` function takes two parameters. The first parameter is the 
         return NULL;
     }
 
-##Creating the JavaScript part of your plugin##
+## Creating the JavaScript part of your plugin##
 
 The JavaScript portion of your plugin must contain the following files:
 

--- a/www/docs/en/2.8.0/guide/upgrading/android/index.md
+++ b/www/docs/en/2.8.0/guide/upgrading/android/index.md
@@ -178,7 +178,7 @@ getContext() or getActivity().  If you are not an experienced Android developer,
 7. Replace the res/xml/phonegap.xml with res/xml/cordova.xml so that it is the same as the one found in framework/res/xml/cordova.xml
 
 
-## Upgrade to 1.5.0 from 1.4.0##
+## Upgrade to 1.5.0 from 1.4.0 ##
 1. Remove phonegap-1.4.0.jar from the libs directory in your project
 2. Add cordova-1.5.0.jar to the libs directory in your project
 3. If you are using Eclipse, please refresh your eclipse project and do a clean

--- a/www/docs/en/2.9.0/guide/getting-started/blackberry10/index.md
+++ b/www/docs/en/2.9.0/guide/getting-started/blackberry10/index.md
@@ -61,7 +61,7 @@ Adding and managing targets
 
 A target refers to a BlackBerry device or simulator that you will use to test your app. Targets are added directly to your project; you can add multiple targets to your project, each with a unique name. Then, when you want to deploy your app to a particular target, you can simply refer to that target by name when you run your script.
 
-###Add a target
+### Add a target
 
 To add a target, on the command line, type the following command:
 
@@ -77,7 +77,7 @@ where
 -   `-p|--password <password>`  specifies the password for the device or simulator. This is required only if the device or simulator is password protected.
 -   `--pin <device-pin>`  specifies the PIN of the BlackBerry device, which identifies that device as a valid host for the debug token. This argument is required only if you are creating a debug token.
 
-###Remove a target
+### Remove a target
 
 To remove a target, on the command line, type the following command:
 
@@ -85,7 +85,7 @@ To remove a target, on the command line, type the following command:
 <path-to-project>/cordova/target  remove  <name>
 ```
 
-###Set a target as the default
+### Set a target as the default
 
 To specify a specific target as the default, on the command line, type the following command:
 
@@ -103,7 +103,7 @@ To build your app, run the build script. You can build the app in either release
 
     Debug mode also enables Web Inspector for the app, which allows you to remotely inspect the source code. A prompt displays the URL that you can use to connect to and inspect your app. For more information on using Web Inspector, see [Debugging using Web Inspector](http://developer.blackberry.com/html5/documentation/web_inspector_overview_1553586_11.html).
 
-###Build your app in release mode
+### Build your app in release mode
 
 To build your app in release mode, on the command line, type the following command:
 
@@ -117,7 +117,7 @@ where
 -   `-b|--buildId <number>`  specifies the build version number of your application. Typically, this number should be incremented from the previous signed version. This argument is optional.
 -   `-p|--params <params-JSON-file>`  specifies a JSON file containing additional parameters to pass to downstream tools. This argument is optional.
 
-###Build your app in debug mode
+### Build your app in debug mode
 
 To build your app in release mode, on the command line, type the following command:
 
@@ -163,7 +163,7 @@ To add additional functionality that is outside of the core features of Cordova,
 
 In order to use a plugin, you must first add it into your project. Once added into your project, the plugin will be bundled with your project during the build process, to ensure that your app has access to all the APIs it needs.
 
-###Add a plugin
+### Add a plugin
 
 To add a plugin, on the command line, type the following command:
 
@@ -171,7 +171,7 @@ To add a plugin, on the command line, type the following command:
 <path-to-project>/cordova/plugin add <path to plugin>
 ```
 
-###Remove a plugin
+### Remove a plugin
 
 To remove a plugin, on the command line, type the following command:
 
@@ -179,7 +179,7 @@ To remove a plugin, on the command line, type the following command:
 <path-to-project>/cordova/plugin rm <name>
 ```
 
-###View a list of installed plugins
+### View a list of installed plugins
 
 To view a list of installed plugins, on the command line, type the following command:
 

--- a/www/docs/en/2.9.0/guide/getting-started/ios/index.md
+++ b/www/docs/en/2.9.0/guide/getting-started/ios/index.md
@@ -294,7 +294,7 @@ references the deprecated invokeString API:
         <body onload=”onLoad();”>
         .....
 
-###Code Your Application
+### Code Your Application
 
   Replace the sample code in the `www` directory of a new project with the HTML, JavaScript and CSS code for your application.  The name of the initial file to load when the app is launched should be `index.html` (advanced users can change this if necessary).  As demonstrated in the HelloWorld sample application, subdirectories within the `www` directory are permitted.  Note that the `www` directory is readonly, you can not write information to this directory during app execution.  If you need to store information use the Cordova [File](../../../cordova/file/fileobj/fileobj.html) or [Storage](../../../cordova/storage/storage.html) APIs.
 

--- a/www/docs/en/2.9.0/guide/plugin-development/blackberry10/index.md
+++ b/www/docs/en/2.9.0/guide/plugin-development/blackberry10/index.md
@@ -116,7 +116,7 @@ The `onCreateObject ` function takes two parameters. The first parameter is the 
         return NULL;
     }
 
-## Creating the JavaScript part of your plugin##
+## Creating the JavaScript part of your plugin ##
 
 The JavaScript portion of your plugin must contain the following files:
 
@@ -174,7 +174,7 @@ You can place the artifacts of the plugin, which includes the plugin.xml file, t
 
 (The list shows the hierarchical relationship among the top level folders. The parenthesis shows the contents of a given folder. All folder names appear in bold text. [File](../../../cordova/file/fileobj/fileobj.html) names are preceded by the '>' sign.)
 
-## Contents of the plugin.xml file##
+## Contents of the plugin.xml file ##
 The plugin.xml file contains the namespace of the extension and other metadata. Define the namespace and specify other metadata for the Echo plugin as follows:
 
     <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"

--- a/www/docs/en/2.9.0/guide/plugin-development/blackberry10/index.md
+++ b/www/docs/en/2.9.0/guide/plugin-development/blackberry10/index.md
@@ -116,7 +116,7 @@ The `onCreateObject ` function takes two parameters. The first parameter is the 
         return NULL;
     }
 
-##Creating the JavaScript part of your plugin##
+## Creating the JavaScript part of your plugin##
 
 The JavaScript portion of your plugin must contain the following files:
 

--- a/www/docs/en/2.9.0/guide/upgrading/android/index.md
+++ b/www/docs/en/2.9.0/guide/upgrading/android/index.md
@@ -191,7 +191,7 @@ getContext() or getActivity().  If you are not an experienced Android developer,
 6. Update the res/xml/plugins.xml so that it is the same as the one found in framework/res/xml/plugins.xml
 7. Replace the res/xml/phonegap.xml with res/xml/cordova.xml so that it is the same as the one found in framework/res/xml/cordova.xml
 
-## Upgrade to 1.5.0 from 1.4.0##
+## Upgrade to 1.5.0 from 1.4.0 ##
 1. Remove phonegap-1.4.0.jar from the libs directory in your project
 2. Add cordova-1.5.0.jar to the libs directory in your project
 3. If you are using Eclipse, please refresh your eclipse project and do a clean

--- a/www/docs/en/3.0.0/guide/platforms/android/upgrading.md
+++ b/www/docs/en/3.0.0/guide/platforms/android/upgrading.md
@@ -329,7 +329,7 @@ maintainer and add this task to their bug tracker.
 
 7. Replace `res/xml/phonegap.xml` with `res/xml/cordova.xml` to match `framework/res/xml/cordova.xml`.
 
-## Upgrade to 1.5.0 from 1.4.0##
+## Upgrade to 1.5.0 from 1.4.0 ##
 
 1. Remove `phonegap-1.4.0.jar` from the project's `libs` directory.
 

--- a/www/docs/en/3.0.0/guide/platforms/blackberry10/plugin.md
+++ b/www/docs/en/3.0.0/guide/platforms/blackberry10/plugin.md
@@ -117,7 +117,7 @@ The `onCreateObject ` function takes two parameters. The first parameter is the 
         return NULL;
     }
 
-## Creating the JavaScript part of your plugin##
+## Creating the JavaScript part of your plugin ##
 
 The JavaScript portion of your plugin must contain the following files:
 
@@ -182,7 +182,7 @@ folders. The parenthesis shows the contents of a given directory. All
 directory names appear in bold text. [File](../../../cordova/file/fileobj/fileobj.html) names are preceded by the `>`
 sign.)
 
-## Contents of the `plugin.xml` file##
+## Contents of the `plugin.xml` file ##
 
 The `plugin.xml` file contains the namespace of the extension and other
 metadata. Define the namespace and specify other metadata for the Echo

--- a/www/docs/en/3.0.0/guide/platforms/blackberry10/plugin.md
+++ b/www/docs/en/3.0.0/guide/platforms/blackberry10/plugin.md
@@ -117,7 +117,7 @@ The `onCreateObject ` function takes two parameters. The first parameter is the 
         return NULL;
     }
 
-##Creating the JavaScript part of your plugin##
+## Creating the JavaScript part of your plugin##
 
 The JavaScript portion of your plugin must contain the following files:
 

--- a/www/docs/en/3.1.0/guide/platforms/android/upgrading.md
+++ b/www/docs/en/3.1.0/guide/platforms/android/upgrading.md
@@ -340,7 +340,7 @@ maintainer and add this task to their bug tracker.
 
 7. Replace `res/xml/phonegap.xml` with `res/xml/cordova.xml` to match `framework/res/xml/cordova.xml`.
 
-## Upgrade to 1.5.0 from 1.4.0##
+## Upgrade to 1.5.0 from 1.4.0 ##
 
 1. Remove `phonegap-1.4.0.jar` from the project's `libs` directory.
 

--- a/www/docs/en/3.1.0/guide/platforms/blackberry10/plugin.md
+++ b/www/docs/en/3.1.0/guide/platforms/blackberry10/plugin.md
@@ -117,7 +117,7 @@ The `onCreateObject ` function takes two parameters. The first parameter is the 
         return NULL;
     }
 
-## Creating the JavaScript part of your plugin##
+## Creating the JavaScript part of your plugin ##
 
 The JavaScript portion of your plugin must contain the following files:
 
@@ -182,7 +182,7 @@ directories. The parenthesis shows the contents of a given directory. All
 directory names appear in bold text. [File](../../../cordova/file/fileobj/fileobj.html) names are preceded by the `>`
 sign.)
 
-## Contents of the `plugin.xml` file##
+## Contents of the `plugin.xml` file ##
 
 The `plugin.xml` file contains the namespace of the extension and other
 metadata. Define the namespace and specify other metadata for the Echo

--- a/www/docs/en/3.1.0/guide/platforms/blackberry10/plugin.md
+++ b/www/docs/en/3.1.0/guide/platforms/blackberry10/plugin.md
@@ -117,7 +117,7 @@ The `onCreateObject ` function takes two parameters. The first parameter is the 
         return NULL;
     }
 
-##Creating the JavaScript part of your plugin##
+## Creating the JavaScript part of your plugin##
 
 The JavaScript portion of your plugin must contain the following files:
 

--- a/www/docs/en/3.4.0/guide/platforms/firefoxos/index.md
+++ b/www/docs/en/3.4.0/guide/platforms/firefoxos/index.md
@@ -46,7 +46,7 @@ Add Firefox OS as a supported platform to the app with the following:
 
 This creates a Firefox OS app in platforms/firefoxos/www directory, which currently looks the same except that it has a Firefox manifest file (manifest.webapp) inside the www directory.
 
-##Developing your app
+## Developing your app
 
 At this point you are ready to go — change the code inside test-app/www to whatever you want your app to be. You can add [supported plugins]() to the app using "cordova plugin add", for example:
 
@@ -74,7 +74,7 @@ When your app code is written, deploy your changes to the Firefox OS app you've 
   	
 Note that a build step (i.e. cordova build) is not required when deploying to the Firefox OS platform, as Firefox OS apps are HTML-based, and therefore not compiled. 
 
-##Testing and Debugging
+## Testing and Debugging
 
 The app can be tested using the Firefox OS [App Manager](https://developer.mozilla.org/en-US/Firefox_OS/Using_the_App_Manager).
 
@@ -84,7 +84,7 @@ For here you can install the app on your test device/simulator (with the "Update
 
 Note: Before attempting to publish your app you should consider validating it using the [App validator](https://marketplace.firefox.com/developers/validator).
 
-##Publishing your app on the Firefox Marketplace
+## Publishing your app on the Firefox Marketplace
 
 You can submit your app to the Firefox Marketplace, or publish it yourself. Visit the [Firefox Marketplace Zone](https://developer.mozilla.org/en-US/Marketplace) on MDN to find out more about how to do this; [App publishing options](https://developer.mozilla.org/en-US/Marketplace/Publishing/Publish_options) is the best place to start.
 

--- a/www/docs/en/3.5.0/guide/platforms/firefoxos/index.md
+++ b/www/docs/en/3.5.0/guide/platforms/firefoxos/index.md
@@ -46,7 +46,7 @@ Add Firefox OS as a supported platform to the app with the following:
 
 This creates a Firefox OS app in platforms/firefoxos/www directory, which currently looks the same except that it has a Firefox manifest file (manifest.webapp) inside the www directory.
 
-##Developing your app
+## Developing your app
 
 At this point you are ready to go — change the code inside test-app/www to whatever you want your app to be. You can add [supported plugins]() to the app using "cordova plugin add", for example:
 
@@ -74,7 +74,7 @@ When your app code is written, deploy your changes to the Firefox OS app you've 
   	
 Note that a build step (i.e. cordova build) is not required when deploying to the Firefox OS platform, as Firefox OS apps are HTML-based, and therefore not compiled. 
 
-##Testing and Debugging
+## Testing and Debugging
 
 The app can be tested using the Firefox OS [App Manager](https://developer.mozilla.org/en-US/Firefox_OS/Using_the_App_Manager).
 
@@ -84,7 +84,7 @@ For here you can install the app on your test device/simulator (with the "Update
 
 Note: Before attempting to publish your app you should consider validating it using the [App validator](https://marketplace.firefox.com/developers/validator).
 
-##Publishing your app on the Firefox Marketplace
+## Publishing your app on the Firefox Marketplace
 
 You can submit your app to the Firefox Marketplace, or publish it yourself. Visit the [Firefox Marketplace Zone](https://developer.mozilla.org/en-US/Marketplace) on MDN to find out more about how to do this; [App publishing options](https://developer.mozilla.org/en-US/Marketplace/Publishing/Publish_options) is the best place to start.
 

--- a/www/docs/en/3.6.0/guide/platforms/firefoxos/index.md
+++ b/www/docs/en/3.6.0/guide/platforms/firefoxos/index.md
@@ -46,7 +46,7 @@ Add Firefox OS as a supported platform to the app with the following:
 
 This creates a Firefox OS app in platforms/firefoxos/www directory, which currently looks the same except that it has a Firefox manifest file (manifest.webapp) inside the www directory.
 
-##Developing your app
+## Developing your app
 
 At this point you are ready to go — change the code inside test-app/www to whatever you want your app to be. You can add [supported plugins]() to the app using "cordova plugin add", for example:
 
@@ -74,7 +74,7 @@ When your app code is written, deploy your changes to the Firefox OS app you've 
   	
 Note that a build step (i.e. cordova build) is not required when deploying to the Firefox OS platform, as Firefox OS apps are HTML-based, and therefore not compiled. 
 
-##Testing and Debugging
+## Testing and Debugging
 
 The app can be tested using the Firefox OS [App Manager](https://developer.mozilla.org/en-US/Firefox_OS/Using_the_App_Manager).
 
@@ -84,7 +84,7 @@ For here you can install the app on your test device/simulator (with the "Update
 
 Note: Before attempting to publish your app you should consider validating it using the [App validator](https://marketplace.firefox.com/developers/validator).
 
-##Publishing your app on the Firefox Marketplace
+## Publishing your app on the Firefox Marketplace
 
 You can submit your app to the Firefox Marketplace, or publish it yourself. Visit the [Firefox Marketplace Zone](https://developer.mozilla.org/en-US/Marketplace) on MDN to find out more about how to do this; [App publishing options](https://developer.mozilla.org/en-US/Marketplace/Publishing/Publish_options) is the best place to start.
 

--- a/www/docs/en/4.0.0/guide/next/index.md
+++ b/www/docs/en/4.0.0/guide/next/index.md
@@ -136,12 +136,12 @@ Tip: It is possible on Android Nexus devices to easily flash different versions 
 
 Debugging Cordova requires some setup. Unlike a desktop application, you can't simply open dev tools on your mobile device and start debugging, luckily there are some great alternatives.
 
-##iOS Debugging
+## iOS Debugging
 
-###Xcode
+### Xcode
 With Xcode you can debug the iOS native side of your Cordova application. Make sure the Debug Area is showing (View -> Debug Area). Once your app is running on the device (or simulator), you can view log output in the debug area. This is where any errors or warnings will print. You can also set breakpoints within the source files. This will allow you to step through the code one line at a time and view the state of the variables at that time. The state of the variables is shown in the debug area when a breakpoint is hit. Once your app is up and running on the device, you can bring up Safari's web inspector (as described below) to debug the webview and js side of your application. For more details and help, see the Xcode guide: [Xcode Debugging Guide](https://developer.apple.com/library/mac/documentation/ToolsLanguages/Conceptual/Xcode_Overview/DebugYourApp/DebugYourApp.html#//apple_ref/doc/uid/TP40010215-CH18-SW1)
 
-###Safari Remote Debugging with Web Inspector
+### Safari Remote Debugging with Web Inspector
 With Safari's web inspector you can debug the webview and js code in your Cordova application. This works only on OSX and only with iOS 6 (and higher). It uses Safari to connect to your device (or the simulator) and will connect the browser's dev tools to the Cordova application. You get what you expect from dev tools - DOM inspection/manipulation, a JavaScript debugger, network inspection, the console, and more. Like Xcode, with Safari's web inspector you can set breakpoints in the JavaScript code and view the state of the variables at that time. You can view any errors, warnings or messages that are printed to the console. You can also run JavaScript commands directly from the console as your app is running. For more details on how to set it up and what you can do, see this excellent blog post: [http://moduscreate.com/enable-remote-web-inspector-in-ios-6/](http://moduscreate.com/enable-remote-web-inspector-in-ios-6/) and this guide: [Safari Web Inspector Guide](https://developer.apple.com/library/safari/documentation/AppleApplications/Conceptual/Safari_Developer_Guide/Introduction/Introduction.html)
 
 ## Chrome Remote Debugging

--- a/www/docs/en/4.0.0/guide/platforms/firefoxos/index.md
+++ b/www/docs/en/4.0.0/guide/platforms/firefoxos/index.md
@@ -46,7 +46,7 @@ Add Firefox OS as a supported platform to the app with the following:
 
 This creates a Firefox OS app in platforms/firefoxos/www directory, which currently looks the same except that it has a Firefox manifest file (manifest.webapp) inside the www directory.
 
-##Developing your app
+## Developing your app
 
 At this point you are ready to go — change the code inside test-app/www to whatever you want your app to be. You can add [supported plugins]() to the app using "cordova plugin add", for example:
 
@@ -74,7 +74,7 @@ When your app code is written, deploy your changes to the Firefox OS app you've 
   	
 Note that a build step (i.e. cordova build) is not required when deploying to the Firefox OS platform, as Firefox OS apps are HTML-based, and therefore not compiled. 
 
-##Testing and Debugging
+## Testing and Debugging
 
 The app can be tested using the Firefox OS [App Manager](https://developer.mozilla.org/en-US/Firefox_OS/Using_the_App_Manager).
 
@@ -84,7 +84,7 @@ For here you can install the app on your test device/simulator (with the "Update
 
 Note: Before attempting to publish your app you should consider validating it using the [App validator](https://marketplace.firefox.com/developers/validator).
 
-##Publishing your app on the Firefox Marketplace
+## Publishing your app on the Firefox Marketplace
 
 You can submit your app to the Firefox Marketplace, or publish it yourself. Visit the [Firefox Marketplace Zone](https://developer.mozilla.org/en-US/Marketplace) on MDN to find out more about how to do this; [App publishing options](https://developer.mozilla.org/en-US/Marketplace/Publishing/Publish_options) is the best place to start.
 

--- a/www/docs/en/5.0.0/guide/next/index.md
+++ b/www/docs/en/5.0.0/guide/next/index.md
@@ -136,12 +136,12 @@ Tip: It is possible on Android Nexus devices to easily flash different versions 
 
 Debugging Cordova requires some setup. Unlike a desktop application, you can't simply open dev tools on your mobile device and start debugging, luckily there are some great alternatives.
 
-##iOS Debugging
+## iOS Debugging
 
-###Xcode
+### Xcode
 With Xcode you can debug the iOS native side of your Cordova application. Make sure the Debug Area is showing (View -> Debug Area). Once your app is running on the device (or simulator), you can view log output in the debug area. This is where any errors or warnings will print. You can also set breakpoints within the source files. This will allow you to step through the code one line at a time and view the state of the variables at that time. The state of the variables is shown in the debug area when a breakpoint is hit. Once your app is up and running on the device, you can bring up Safari's web inspector (as described below) to debug the webview and js side of your application. For more details and help, see the Xcode guide: [Xcode Debugging Guide](https://developer.apple.com/library/mac/documentation/ToolsLanguages/Conceptual/Xcode_Overview/DebugYourApp/DebugYourApp.html#//apple_ref/doc/uid/TP40010215-CH18-SW1)
 
-###Safari Remote Debugging with Web Inspector
+### Safari Remote Debugging with Web Inspector
 With Safari's web inspector you can debug the webview and js code in your Cordova application. This works only on OSX and only with iOS 6 (and higher). It uses Safari to connect to your device (or the simulator) and will connect the browser's dev tools to the Cordova application. You get what you expect from dev tools - DOM inspection/manipulation, a JavaScript debugger, network inspection, the console, and more. Like Xcode, with Safari's web inspector you can set breakpoints in the JavaScript code and view the state of the variables at that time. You can view any errors, warnings or messages that are printed to the console. You can also run JavaScript commands directly from the console as your app is running. For more details on how to set it up and what you can do, see this excellent blog post: [http://moduscreate.com/enable-remote-web-inspector-in-ios-6/](http://moduscreate.com/enable-remote-web-inspector-in-ios-6/) and this guide: [Safari Web Inspector Guide](https://developer.apple.com/library/safari/documentation/AppleApplications/Conceptual/Safari_Developer_Guide/Introduction/Introduction.html)
 
 ## Chrome Remote Debugging

--- a/www/docs/en/5.0.0/guide/platforms/firefoxos/index.md
+++ b/www/docs/en/5.0.0/guide/platforms/firefoxos/index.md
@@ -46,7 +46,7 @@ Add Firefox OS as a supported platform to the app with the following:
 
 This creates a Firefox OS app in platforms/firefoxos/www directory, which currently looks the same except that it has a Firefox manifest file (manifest.webapp) inside the www directory.
 
-##Developing your app
+## Developing your app
 
 At this point you are ready to go — change the code inside test-app/www to whatever you want your app to be. You can add [supported plugins]() to the app using "cordova plugin add", for example:
 
@@ -63,7 +63,7 @@ To create a packaged app one can zip the platforms/firefoxos/www directory. You 
 
 The Firefox OS packaged app will be built in platforms/firefoxos/build/package.zip
 
-##Testing and Debugging
+## Testing and Debugging
 
 The app can be tested using the Firefox OS [Web IDE](https://developer.mozilla.org/en-US/docs/Tools/WebIDE).
 
@@ -73,7 +73,7 @@ For here you can install the app on your test device/simulator (with the "Play" 
 
 Note: Before attempting to publish your app you should consider validating it using the [App validator](https://marketplace.firefox.com/developers/validator).
 
-##Publishing your app on the Firefox Marketplace
+## Publishing your app on the Firefox Marketplace
 
 You can submit your app to the Firefox Marketplace, or publish it yourself. Visit the [Firefox Marketplace Zone](https://developer.mozilla.org/en-US/Marketplace) on MDN to find out more about how to do this; [App publishing options](https://developer.mozilla.org/en-US/Marketplace/Publishing/Publish_options) is the best place to start.
 

--- a/www/docs/en/5.1.1/guide/next/index.md
+++ b/www/docs/en/5.1.1/guide/next/index.md
@@ -136,12 +136,12 @@ Tip: It is possible on Android Nexus devices to easily flash different versions 
 
 Debugging Cordova requires some setup. Unlike a desktop application, you can't simply open dev tools on your mobile device and start debugging, luckily there are some great alternatives.
 
-##iOS Debugging
+## iOS Debugging
 
-###Xcode
+### Xcode
 With Xcode you can debug the iOS native side of your Cordova application. Make sure the Debug Area is showing (View -> Debug Area). Once your app is running on the device (or simulator), you can view log output in the debug area. This is where any errors or warnings will print. You can also set breakpoints within the source files. This will allow you to step through the code one line at a time and view the state of the variables at that time. The state of the variables is shown in the debug area when a breakpoint is hit. Once your app is up and running on the device, you can bring up Safari's web inspector (as described below) to debug the webview and js side of your application. For more details and help, see the Xcode guide: [Xcode Debugging Guide](https://developer.apple.com/library/mac/documentation/ToolsLanguages/Conceptual/Xcode_Overview/DebugYourApp/DebugYourApp.html#//apple_ref/doc/uid/TP40010215-CH18-SW1)
 
-###Safari Remote Debugging with Web Inspector
+### Safari Remote Debugging with Web Inspector
 With Safari's web inspector you can debug the webview and js code in your Cordova application. This works only on OSX and only with iOS 6 (and higher). It uses Safari to connect to your device (or the simulator) and will connect the browser's dev tools to the Cordova application. You get what you expect from dev tools - DOM inspection/manipulation, a JavaScript debugger, network inspection, the console, and more. Like Xcode, with Safari's web inspector you can set breakpoints in the JavaScript code and view the state of the variables at that time. You can view any errors, warnings or messages that are printed to the console. You can also run JavaScript commands directly from the console as your app is running. For more details on how to set it up and what you can do, see this excellent blog post: [http://moduscreate.com/enable-remote-web-inspector-in-ios-6/](http://moduscreate.com/enable-remote-web-inspector-in-ios-6/) and this guide: [Safari Web Inspector Guide](https://developer.apple.com/library/safari/documentation/AppleApplications/Conceptual/Safari_Developer_Guide/Introduction/Introduction.html)
 
 ## Chrome Remote Debugging

--- a/www/docs/en/5.1.1/guide/platforms/firefoxos/index.md
+++ b/www/docs/en/5.1.1/guide/platforms/firefoxos/index.md
@@ -46,7 +46,7 @@ Add Firefox OS as a supported platform to the app with the following:
 
 This creates a Firefox OS app in platforms/firefoxos/www directory, which currently looks the same except that it has a Firefox manifest file (manifest.webapp) inside the www directory.
 
-##Developing your app
+## Developing your app
 
 At this point you are ready to go — change the code inside test-app/www to whatever you want your app to be. You can add [supported plugins]() to the app using "cordova plugin add", for example:
 
@@ -63,7 +63,7 @@ To create a packaged app one can zip the platforms/firefoxos/www directory. You 
 
 The Firefox OS packaged app will be built in platforms/firefoxos/build/package.zip
 
-##Testing and Debugging
+## Testing and Debugging
 
 The app can be tested using the Firefox OS [Web IDE](https://developer.mozilla.org/en-US/docs/Tools/WebIDE).
 
@@ -73,7 +73,7 @@ For here you can install the app on your test device/simulator (with the "Play" 
 
 Note: Before attempting to publish your app you should consider validating it using the [App validator](https://marketplace.firefox.com/developers/validator).
 
-##Publishing your app on the Firefox Marketplace
+## Publishing your app on the Firefox Marketplace
 
 You can submit your app to the Firefox Marketplace, or publish it yourself. Visit the [Firefox Marketplace Zone](https://developer.mozilla.org/en-US/Marketplace) on MDN to find out more about how to do this; [App publishing options](https://developer.mozilla.org/en-US/Marketplace/Publishing/Publish_options) is the best place to start.
 

--- a/www/docs/en/6.x/config_ref/images.md
+++ b/www/docs/en/6.x/config_ref/images.md
@@ -53,7 +53,7 @@ which will be used for all platforms.
 For each platform, you can also define a pixel-perfect icon set to fit
 different screen resolutions.
 
-##Android
+## Android
 ```xml
     <platform name="android">
         <!--
@@ -72,24 +72,24 @@ different screen resolutions.
         <icon src="res/android/xxxhdpi.png" density="xxxhdpi" />
     </platform>
 ```
-###See Also
+### See Also
 - [Android icon guide](https://www.google.com/design/spec/style/icons.html)
 - [Android - Supporting multiple screens](http://developer.android.com/guide/practices/screens_support.html)
 
-##BlackBerry10
+## BlackBerry10
 ```xml
     <platform name="blackberry10">
         <icon src="res/bb10/icon-86.png" />
         <icon src="res/bb10/icon-150.png" />
     </platform>
 ```
-###See Also
+### See Also
 - [BlackBerry's documentation][blackberry_icon] for targeting multiple sizes and locales.
 
-##Browser
+## Browser
 Icons are not applicable to the Browser platform.
 
-##iOS
+## iOS
 ```xml
     <platform name="ios">
         <!-- iOS 8.0+ -->
@@ -122,10 +122,10 @@ Icons are not applicable to the Browser platform.
         <icon src="res/ios/icon-83.5@2x.png" width="167" height="167" />
     </platform>
 ```
-###See Also
+### See Also
 - [App Icons on iPad and iPhone](https://developer.apple.com/library/content/qa/qa1686/_index.html)
 
-##Windows
+## Windows
 
 For Windows the recommended approach to define application icons is to use the `target` attribute.
 
@@ -184,11 +184,11 @@ Although it is not recommended, it is also possible to define icons using the `w
     </platform>
 ```
 
-###See Also:
+### See Also:
 - [Windows 10 platform guidelines for icons](https://msdn.microsoft.com/en-us/library/windows/apps/mt412102.aspx).
 - [Windows 8.1 tiles and icons sizes](https://msdn.microsoft.com/en-us/library/windows/apps/xaml/hh781198.aspx)
 
-##Windows Phone 8 (WP8 Platform)
+## Windows Phone 8 (WP8 Platform)
 ```xml
     <platform name="wp8">
         <icon src="res/wp/ApplicationIcon.png" width="99" height="99" />

--- a/www/docs/en/6.x/guide/cli/index.md
+++ b/www/docs/en/6.x/guide/cli/index.md
@@ -82,7 +82,7 @@ $ cordova create hello com.example.hello HelloWorld
 
 This creates the required directory structure for your cordova app. By default, the `cordova create` script generates a skeletal web-based application whose home page is the project's `www/index.html` file.
 
-###See Also
+### See Also
 - [Cordova create command reference documentation][cdv_create]
 - [Cordova project directory structure][cdv_dir]
 - [Cordova project templates][cdv_template]
@@ -118,10 +118,10 @@ _not_ edit any files in the `/platforms/` directory. The files
 in this directory are routinely overwritten when preparing
 applications for building, or when plugins are re-installed.
 
-###See Also
+### See Also
 - [Cordova platform command reference documentation][cdv_platform]
 
-##Install pre-requisites for building
+## Install pre-requisites for building
 To build and run apps, you need to install SDKs for each platform you wish to target. Alternatively, if you are using browser for development you can use `browser` platform which does not require any platform SDKs.
 
 To check if you satisfy requirements for building the platform:
@@ -140,7 +140,7 @@ Cordova tooling for iOS requires Apple OS X
 Error: Some of requirements check failed
 ```
 
-###See Also
+### See Also
 - [Android platform requirements](../../guide/platforms/android/index.html#requirements-and-support)
 - [iOS platform requirements](../../guide/platforms/ios/index.html#requirements-and-support)
 - [Windows platform requirements](../../guide/platforms/win8/index.html#requirements-and-support)
@@ -162,10 +162,10 @@ You can optionally limit the scope of each build to specific platforms - 'ios' i
 $ cordova build ios
 ```
 
-###See Also
+### See Also
 - [Cordova build command reference documentation][cdv_build]
 
-##Test the App
+## Test the App
 
 SDKs for mobile platforms often come bundled with emulators that
 execute a device image, so that you can launch the app from the home
@@ -195,7 +195,7 @@ $ cordova run android
 Before running this command, you need to set up the device for
 testing, following procedures that vary for each platform.
 
-###See Also
+### See Also
 - [Setting up Android emulator](../../guide/platforms/android/index.html#setting-up-an-emulator)
 - [Cordova run command reference documentation][cdv_run]
 - [Cordova emulate command reference documentation][cdv_emulate]
@@ -238,7 +238,7 @@ cordova-plugin-camera 2.1.0 "Camera"
 cordova-plugin-whitelist 1.2.1 "Whitelist"
 ```
 
-###See Also
+### See Also
 - [Cordova plugin command reference documentation][cdv_plugin]
 - [Cordova plugin search page](/plugins/)
 - [Core Plugin APIs]

--- a/www/docs/en/6.x/reference/cordova-cli/index.md
+++ b/www/docs/en/6.x/reference/cordova-cli/index.md
@@ -433,7 +433,7 @@ cordova prepare [<platform> [..]]
      [--browserify | --fetch]
 ```
 
-###Options
+### Options
 
 | Option     | Description
 |------------|------------------
@@ -449,7 +449,7 @@ cordova prepare [<platform> [..]]
 `cordova compile` is a subset of the [cordova build command](#cordova-build-command).
 It only performs the compilation step without doing prepare. It's common to invoke `cordova build` instead of this command - however, this stage is useful to allow extending using [hooks][Hooks guide].
 
-###Syntax
+### Syntax
 
 ```bash
 cordova build [<platform> [...]]
@@ -509,7 +509,7 @@ cordova build [<platform> [...]]
 
 Prepares, builds, and deploys app on specified platform devices/emulators. If a device is connected it will be used, unless an eligible emulator is already running.
 
-###Syntax
+### Syntax
 
 ```bash
 cordova run [<platform> [...]]
@@ -536,7 +536,7 @@ cordova run [<platform> [...]]
 | --browserify | Compile plugin JS at build time using browserify instead of runtime
 | `<platformOpts>` | To provide platform specific options, you must include them after `--` separator. Review platform guide docs for more details.
 
-###Examples
+### Examples
 
 - Run a release build of current cordova project on `android` platform emulator named `Nexus_5_API_23_x86`. Use the spcified build configuration when running:
 

--- a/www/docs/en/6.x/reference/cordova-plugin-vibration/index.md
+++ b/www/docs/en/6.x/reference/cordova-plugin-vibration/index.md
@@ -75,7 +75,7 @@ navigator.notification.cancelVibration
 
 This function has three different functionalities based on parameters passed to it.
 
-###Standard vibrate
+### Standard vibrate
 
 Vibrates the device for a given amount of time.
 
@@ -88,7 +88,7 @@ or
 
 -__time__: Milliseconds to vibrate the device. _(Number)_
 
-####Example
+#### Example
 
     // Vibrate for 3 seconds
     navigator.vibrate(3000);
@@ -96,26 +96,26 @@ or
     // Vibrate for 3 seconds
     navigator.vibrate([3000]);
 
-####iOS Quirks
+#### iOS Quirks
 
 - __time__: Ignores the specified time and vibrates for a pre-set amount of time.
 
     navigator.vibrate(3000); // 3000 is ignored
 
-####Windows and Blackberry Quirks
+#### Windows and Blackberry Quirks
 
 - __time__: Max time is 5000ms (5s) and min time is 1ms
 
     navigator.vibrate(8000); // will be truncated to 5000
 
-###Vibrate with a pattern (Android and Windows only)
+### Vibrate with a pattern (Android and Windows only)
 Vibrates the device with a given pattern
 
     navigator.vibrate(pattern);
 
 - __pattern__: Sequence of durations (in milliseconds) for which to turn on or off the vibrator. _(Array of Numbers)_
 
-####Example
+#### Example
 
     // Vibrate for 1 second
     // Wait for 1 second
@@ -124,11 +124,11 @@ Vibrates the device with a given pattern
     // Vibrate for 5 seconds
     navigator.vibrate([1000, 1000, 3000, 1000, 5000]);
 
-####Windows Phone 8 Quirks
+#### Windows Phone 8 Quirks
 
 - vibrate(pattern) falls back on vibrate with default duration
 
-###Cancel vibration (not supported in iOS)
+### Cancel vibration (not supported in iOS)
 
 Immediately cancels any currently running vibration.
 

--- a/www/docs/en/7.x/config_ref/images.md
+++ b/www/docs/en/7.x/config_ref/images.md
@@ -53,7 +53,7 @@ which will be used for all platforms.
 For each platform, you can also define a pixel-perfect icon set to fit
 different screen resolutions.
 
-##Android
+## Android
 ```xml
     <platform name="android">
         <!--
@@ -72,24 +72,24 @@ different screen resolutions.
         <icon src="res/android/xxxhdpi.png" density="xxxhdpi" />
     </platform>
 ```
-###See Also
+### See Also
 - [Android icon guide](https://www.google.com/design/spec/style/icons.html)
 - [Android - Supporting multiple screens](http://developer.android.com/guide/practices/screens_support.html)
 
-##BlackBerry10
+## BlackBerry10
 ```xml
     <platform name="blackberry10">
         <icon src="res/bb10/icon-86.png" />
         <icon src="res/bb10/icon-150.png" />
     </platform>
 ```
-###See Also
+### See Also
 - [BlackBerry's documentation][blackberry_icon] for targeting multiple sizes and locales.
 
-##Browser
+## Browser
 Icons are not applicable to the Browser platform.
 
-##iOS
+## iOS
 ```xml
     <platform name="ios">
         <!-- iOS 8.0+ -->
@@ -124,10 +124,10 @@ Icons are not applicable to the Browser platform.
         <icon src="res/ios/icon-83.5@2x.png" width="167" height="167" />
     </platform>
 ```
-###See Also
+### See Also
 - [App Icons on iPad and iPhone](https://developer.apple.com/library/content/qa/qa1686/_index.html)
 
-##Windows
+## Windows
 
 For Windows the recommended approach to define application icons is to use the `target` attribute.
 
@@ -186,11 +186,11 @@ Although it is not recommended, it is also possible to define icons using the `w
     </platform>
 ```
 
-###See Also:
+### See Also:
 - [Windows 10 platform guidelines for icons](https://msdn.microsoft.com/en-us/library/windows/apps/mt412102.aspx).
 - [Windows 8.1 tiles and icons sizes](https://msdn.microsoft.com/en-us/library/windows/apps/xaml/hh781198.aspx)
 
-##Windows Phone 8 (WP8 Platform)
+## Windows Phone 8 (WP8 Platform)
 ```xml
     <platform name="wp8">
         <icon src="res/wp/ApplicationIcon.png" width="99" height="99" />

--- a/www/docs/en/7.x/guide/cli/index.md
+++ b/www/docs/en/7.x/guide/cli/index.md
@@ -82,7 +82,7 @@ $ cordova create hello com.example.hello HelloWorld
 
 This creates the required directory structure for your cordova app. By default, the `cordova create` script generates a skeletal web-based application whose home page is the project's `www/index.html` file.
 
-###See Also
+### See Also
 - [Cordova create command reference documentation][cdv_create]
 - [Cordova project directory structure][cdv_dir]
 - [Cordova project templates][cdv_template]
@@ -118,10 +118,10 @@ _not_ edit any files in the `/platforms/` directory. The files
 in this directory are routinely overwritten when preparing
 applications for building, or when plugins are re-installed.
 
-###See Also
+### See Also
 - [Cordova platform command reference documentation][cdv_platform]
 
-##Install pre-requisites for building
+## Install pre-requisites for building
 To build and run apps, you need to install SDKs for each platform you wish to target. Alternatively, if you are using browser for development you can use `browser` platform which does not require any platform SDKs.
 
 To check if you satisfy requirements for building the platform:
@@ -140,7 +140,7 @@ Cordova tooling for iOS requires Apple OS X
 Error: Some of requirements check failed
 ```
 
-###See Also
+### See Also
 - [Android platform requirements](../../guide/platforms/android/index.html#requirements-and-support)
 - [iOS platform requirements](../../guide/platforms/ios/index.html#requirements-and-support)
 - [Windows platform requirements](../../guide/platforms/win8/index.html#requirements-and-support)
@@ -162,10 +162,10 @@ You can optionally limit the scope of each build to specific platforms - 'ios' i
 $ cordova build ios
 ```
 
-###See Also
+### See Also
 - [Cordova build command reference documentation][cdv_build]
 
-##Test the App
+## Test the App
 
 SDKs for mobile platforms often come bundled with emulators that
 execute a device image, so that you can launch the app from the home
@@ -195,7 +195,7 @@ $ cordova run android
 Before running this command, you need to set up the device for
 testing, following procedures that vary for each platform.
 
-###See Also
+### See Also
 - [Setting up Android emulator](../../guide/platforms/android/index.html#setting-up-an-emulator)
 - [Cordova run command reference documentation][cdv_run]
 - [Cordova emulate command reference documentation][cdv_emulate]
@@ -238,7 +238,7 @@ cordova-plugin-camera 2.1.0 "Camera"
 cordova-plugin-whitelist 1.2.1 "Whitelist"
 ```
 
-###See Also
+### See Also
 - [Cordova plugin command reference documentation][cdv_plugin]
 - [Cordova plugin search page](/plugins/)
 - [Core Plugin APIs]

--- a/www/docs/en/8.x/config_ref/images.md
+++ b/www/docs/en/8.x/config_ref/images.md
@@ -53,7 +53,7 @@ which will be used for all platforms.
 For each platform, you can also define a pixel-perfect icon set to fit
 different screen resolutions.
 
-##Android
+## Android
 ```xml
     <platform name="android">
         <!--
@@ -72,14 +72,14 @@ different screen resolutions.
         <icon src="res/android/xxxhdpi.png" density="xxxhdpi" />
     </platform>
 ```
-###See Also
+### See Also
 - [Android icon guide](https://www.google.com/design/spec/style/icons.html)
 - [Android - Supporting multiple screens](http://developer.android.com/guide/practices/screens_support.html)
 
-##Browser
+## Browser
 Icons are not applicable to the Browser platform.
 
-##iOS
+## iOS
 ```xml
     <platform name="ios">
         <!-- iOS 8.0+ -->
@@ -114,10 +114,10 @@ Icons are not applicable to the Browser platform.
         <icon src="res/ios/icon-83.5@2x.png" width="167" height="167" />
     </platform>
 ```
-###See Also
+### See Also
 - [App Icons on iPad and iPhone](https://developer.apple.com/library/content/qa/qa1686/_index.html)
 
-##Windows
+## Windows
 
 For Windows the recommended approach to define application icons is to use the `target` attribute.
 
@@ -176,7 +176,7 @@ Although it is not recommended, it is also possible to define icons using the `w
     </platform>
 ```
 
-###See Also:
+### See Also:
 - [Windows 10 platform guidelines for icons](https://msdn.microsoft.com/en-us/library/windows/apps/mt412102.aspx).
 - [Windows 8.1 tiles and icons sizes](https://msdn.microsoft.com/en-us/library/windows/apps/xaml/hh781198.aspx)
 

--- a/www/docs/en/8.x/guide/cli/index.md
+++ b/www/docs/en/8.x/guide/cli/index.md
@@ -82,7 +82,7 @@ $ cordova create hello com.example.hello HelloWorld
 
 This creates the required directory structure for your cordova app. By default, the `cordova create` script generates a skeletal web-based application whose home page is the project's `www/index.html` file.
 
-###See Also
+### See Also
 - [Cordova create command reference documentation][cdv_create]
 - [Cordova project directory structure][cdv_dir]
 - [Cordova project templates][cdv_template]
@@ -118,10 +118,10 @@ _not_ edit any files in the `/platforms/` directory. The files
 in this directory are routinely overwritten when preparing
 applications for building, or when plugins are re-installed.
 
-###See Also
+### See Also
 - [Cordova platform command reference documentation][cdv_platform]
 
-##Install pre-requisites for building
+## Install pre-requisites for building
 To build and run apps, you need to install SDKs for each platform you wish to target. Alternatively, if you are using browser for development you can use `browser` platform which does not require any platform SDKs.
 
 To check if you satisfy requirements for building the platform:
@@ -162,10 +162,10 @@ You can optionally limit the scope of each build to specific platforms - 'ios' i
 $ cordova build ios
 ```
 
-###See Also
+### See Also
 - [Cordova build command reference documentation][cdv_build]
 
-##Test the App
+## Test the App
 
 SDKs for mobile platforms often come bundled with emulators that
 execute a device image, so that you can launch the app from the home
@@ -195,7 +195,7 @@ $ cordova run android
 Before running this command, you need to set up the device for
 testing, following procedures that vary for each platform.
 
-###See Also
+### See Also
 - [Setting up Android emulator](../../guide/platforms/android/index.html#setting-up-an-emulator)
 - [Cordova run command reference documentation][cdv_run]
 - [Cordova emulate command reference documentation][cdv_emulate]
@@ -238,7 +238,7 @@ cordova-plugin-camera 2.1.0 "Camera"
 cordova-plugin-whitelist 1.2.1 "Whitelist"
 ```
 
-###See Also
+### See Also
 - [Cordova plugin command reference documentation][cdv_plugin]
 - [Cordova plugin search page](/plugins/)
 - [Core Plugin APIs]

--- a/www/docs/en/9.x/guide/cli/index.md
+++ b/www/docs/en/9.x/guide/cli/index.md
@@ -82,7 +82,7 @@ $ cordova create hello com.example.hello HelloWorld
 
 This creates the required directory structure for your cordova app. By default, the `cordova create` script generates a skeletal web-based application whose home page is the project's `www/index.html` file.
 
-###See Also
+### See Also
 - [Cordova create command reference documentation][cdv_create]
 - [Cordova project directory structure][cdv_dir]
 - [Cordova project templates][cdv_template]
@@ -118,10 +118,10 @@ _not_ edit any files in the `/platforms/` directory. The files
 in this directory are routinely overwritten when preparing
 applications for building, or when plugins are re-installed.
 
-###See Also
+### See Also
 - [Cordova platform command reference documentation][cdv_platform]
 
-##Install pre-requisites for building
+## Install pre-requisites for building
 To build and run apps, you need to install SDKs for each platform you wish to target. Alternatively, if you are using browser for development you can use `browser` platform which does not require any platform SDKs.
 
 To check if you satisfy requirements for building the platform:
@@ -162,10 +162,10 @@ You can optionally limit the scope of each build to specific platforms - 'ios' i
 $ cordova build ios
 ```
 
-###See Also
+### See Also
 - [Cordova build command reference documentation][cdv_build]
 
-##Test the App
+## Test the App
 
 SDKs for mobile platforms often come bundled with emulators that
 execute a device image, so that you can launch the app from the home
@@ -195,7 +195,7 @@ $ cordova run android
 Before running this command, you need to set up the device for
 testing, following procedures that vary for each platform.
 
-###See Also
+### See Also
 - [Setting up Android emulator](../../guide/platforms/android/index.html#setting-up-an-emulator)
 - [Cordova run command reference documentation][cdv_run]
 - [Cordova emulate command reference documentation][cdv_emulate]
@@ -238,7 +238,7 @@ cordova-plugin-camera 2.1.0 "Camera"
 cordova-plugin-whitelist 1.2.1 "Whitelist"
 ```
 
-###See Also
+### See Also
 - [Cordova plugin command reference documentation][cdv_plugin]
 - [Cordova plugin search page](/plugins/)
 - [Core Plugin APIs]

--- a/www/docs/en/dev/guide/cli/index.md
+++ b/www/docs/en/dev/guide/cli/index.md
@@ -80,7 +80,7 @@ $ cordova create hello com.example.hello HelloWorld
 
 This creates the required directory structure for your cordova app. By default, the `cordova create` script generates a skeletal web-based application whose home page is the project's `www/index.html` file.
 
-###See Also
+### See Also
 - [Cordova create command reference documentation][cdv_create]
 - [Cordova project directory structure][cdv_dir]
 - [Cordova project templates][cdv_template]
@@ -116,10 +116,10 @@ _not_ edit any files in the `/platforms/` directory. The files
 in this directory are routinely overwritten when preparing
 applications for building, or when plugins are re-installed.
 
-###See Also
+### See Also
 - [Cordova platform command reference documentation][cdv_platform]
 
-##Install pre-requisites for building
+## Install pre-requisites for building
 To build and run apps, you need to install SDKs for each platform you wish to target. Alternatively, if you are using browser for development you can use `browser` platform which does not require any platform SDKs.
 
 To check if you satisfy requirements for building the platform:
@@ -160,10 +160,10 @@ You can optionally limit the scope of each build to specific platforms - 'ios' i
 $ cordova build ios
 ```
 
-###See Also
+### See Also
 - [Cordova build command reference documentation][cdv_build]
 
-##Test the App
+## Test the App
 
 SDKs for mobile platforms often come bundled with emulators that
 execute a device image, so that you can launch the app from the home
@@ -193,7 +193,7 @@ $ cordova run android
 Before running this command, you need to set up the device for
 testing, following procedures that vary for each platform.
 
-###See Also
+### See Also
 - [Setting up Android emulator](../../guide/platforms/android/index.html#setting-up-an-emulator)
 - [Cordova run command reference documentation][cdv_run]
 - [Cordova emulate command reference documentation][cdv_emulate]
@@ -236,7 +236,7 @@ cordova-plugin-camera 2.1.0 "Camera"
 cordova-plugin-whitelist 1.2.1 "Whitelist"
 ```
 
-###See Also
+### See Also
 - [Cordova plugin command reference documentation][cdv_plugin]
 - [Cordova plugin search page](/plugins/)
 - [Core Plugin APIs]


### PR DESCRIPTION
Add spaces between the hashes each markdown heading that didn't have them.

### Platforms affected
n/a


### Motivation and Context
Basically the headings won't be formatted correctly unless the markdown has a space between the #'s and the heading text. This is recommended in the [Heading Best Practices](https://www.markdownguide.org/basic-syntax/#heading-best-practices) of this somewhat official [Markdown Guide](https://www.markdownguide.org/).

Fixes #1214 

### Description
I only updated instances with two hashes or more, seems like most of the instances with one hash at the start are intentional and part of code rather than a heading.

Pretty simple, basically just two regex find and replaces in VS Code, one for the leading ### and one for any trailing ###
Find: ^(##+)(\w)
Replace with: $1 %2

Find: (\w)(##+)$
Replace with: $1 $2

### Testing
Have not tested this specifically. Checked through each file in the diff to ensure each place was intended to be a heading and not just #s in code or something. 

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
