### PR TITLE
[Android] Set ANDROID_HOME instead of deprecated ANDROID_SDK_ROOT

### DIFF
--- a/www/docs/en/dev/guide/platforms/android/index.md
+++ b/www/docs/en/dev/guide/platforms/android/index.md
@@ -108,14 +108,15 @@ Cordova's CLI requires specific environment variables so it can function correct
 The following variables must be set:
 
 - `JAVA_HOME` - The environment variable to the location of your JDK installation
-- `ANDROID_SDK_ROOT` - The environment variable to the location of your Android SDK installation
+- `ANDROID_HOME` - The environment variable to the location of your Android SDK installation
 
 It is also recommended to update the `PATH` environment variable to include the following directories.
 
 - `cmdline-tools/latest/bin`
-- `emulator`
 - `platform-tools`
 - `build-tools`
+- `tool/bin`
+- `emulator`
   - This is required for the `apksigner` and `zipalign` tools.
 
 _**Note:** The directories above are generally located in the Android SDK ROOT._
@@ -127,15 +128,17 @@ On a Mac or Linux, with a text editor, create or modify the `~/.bash_profile` fi
 To set an environment variable, add a line that uses `export` like so (substitute the path with your local installation):
 
 ```bash
-export ANDROID_SDK_ROOT=/Development/android-sdk/
+export ANDROID_HOME=/Development/android-sdk/
 ```
 
 To update your `PATH`, add a line resembling the following (substitute the paths with your local Android SDK installation's location):
 
 ```bash
-export PATH=$PATH:$ANDROID_SDK_ROOT/platform-tools/
-export PATH=$PATH:$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/
-export PATH=$PATH:$ANDROID_SDK_ROOT/emulator/
+export PATH=$PATH:$ANDROID_HOME/platform-tools/
+export PATH=$PATH:$ANDROID_HOME/cmdline-tools/latest/bin/
+export PATH=$PATH:$ANDROID_HOME/tools/bin/
+export PATH=$PATH:$ANDROID_HOME/build-tools
+export PATH=$PATH:$ANDROID_HOME/emulator/
 ```
 
 Reload your terminal to see this change reflected or run the following command:
@@ -174,7 +177,9 @@ Example paths (substitute the paths with your local Android SDK installation's l
 ```txt
 C:\Users\[your user]\AppData\Local\Android\Sdk\platform-tools
 C:\Users\[your user]\AppData\Local\Android\Sdk\cmdline-tools\latest\bin
-C:\Users\[your user]\AppData\Local\Android\Sdk\tools\emulator
+C:\Users\[your user]\AppData\Local\Android\Sdk\build-tools
+C:\Users\[your user]\AppData\Local\Android\Sdk\tools\bin
+C:\Users\[your user]\AppData\Local\Android\Sdk\emulator
 ```
 
 Once all paths are added, click the **OK** button until all opened windows for setting & editing environment variables are closed.

--- a/www/docs/en/dev/guide/platforms/android/index.md
+++ b/www/docs/en/dev/guide/platforms/android/index.md
@@ -116,7 +116,6 @@ It is also recommended to update the `PATH` environment variable to include the 
 - `cmdline-tools/latest/bin`
 - `platform-tools`
 - `build-tools`
-- `tool/bin`
 - `emulator`
   - This is required for the `apksigner` and `zipalign` tools.
 
@@ -137,7 +136,6 @@ To update your `PATH`, add a line resembling the following (substitute the paths
 ```bash
 export PATH=$PATH:$ANDROID_HOME/platform-tools/
 export PATH=$PATH:$ANDROID_HOME/cmdline-tools/latest/bin/
-export PATH=$PATH:$ANDROID_HOME/tools/bin/
 export PATH=$PATH:$ANDROID_HOME/build-tools
 export PATH=$PATH:$ANDROID_HOME/emulator/
 ```
@@ -179,7 +177,6 @@ Example paths (substitute the paths with your local Android SDK installation's l
 C:\Users\[your user]\AppData\Local\Android\Sdk\platform-tools
 C:\Users\[your user]\AppData\Local\Android\Sdk\cmdline-tools\latest\bin
 C:\Users\[your user]\AppData\Local\Android\Sdk\build-tools
-C:\Users\[your user]\AppData\Local\Android\Sdk\tools\bin
 C:\Users\[your user]\AppData\Local\Android\Sdk\emulator
 ```
 

--- a/www/docs/en/dev/guide/platforms/android/index.md
+++ b/www/docs/en/dev/guide/platforms/android/index.md
@@ -88,6 +88,7 @@ In the Android Studio, open the **SDK Manager** (`Tools > SDK Manager`) and conf
 
 - Android's **SDK Platform** for your targeted API Level
 - **Android SDK Build-Tools** under the **SDK Tools** tab, for the targeted version.
+- **Android SDK Command-line Tools (latest)** under the **SDK Tools** tab, for the latest version.
 
 #### Android SDK Tools
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

https://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Closes https://github.com/apache/cordova-docs/issues/1296

ANDROID_HOME is default
Since this PR: https://github.com/apache/cordova-android/pull/1471
The documentation should be deal with latest updates.
Because ANDROID_HOME is new default and ANDROID_SDK_ROOT is deprecated.

---
Also to insure that Android SDK Command-line Tools is selected.

### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
