### PR TITLE
Splashscreen(android): Min SDK notes

### DIFF
--- a/www/docs/en/11.x/core/features/splashscreen/index.md
+++ b/www/docs/en/11.x/core/features/splashscreen/index.md
@@ -437,6 +437,10 @@ _Note:_ This setting is available but use at your own risk.
 
 The splash screen image. This preference is used for both animated and non-animated icons. The current acceptable asset files can either be an XML Vector Drwable or PNG.
 
+:warning: Using [Adaptive Icons](https://medium.com/androiddevelopers/implementing-adaptive-icons-1e4d1795470e) requires Minimum SDK 26 to be set.
+
+:warning: Some XML Vector [features](https://developer.android.com/develop/ui/views/graphics/vector-drawable-resources) requires Minimum SDK 24 to be set.
+
 **Supported Platforms:**
 
 - Android

--- a/www/docs/en/dev/core/features/splashscreen/index.md
+++ b/www/docs/en/dev/core/features/splashscreen/index.md
@@ -437,6 +437,10 @@ _Note:_ This setting is available but use at your own risk.
 
 The splash screen image. This preference is used for both animated and non-animated icons. The current acceptable asset files can either be a XML Vector Drawable or PNG.
 
+:warning: Using [Adaptive Icons](https://medium.com/androiddevelopers/implementing-adaptive-icons-1e4d1795470e) requires Minimum SDK 26 to be set.
+
+:warning: Some XML Vector [features](https://developer.android.com/develop/ui/views/graphics/vector-drawable-resources) requires Minimum SDK 24 to be set.
+
 **Supported Platforms:**
 
 - Android


### PR DESCRIPTION
Added notes that requires API minimums to be set depending on XML vectors features being used or for adaptive-icons usage.

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

https://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android Splashscreen

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->



### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
