### PR TITLE
Add Fig as an autocomplete method

### DIFF
--- a/www/docs/en/dev/guide/cli/index.md
+++ b/www/docs/en/dev/guide/cli/index.md
@@ -70,6 +70,16 @@ To install the `cordova` command-line tool, follow these steps:
    `cordova` on the command line with no arguments and it should
    print help text.
 
+### Autocomplete
+
+You can get IDE-style autocompletions for `cordova` with <a href="https://fig.io/" target="_blank"><img src="https://fig.io/badges/Logo.svg" width="15" height="15"/></a> [Fig](https://fig.io/). It works in bash, zsh, and fish.
+
+To install, run:
+
+```shell
+brew install fig
+```
+
 ## Create the App
 
 Go to the directory where you maintain your source code, and create a cordova project:


### PR DESCRIPTION
[Fig](https://fig.io) provides autocomplete for 300+ CLI tools including Cordova. It looks like this:

<img width="405" alt="image" src="https://user-images.githubusercontent.com/4949076/181387201-77f9f7d0-d86e-4710-953c-ddc726f5567a.png">

We think this will help users become more efficient with Cordova CLI, so we would love to have Fig listed as an autocomplete method in your docs. Thanks so much and please let me know if you have any questions!