### PR TITLE
small fix category in doap file for better https://projects.apache.org/projects.html?category rendering

### DIFF
--- a/www/infra/doap_Cordova.rdf
+++ b/www/infra/doap_Cordova.rdf
@@ -39,8 +39,8 @@
     <programming-language>C++</programming-language>
     <programming-language>C#</programming-language>
     <programming-language>node.js</programming-language>
-    <category rdf:resource="https://projects.apache.org/projects.html?category#mobile" />
-    <category rdf:resource="https://projects.apache.org/projects.html?category#library" />
+    <category rdf:resource="https://projects.apache.org/category/mobile" />
+    <category rdf:resource="https://projects.apache.org/category/library" />
     <release>
        <Version>
            <name>Latest Stable</name>


### PR DESCRIPTION
The following page https://projects.apache.org/projects.html?category expose cordova own category instead of belonging to existing mobile and library categories
This is caused by wrong link in category element in the doap file.


