### PR TITLE
Fix CocoaPods section grammar

### DIFF
--- a/www/docs/en/dev/guide/platforms/ios/index.md
+++ b/www/docs/en/dev/guide/platforms/ios/index.md
@@ -77,7 +77,7 @@ $ brew install ios-deploy
 
 ### CocoaPods
 
-The [CocoaPods](https://cocoapods.org/#install) tools is needed to build iOS apps. A minimum version of 1.8.0 is required but the latest release is always recommended.
+The [CocoaPods](https://cocoapods.org/#install) tools are needed to build iOS apps. A minimum version of 1.8.0 is required but the latest release is always recommended.
 
 To install CocoaPods, run the following from command-line terminal:
 


### PR DESCRIPTION
Previously, it said that 'The CocoaPods tools _is_ needed", which is grammatically incorrect.

In order for it to be correct, it needs to say 'The CocoaPods tools _are_ needed'.