### PR TITLE
site(attributions): relocate third-party cpy & tm notices

### DIFF
--- a/www/_includes/footer_contents.html
+++ b/www/_includes/footer_contents.html
@@ -66,13 +66,5 @@
     Copyright &copy; {{ 'now' | date: "%Y" }} The Apache Software Foundation, Licensed under the <a target="_blank" href="https://www.apache.org/licenses/LICENSE-2.0">Apache License, Version 2.0</a>.<br/>
     Apache and the Apache feather logos are <a target="_blank" href="https://www.apache.org/foundation/marks/list/">trademarks</a> of The Apache Software Foundation.
     <br/>
-    Apple, iPhone, macOS, OS X are trademarks of Apple Inc., registered in the U.S. and other countries and regions.
-    <br/>
-    The Android robot is reproduced or modified from work created and shared by Google and used according to terms described in the Creative Commons 3.0 Attribution License.
-    <br/>
-    GITHUB &reg;, the GITHUB &reg; logo design, the INVERTOCAT logo design, OCTOCAT &reg;, and the OCTOCAT &reg; logo design are trademarks of GitHub, Inc., registered in the United States and other countries.
-    <br/>
-    npm is a registered trademark of npm, Inc.
-    <br/>
-    "Raleway" font used under license. For details see the <a href="{{ site.baseurl }}/attributions/">attributions page</a>.
+    <p>See the <a href="{{ site.baseurl }}/attributions/">attributions page</a> for other copyright & trademark notices.</p>
 </p>

--- a/www/attributions.html
+++ b/www/attributions.html
@@ -7,11 +7,32 @@ permalink: /attributions/
 <h1>Attributions</h1>
 
 <section>
+    <h2>Apple Inc.</h2>
+    <hr>
+    <p>Apple, iPhone, macOS, OS X are trademarks of Apple Inc., registered in the U.S. and other countries and regions.</p>
+</section>
+
+<section>
+    <h2>GitHub, Inc.</h2>
+    <hr>
+    <p>GITHUB &reg;, the GITHUB &reg; logo design, the INVERTOCAT logo design, OCTOCAT &reg;, and the OCTOCAT &reg; logo design are trademarks of GitHub, Inc., registered in the United States and other countries.</p>
+</section>
+
+<section>
+    <h2>Google LLC</h2>
+    <hr>
+    <p>The Android robot is reproduced or modified from work created and shared by Google and used according to terms described in the Creative Commons 3.0 Attribution License.</p>
+</section>
+
+<section>
+    <h2>npm, Inc.</h2>
+    <hr>
+    <p>npm is a registered trademark of npm, Inc.</p>
+</section>
+
+<section>
     <h2>
-        Raleway Font -
-        <a href="https://scripts.sil.org/cms/scripts/page.php?site_id=nrsi&id=OFL">
-            SIL Open Font License, 1.1
-        </a>
+        Raleway Font - <a href="https://scripts.sil.org/cms/scripts/page.php?site_id=nrsi&id=OFL">SIL Open Font License, 1.1</a>
     </h2>
     <hr>
     <p>
@@ -28,4 +49,10 @@ permalink: /attributions/
         Raleway-BoldItalic.ttf: Copyright &copy; 2010 - 2012, <a href="mailto:matt@pixelspread.com">Matt McInerney</a>, <a href="mailto:impallari@gmail.com">Pablo Impallari</a>, <a href="mailto:hello@rfuenzalida.com">Rodrigo Fuenzalida</a> with Reserved Font Name "Raleway"
         <br/>
     </p>
+</section>
+
+<section>
+    <h2>Twitter Inc.</h2>
+    <hr>
+    <p>TWITTER, TWEET, RETWEET and the Twitter Bird logo are trademarks of Twitter Inc. or its affiliates.</p>
 </section>


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Cleanup bloated footer

### Description
<!-- Describe your changes in detail -->

Move all third-party, non-Apache, related copyright and trademark notices to the attributions page.

<img src="https://user-images.githubusercontent.com/1029107/199184585-b7fe5c0c-9043-45ce-b4dc-78015f4a9876.png" height="600" />

### Testing
<!-- Please describe in detail how you tested your changes. -->

n/a
