### PR TITLE
Remove cordova.io links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 This repository contains the source code for the Cordova website at [cordova.apache.org](https://cordova.apache.org).
 
-The site is also reachable with the short domain [cordova.io](http://cordova.io), the important subareas as [docs.cordova.io](http://docs.cordova.io), [blog.cordova.io](http://blog.cordova.io) and [plugins.cordova.io](http://plugins.cordova.io).
-
 ## Technical Overview
 
 The main parts are built as a static site with [Jekyll](http://jekyllrb.com/), containing the homepage and subpages, the [blog](https://cordova.apache.org/blog) and the [docs](https://cordova.apache.org/docs).  


### PR DESCRIPTION
So we don't need to keep a second domain around forever ...

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->



### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
