### PR TITLE
docs: rename Plugin APIs to Plugins

### DIFF
--- a/www/_data/toc/en_11-x-src.yml
+++ b/www/_data/toc/en_11-x-src.yml
@@ -49,7 +49,7 @@
         - url: guide/appdev/hooks/index.html
         - url: plugin_ref/spec.html
         -
-            name: Plugin APIs
+            name: Plugins
             children:
                 - url: reference/cordova-plugin-battery-status/index.html
                 - url: reference/cordova-plugin-camera/index.html

--- a/www/_data/toc/en_dev-src.yml
+++ b/www/_data/toc/en_dev-src.yml
@@ -49,7 +49,7 @@
         - url: guide/appdev/hooks/index.html
         - url: plugin_ref/spec.html
         -
-            name: Plugin APIs
+            name: Plugins
             children:
                 - url: reference/cordova-plugin-battery-status/index.html
                 - url: reference/cordova-plugin-camera/index.html


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

IMO, the plugins documentation is not only about APIs. The documentation is more general about plugins.

* JS APIs
* Native APIs (maybe)
* Configurations
* Quirks
* Issues/Workarounds
* Usage Examples
* ...

### Description
<!-- Describe your changes in detail -->

Rename `Plugin APIs` to `Plugins`

Note: This change is only UI and does not effect the URLs.

### Testing
<!-- Please describe in detail how you tested your changes. -->

n/a

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
