### PR TITLE
blog(release): cordova-cli@11.0.0

### DIFF
--- a/www/_posts/2021-12-21-cordova-cli-11.0.0-release.md
+++ b/www/_posts/2021-12-21-cordova-cli-11.0.0-release.md
@@ -19,7 +19,7 @@ In this CLI release, it will also be using the latest internal libraries and tem
 
 ## Release Highlights
 
-In this release, we have dropped Nodejs 10 support. The minimum supported version which Cordova requires is 12.x.
+This release drops Nodejs 10 support. The minimum supported version which Cordova requires is 12.x.
 
 In all releases, we have updated all npm packages to the possible latest release in which Cordova can support.
 
@@ -29,7 +29,7 @@ In this release, we fixed an issue where users were unable to use Cordova CLI af
 
 **Cordova Lib 11.0.0:**
 
-We have bumped all platform pinnings to use the latest released platforms.
+We have bumped all platform pinnings to use the latest released platforms. This means new Cordova app projects will now use the latest major versions of the supported platforms.
 
 * `cordova-android@^10.1.1`
 * `cordova-electron@^3.0.0`
@@ -37,11 +37,15 @@ We have bumped all platform pinnings to use the latest released platforms.
 
 **Cordova Create 4.0.0:**
 
-In this release, all new projects will start with the newest App Hello World template.
+All new projects will now start with the newest App Hello World template.
 
 **Cordova App Hello World Template 6.0.0:**
 
 Please refer to the [App Hello World Release Blog](https://cordova.apache.org/news/2021/10/31/template-release.html) post for more details.
+
+## Greetings
+
+The Apache Cordova team wishes you Happy Holidays and a good start for the new year.
 
 <!--more-->
 # Changes include:

--- a/www/_posts/2021-12-21-cordova-cli-11.0.0-release.md
+++ b/www/_posts/2021-12-21-cordova-cli-11.0.0-release.md
@@ -43,6 +43,8 @@ All new projects will now start with the newest App Hello World template.
 
 Please refer to the [App Hello World Release Blog](https://cordova.apache.org/news/2021/10/31/template-release.html) post for more details.
 
+Please report any issues you find at [issues.cordova.io](http://issues.cordova.io/)!
+
 ## Greetings
 
 The Apache Cordova team wishes you Happy Holidays and a good start for the new year.

--- a/www/_posts/2021-12-21-cordova-cli-11.0.0-release.md
+++ b/www/_posts/2021-12-21-cordova-cli-11.0.0-release.md
@@ -1,0 +1,80 @@
+---
+layout: post
+author:
+    name: Bryan Ellis
+title:  "Cordova CLI 11.0.0 Released!"
+categories: news
+tags: news releases
+---
+
+We are happy to announce that we have just released a major update to our Cordova CLI!
+
+* [cordova@11.0.0](https://www.npmjs.com/package/cordova)
+
+In this CLI release, it will also be using the latest internal libraries and template:
+
+* [cordova-lib@11.0.0](https://www.npmjs.com/package/cordova-lib)
+* [cordova-create@4.0.0](https://www.npmjs.com/package/cordova-create)
+* [cordova-app-hello-world@6.0.0](https://www.npmjs.com/package/cordova-app-hello-world)
+
+## Release Highlights
+
+In this release, we have dropped Nodejs 10 support. The minimum supported version which Cordova requires is 12.x.
+
+In all releases, we have updated all npm packages to the possible latest release in which Cordova can support.
+
+**Cordova CLI 11.0.0:**
+
+In this release, we fixed an issue where users were unable to use Cordova CLI after upgrading their macOS environment to macOS Monterey. This issue was caused by one of the package dependencies, `insight`. The previous workaround was to reinstall Cordova CLI, but now this is no longer required with this release.
+
+**Cordova Lib 11.0.0:**
+
+We have bumped all platform pinnings to use the latest released platforms.
+
+* `cordova-android@^10.1.1`
+* `cordova-electron@^3.0.0`
+* `cordova-ios@^6.2.0`
+
+**Cordova Create 4.0.0:**
+
+In this release, all new projects will start with the newest App Hello World template.
+
+**Cordova App Hello World Template 6.0.0:**
+
+Please refer to the [App Hello World Release Blog](https://cordova.apache.org/news/2021/10/31/template-release.html) post for more details.
+
+<!--more-->
+# Changes include:
+
+**Cordova CLI 11.0.0:**
+
+* [GH-575](https://github.com/apache/cordova-cli/pull/575) chore: rebuilt `package-lock.json`
+* [GH-574](https://github.com/apache/cordova-cli/pull/574) dep: bump `@cordova/eslint-config@^4.0.0`
+* [GH-573](https://github.com/apache/cordova-cli/pull/573) dep: update `insight` w/ updated code usage
+* [GH-572](https://github.com/apache/cordova-cli/pull/572) dep: bump all dependencies
+* [GH-570](https://github.com/apache/cordova-cli/pull/570) feat: rebuilt `package-lock.json` w/ v2
+* [GH-571](https://github.com/apache/cordova-cli/pull/571) feat!: update node support
+* [GH-564](https://github.com/apache/cordova-cli/pull/564) chore: `npmrc`
+* [GH-559](https://github.com/apache/cordova-cli/pull/559) docs: remove plugin save command from CLI help
+* [GH-550](https://github.com/apache/cordova-cli/pull/550) dep: `systeminformation@^5.5.0`
+* [GH-535](https://github.com/apache/cordova-cli/pull/535) chore(pkg): remove deprecated `no-op` field `preferGlobal`
+* [GH-534](https://github.com/apache/cordova-cli/pull/534) chore: clean up `package.json`
+* [GH-533](https://github.com/apache/cordova-cli/pull/533) (android) Replace deprecated `android` command with `avdmanager`
+
+**Cordova Lib 11.0.0:**
+
+* [GH-889](https://github.com/apache/cordova-lib/pull/889) bump(platform): bump **Electron** & **Android** to latest release
+* [GH-890](https://github.com/apache/cordova-lib/pull/890) chore: rebuild `package-lock`
+* [GH-888](https://github.com/apache/cordova-lib/pull/888) dep(dev)!: bump `@cordova/eslint-config@^4.0.0` w/ fix
+* [GH-887](https://github.com/apache/cordova-lib/pull/887) dep!: update dependencies
+* [GH-873](https://github.com/apache/cordova-lib/pull/873) ci: switch to GitHub Actions
+* [GH-884](https://github.com/apache/cordova-lib/pull/884) chore!: drop support for Node.js 10
+
+**Cordova Create 4.0.0:**
+
+* [GH-68](https://github.com/apache/cordova-create/pull/68) dep!: update all dependencies
+  * `cordova-app-hello-world@^6.0.0`
+  * `cordova-common@^4.0.2`
+  * `cordova-fetch@^3.0.1`
+* [GH-67](https://github.com/apache/cordova-create/pull/67) chore: clean up `package.json`
+* [GH-66](https://github.com/apache/cordova-create/pull/66) ci: add node 14 to workflow


### PR DESCRIPTION
Cordova CLI 11.0.0 Release Blog

Include some notes about the Cordova Lib 11.0.0 & Cordova Create 4.0.0 release.
Also a link to the Cordova App Hello World 6.0.0 release blog post which is used starting from this release.