### PR TITLE
Clarify default value for packageType build flag

### DIFF
--- a/www/docs/en/10.x/guide/platforms/android/index.md
+++ b/www/docs/en/10.x/guide/platforms/android/index.md
@@ -357,7 +357,7 @@ To sign an app, you need the following parameters:
 | Alias                 | `--alias`         | The id specifying the private key used for signing
 | Password              | `--password`      | Password for the private key specified
 | Type of the Keystore  | `--keystoreType`  | *Default: auto-detect based on file extension*<br>Either pkcs12 or jks
-| Package Type          | `--packageType`   | *Default: apk*<br>Specify whether to build an APK or an [Android App Bundle] (https://developer.android.com/guide/app-bundle) (.aab) file.<br>Accepts either `apk` or `bundle`
+| Package Type          | `--packageType`   | *Default: apk for debug, bundle for release*<br>Specify whether to build an APK or an [Android App Bundle] (https://developer.android.com/guide/app-bundle) (.aab) file.<br>Accepts either `apk` or `bundle`
 
 These parameters can be specified using the command line arguments above to
 the [Cordova CLI][cli_reference] `build` or `run` commands.

--- a/www/docs/en/11.x/guide/platforms/android/index.md
+++ b/www/docs/en/11.x/guide/platforms/android/index.md
@@ -349,7 +349,7 @@ To sign an app, you need the following parameters:
 | Alias                 | `--alias`         | The id specifying the private key used for signing
 | Password              | `--password`      | Password for the private key specified
 | Type of the Keystore  | `--keystoreType`  | _Default: auto-detect based on file extension_<br>Either pkcs12 or jks
-| Package Type          | `--packageType`   | _Default: apk_<br>Specify whether to build an APK or an [AAB](https://developer.android.com/guide/app-bundle) (Android App Bundle) file.<br>Acceptable Values: `apk` or `bundle`
+| Package Type          | `--packageType`   | _Default: apk for debug, bundle for release_<br>Specify whether to build an APK or an [AAB](https://developer.android.com/guide/app-bundle) (Android App Bundle) file.<br>Acceptable Values: `apk` or `bundle`
 
 The parameters above can be specified as an argument when using the [Cordova CLI][cli_reference] `build` or `run` commands.
 

--- a/www/docs/en/dev/guide/platforms/android/index.md
+++ b/www/docs/en/dev/guide/platforms/android/index.md
@@ -349,7 +349,7 @@ To sign an app, you need the following parameters:
 | Alias                 | `--alias`         | The id specifying the private key used for signing
 | Password              | `--password`      | Password for the private key specified
 | Type of the Keystore  | `--keystoreType`  | _Default: auto-detect based on file extension_<br>Either pkcs12 or jks
-| Package Type          | `--packageType`   | _Default: apk_<br>Specify whether to build an APK or an [AAB](https://developer.android.com/guide/app-bundle) (Android App Bundle) file.<br>Acceptable Values: `apk` or `bundle`
+| Package Type          | `--packageType`   | _Default: apk for debug, bundle for release_<br>Specify whether to build an APK or an [AAB](https://developer.android.com/guide/app-bundle) (Android App Bundle) file.<br>Acceptable Values: `apk` or `bundle`
 
 The parameters above can be specified as an argument when using the [Cordova CLI][cli_reference] `build` or `run` commands.
 


### PR DESCRIPTION
### Platforms affected

Android

### Motivation and Context

Documentation clarification that will save developers some time.

### Description

Document that the default value for the `packageType` build flag is `bundle` for release builds.

### Testing

No testing done.

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
