### PR TITLE
Correct "plugins" section syntaxe in package.json

### DIFF
--- a/www/docs/en/dev/platform_plugin_versioning_ref/index.md
+++ b/www/docs/en/dev/platform_plugin_versioning_ref/index.md
@@ -199,9 +199,9 @@ After running the above command, the **`package.json`** should contain something
 
 ```json
 "cordova": {
-  "plugins": [
-    "cordova-plugin-device"
-  ]
+  "plugins": {
+    "cordova-plugin-device": {}
+  }
 },
 "devDependencies": {
   "cordova-plugin-device": "^1.0.0"
@@ -301,9 +301,9 @@ Suppose you have defined in `config.xml` and `package.json` a plugin and version
 
 ```json
 "cordova": {
-  "plugins": [
-    "cordova-plugin-splashscreen"
-  ]
+  "plugins": {
+    "cordova-plugin-splashscreen": {}
+  }
 },
 "devDependencies": {
   "cordova-plugin-splashscreen": "1.0.0"


### PR DESCRIPTION
### Platforms affected
Android, iOS

### Motivation and Context
Having hasd to use package.json to declare plugins in my project, I noticed that the array form was wrongly communicating the names of the plugins as numbers, so noticed that cordova is specting it to be an object/map and not an array.

### Description
Only changed the list of plugins from an array to an object.

### Testing
- Execute the prepare step as usual declaring plugins, only in package.json, as an array. It should fail with a message like the following:
  -   `Failed to restore plugin "0". You might need to try adding it again. Error: CordovaError: Cannot find plugin.xml for plugin "0". Please try adding it again.
Discovered plugin "2". Adding it to the project`
- Then, change it to an object. It should work now.

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [X ] I've updated the documentation if necessary
