### PR TITLE
docs(android): Mention CORDOVA_JAVA_HOME

### DIFF
--- a/www/docs/en/11.x/guide/platforms/android/index.md
+++ b/www/docs/en/11.x/guide/platforms/android/index.md
@@ -64,7 +64,7 @@ If you are using `cordova-android` 10.0.0 or greater, install the [Java Developm
 
 If you are using any version below `cordova-android` 10.0.0, install the [Java Development Kit (JDK) 8](https://www.oracle.com/java/technologies/javase/javase-jdk8-downloads.html).
 
-The `JAVA_HOME` environment variable must be set according to your JDK installation path when installing on a Windows environment. See the [Setting Environment Variables](#setting-environment-variables) section on how to set up environment variables.
+The `JAVA_HOME` environment variable must be set according to your JDK installation path. See the [Setting Environment Variables](#setting-environment-variables) section on how to set up environment variables. Alternatively as of `cordova-android` 10.0.0 or greater, `CORDOVA_JAVA_HOME` can be set in place of `JAVA_HOME`, allowing a JDK install to be used specifically for Cordova development.
 
 ### Gradle
 

--- a/www/docs/en/dev/guide/platforms/android/index.md
+++ b/www/docs/en/dev/guide/platforms/android/index.md
@@ -64,7 +64,7 @@ If you are using `cordova-android` 10.0.0 or greater, install the [Java Developm
 
 If you are using any version below `cordova-android` 10.0.0, install the [Java Development Kit (JDK) 8](https://www.oracle.com/java/technologies/javase/javase-jdk8-downloads.html).
 
-The `JAVA_HOME` environment variable must be set according to your JDK installation path when installing on a Windows environment. See the [Setting Environment Variables](#setting-environment-variables) section on how to set up environment variables.
+The `JAVA_HOME` environment variable must be set according to your JDK installation path. See the [Setting Environment Variables](#setting-environment-variables) section on how to set up environment variables. Alternatively as of `cordova-android` 10.0.0 or greater, `CORDOVA_JAVA_HOME` can be set in place of `JAVA_HOME`, allowing a JDK install to be used specifically for Cordova development.
 
 ### Gradle
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

https://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android Docs

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Closes https://github.com/apache/cordova-docs/issues/1292

### Description
<!-- Describe your changes in detail -->

Adds a blip mention to `CORDOVA_JAVA_HOME` which can be set instead of `JAVA_HOME` to use an alternate JDK install for cordova.

Back-ported the change to the 11.x docs snapshot.

### Testing
<!-- Please describe in detail how you tested your changes. -->

Manual observations.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
