### PR TITLE
blog: fix link to common blog post on cordova-cli 12 release blog post

### DIFF
--- a/www/_posts/2023-05-22-cordova-cli-12.0.0.md
+++ b/www/_posts/2023-05-22-cordova-cli-12.0.0.md
@@ -110,4 +110,4 @@ Please report any issues you find on our GitHub issue tracker! Please select bel
 
 **Cordova Common 5.0.0:**
 
-See the [Cordova Common Release 5.0.0](2023-03-09-cordova-common-release-5.0.0.md) blog post.
+See the [Cordova Common Release 5.0.0](https://cordova.apache.org/announcements/2023/03/09/cordova-common-release-5.0.0.html) blog post.


### PR DESCRIPTION
Fixes the link to the Cordova Common 5.0.0 blog post in the Cordova-CLI 12 release blog post.