### PR TITLE
doc: improve variable type tagging

### DIFF
--- a/www/_plugins/cdv-vartype-tag.rb
+++ b/www/_plugins/cdv-vartype-tag.rb
@@ -1,0 +1,15 @@
+module Jekyll
+  class CdvVarTypeTag < Liquid::Tag
+
+    def initialize(tag_name, text, tokens)
+      super
+      @text = text.downcase.strip
+    end
+
+    def render(context)
+      "<span class=\"cdv-var-type #{@text}\">#{@text.capitalize}</span>"
+    end
+  end
+end
+
+Liquid::Template.register_tag('cdv_vartype', Jekyll::CdvVarTypeTag)

--- a/www/docs/en/dev/config_ref/index.md
+++ b/www/docs/en/dev/config_ref/index.md
@@ -61,16 +61,16 @@ Root element of the config.xml document.
 
 Attributes(type) <br/> <span class="sub-header">Only for platform:</span> | Description
 ---------------- | ------------
-id(string) | *Required* <br/> Specifies the app's identifier. The `id` should be in a [reverse-DNS format](https://en.wikipedia.org/wiki/Reverse_domain_name_notation#Examples) however, only alphanumeric and dot characters are allowed. e.g: `com.example.myapp`
-version(string) | *Required* <br/> Full version number expressed in major/minor/patch notation.
-android-versionCode(string) <br/> {% cdv_platform android %} | Alternative version for Android. Sets the [version code](https://developer.android.com/tools/publishing/versioning.html) for the application. See [the Android guide](../guide/platforms/android/index.html#setting-the-version-code) for information on how this attribute may be modified.
-ios-CFBundleVersion(string) <br/> {% cdv_platform ios %} | Alternative version for iOS. For further details, see [iOS versioning](https://developer.apple.com/library/ios/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-102364).
-android-packageName(string) <br/> {% cdv_platform android %} | Alternative package name for Android, overrides `id`.
-ios-CFBundleIdentifier(string)  <br/> {% cdv_platform ios %} | Alternative bundle id for iOS. Overrides `id`.
+id<br/>{% cdv_vartype string %} | *Required* <br/> Specifies the app's identifier. The `id` should be in a [reverse-DNS format](https://en.wikipedia.org/wiki/Reverse_domain_name_notation#Examples) however, only alphanumeric and dot characters are allowed. e.g: `com.example.myapp`
+version<br/>{% cdv_vartype string %} | *Required* <br/> Full version number expressed in major/minor/patch notation.
+android-versionCode<br/>{% cdv_vartype string %} {% cdv_platform android %} | Alternative version for Android. Sets the [version code](https://developer.android.com/tools/publishing/versioning.html) for the application. See [the Android guide](../guide/platforms/android/index.html#setting-the-version-code) for information on how this attribute may be modified.
+ios-CFBundleVersion<br/>{% cdv_vartype string %} {% cdv_platform ios %} | Alternative version for iOS. For further details, see [iOS versioning](https://developer.apple.com/library/ios/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-102364).
+android-packageName<br/>{% cdv_vartype string %} {% cdv_platform android %} | Alternative package name for Android, overrides `id`.
+ios-CFBundleIdentifier<br/>{% cdv_vartype string %}  <br/> {% cdv_platform ios %} | Alternative bundle id for iOS. Overrides `id`.
 defaultlocale <br /> {% cdv_platform ios %} | Specified the default language of the app, as an IANA language code.
-android-activityName(string) <br/> {% cdv_platform android %} | Set the activity name for your app in AndroidManifest.xml. Note that this is only set once after the Android platform is first added.
-xmlns(string) | *Required* <br/> Namespace for the config.xml document.
-xmlns:cdv(string) | *Required* <br/> Namespace prefix.
+android-activityName<br/>{% cdv_vartype string %} {% cdv_platform android %} | Set the activity name for your app in AndroidManifest.xml. Note that this is only set once after the Android platform is first added.
+xmlns<br/>{% cdv_vartype string %} | *Required* <br/> Namespace for the config.xml document.
+xmlns:cdv<br/>{% cdv_vartype string %} | *Required* <br/> Namespace prefix.
 
 Examples:
 
@@ -122,8 +122,8 @@ Specifies contact information that may appear within app-store listings.
 
 Attributes(type) <br/> <span class="sub-header">Only for platform:</span> | Description
 ----------------- | ------------
-email(string) | *Required* <br/> Email of the author.
-href(string) | *Required* <br/> Website of the author.
+email<br/>{% cdv_vartype string %} | *Required* <br/> Email of the author.
+href<br/>{% cdv_vartype string %} | *Required* <br/> Website of the author.
 
 Examples:
 
@@ -139,7 +139,7 @@ Defines the app's starting page in the top-level web assets directory. The defau
 
 Attributes(type) <br/> <span class="sub-header">Only for platform:</span> | Description
 ----------------- | ------------
-src(string) | *Required* <br/> Defines the app's starting page in the top-level web assets directory. The default value is index.html, which customarily appears in a project's top-level ```www``` directory.
+src<br/>{% cdv_vartype string %} | *Required* <br/> Defines the app's starting page in the top-level web assets directory. The default value is index.html, which customarily appears in a project's top-level ```www``` directory.
 
 Examples:
 
@@ -154,7 +154,7 @@ Defines the set of external domains the app is allowed to communicate with. The 
 
 Attributes(type) <br/> <span class="sub-header">Only for platform:</span> | Description
 ----------------- | ------------
-origin(string) | *Required* <br/> Defines the set of external domains the app is allowed to communicate with. The default value shown above allows it to access any server. See the Domain [Whitelist Guide](../guide/appdev/allowlist/index.html) for details.
+origin<br/>{% cdv_vartype string %} | *Required* <br/> Defines the set of external domains the app is allowed to communicate with. The default value shown above allows it to access any server. See the Domain [Whitelist Guide](../guide/appdev/allowlist/index.html) for details.
 
 Examples:
 
@@ -174,7 +174,7 @@ Controls which URLs the WebView itself can be navigated to. Applies to top-level
 
 Attributes(type) <br/> <span class="sub-header">Only for platform:</span> | Description
 ----------------- | ------------
-href(string) | *Required* <br/> Defines the set of external domains the WebView is allowed to navigate to. See the [Allow List Guide][whitelist_navigation] for details.
+href<br/>{% cdv_vartype string %} | *Required* <br/> Defines the set of external domains the WebView is allowed to navigate to. See the [Allow List Guide][whitelist_navigation] for details.
 
 Examples:
 
@@ -191,7 +191,7 @@ Controls which URLs the app is allowed to ask the system to open. By default, no
 
 Attributes(type) <br/> <span class="sub-header">Only for platform:</span> | Description
 ----------------- | ------------
-href(string) | *Required* <br/> Defines which URLs the app is allowed to ask the system to open. See the [Allow List Guide][whitelist_intent] for details.
+href<br/>{% cdv_vartype string %} | *Required* <br/> Defines which URLs the app is allowed to ask the system to open. See the [Allow List Guide][whitelist_intent] for details.
 
 Examples:
 
@@ -214,8 +214,8 @@ Specifies details about what platform to restore during a prepare.
 
 Attributes(type) <br/> <span class="sub-header">Only for platform:</span> | Description
 ----------------- | ------------
-name(string) | *Required* <br/> Name of the platform to be restored
-spec(string) | *Required* <br/> Details about the platform to be restored. This could be a ```major.minor.patch``` version number, a directory containing the platform or a url pointing to a git repository. This information will be used to retrieve the platform code to restore from NPM, a local directory or a git repository. See [Platform Spec][platform_spec] for further details.
+name<br/>{% cdv_vartype string %} | *Required* <br/> Name of the platform to be restored
+spec<br/>{% cdv_vartype string %} | *Required* <br/> Details about the platform to be restored. This could be a ```major.minor.patch``` version number, a directory containing the platform or a url pointing to a git repository. This information will be used to retrieve the platform code to restore from NPM, a local directory or a git repository. See [Platform Spec][platform_spec] for further details.
 
 Examples:
 
@@ -234,8 +234,8 @@ _Note: As of Cordova 9.x, this tag is obsolete. [Learn More](https://github.com/
 
 Attributes(type) <br/> <span class="sub-header">Only for platform:</span> | Description
 ----------------- | ------------
-name(string) | *Required* <br/> Name of the plugin to be restored
-spec(string) | *Required* <br/> Details about the plugin to be restored. This could be a ```major.minor.patch``` version number, a directory containing the plugin or a url pointing to a git repository. This information will be used to retrieve the plugin code to restore from NPM, a local directory or a git repository. See [Plugin Spec][plugin_spec] for further details.
+name<br/>{% cdv_vartype string %} | *Required* <br/> Name of the plugin to be restored
+spec<br/>{% cdv_vartype string %} | *Required* <br/> Details about the plugin to be restored. This could be a ```major.minor.patch``` version number, a directory containing the plugin or a url pointing to a git repository. This information will be used to retrieve the plugin code to restore from NPM, a local directory or a git repository. See [Plugin Spec][plugin_spec] for further details.
 
 Examples:
 
@@ -258,8 +258,8 @@ project and restore it by running `cordova prepare`. See the
 
 Attributes(type) <br/> <span class="sub-header">Only for platform:</span> | Description
 ----------------- | ------------
-name(string) | *Required* <br/> Name of the CLI variable. Can only contain capital letters, digits, and underscores.
-value(string) | *Required* <br/> Value of the CLI variable to be used when restoring the parent plugin during a prepare.
+name<br/>{% cdv_vartype string %} | *Required* <br/> Name of the CLI variable. Can only contain capital letters, digits, and underscores.
+value<br/>{% cdv_vartype string %} | *Required* <br/> Value of the CLI variable to be used when restoring the parent plugin during a prepare.
 
 Examples:
 
@@ -275,55 +275,55 @@ and will be indicated as such.
 
 Attributes(type) <br/> <span class="sub-header">Only for platform:</span> | Description
 ----------------- | ------------
-AllowInlineMediaPlayback(boolean) <br/> {% cdv_platform ios %} | *Default: false* <br/>  Set to true to allow HTML5 media playback to appear inline within the screen layout, using browser-supplied controls rather than native controls. For this to work, add the ```playsinline``` attribute to any ```<video>``` elements. *NOTE*: Prior to iOS 10, ```<video>``` elements need to use the ```webkit-playsinline``` attribute name instead.
-AllowNewWindows(boolean) <br/> {% cdv_platform ios %} | *Default: false* <br/> Set to true to allow JavaScript `window.open` and HTML `target="_blank"` links to open a new view overlaying the web view.
-AndroidLaunchMode(string) <br/> {% cdv_platform android %} | *Default: singleTop* <br/> Allowed values: standard, singleTop, singleTask, singleInstance <br/>  Sets the Activity android:launchMode attribute. This changes what happens when the app is launched from app icon or intent and is already running.
-AndroidInsecureFileModeEnabled(boolean) <br/> {% cdv_platform android %} | *Default: false* <br/>  If set to `true` loading `file:///` URLs is allowed. __Note__: Enabling this setting allows malicious scripts loaded in a `file:///` context to launch cross-site scripting attacks, either accessing arbitrary local files including WebView cookies, app private data or even credentials used on arbitrary web sites.
-android-maxSdkVersion(integer) <br/> {% cdv_platform android %} | *Default: Not Specified* <br/>  Sets the `maxSdkVersion` attribute of the `<uses-sdk>` tag in the project's `AndroidManifest.xml` (see [here][uses-sdk]).
-android-minSdkVersion(integer) <br/> {% cdv_platform android %} | *Default: Dependent on cordova-android Version* <br/>  Sets the `minSdkVersion` attribute of the `<uses-sdk>` tag in the project's `AndroidManifest.xml` (see [here][uses-sdk]).
-android-targetSdkVersion(integer) <br/> {% cdv_platform android %} | *Default: Dependent on cordova-android Version* <br/>  Sets the `targetSdkVersion` attribute of the `<uses-sdk>` tag in the project's `AndroidManifest.xml` (see [here][uses-sdk]).
-AppendUserAgent(string) <br/> {% cdv_platform android %} {% cdv_platform ios %} | If set, the value will append to the end of old UserAgent of webview. When using with OverrideUserAgent, this value will be ignored.
-BackgroundColor(string) <br/> {% cdv_platform android %} {% cdv_platform ios %} | Sets the app's background color. Supports a four-byte hex value, with the first byte representing the alpha channel, and standard RGB values for the following three bytes. <br/>__Note__: `transparent` value will set the application tile background to the accent color on Windows.
-BackupWebStorage(string) <br/> {% cdv_platform ios %} | *Default: cloud* <br/> Allowed values: none, local, cloud. <br/>   Set to cloud to allow web storage data to backup via iCloud. Set to local to allow only local backups via iTunes sync. Set to none prevent web storage backups.
-CordovaWebViewEngine(string) <br/> {% cdv_platform ios %} | *Default: CDVWebViewEngine* <br/>  This sets the WebView engine plugin to be used to render the host app. The plugin must conform to the CDVWebViewEngineProtocol protocol. The 'value' here should match the 'feature' name of the WebView engine plugin that is installed. This preference usually would be set by the WebView engine plugin that is installed, automatically.
-DefaultVolumeStream(string) <br/> {% cdv_platform android %} | *Default: default* <br/>  Added in cordova-android 3.7.0, This preference sets which volume the hardware volume buttons link to. By default this is "call" for phones and "media" for tablets. Set this to "media" to have your app's volume buttons always change the media volume. Note that when using Cordova's media plugin, the volume buttons will dynamically change to controlling the media volume when any Media objects are active.
-DisallowOverscroll(boolean) <br/> {% cdv_platform ios %} {% cdv_platform android %} | *Default: false* <br/>  Set to **true** if you don't want the interface to display any feedback when users scroll past the beginning or end of content. On iOS, overscroll gestures cause content to bounce back to its original position. on Android, they produce a more subtle glowing effect along the top or bottom edge of the content. <br/>
-EnableViewportScale(boolean) <br/> {% cdv_platform ios %} | *Default: false* <br/>   Set to true to allow a viewport meta tag to either disable or restrict the range of user scaling, which is enabled by default. Place a viewport such as the following in the HTML to disable scaling and fit content flexibly within the rendering WebView: <br/> ```<meta name='viewport' content='width=device-width, initial-scale=1, user-scalable=no' />```
-ErrorUrl(URL) <br/> {% cdv_platform android %} | *Default: null* <br/>  If set, will display the referenced page upon an error in the application instead of a dialog with the title "Application Error".
-ErrorUrl(string) <br/> {% cdv_platform ios %} | If set, will display the referenced local page upon an error in the application.
-FullScreen(boolean) <br/> {% cdv_platform android %} | *Default: false* <br/>  Allows you to hide the status bar at the top of the screen. <br/> __Note__: Recommended platform-agnostic way to achieve this is to use the [StatusBar plugin][statusbar_plugin].
-GapBetweenPages(float) <br/> {% cdv_platform ios %} | *Default: 0* <br/>  The size of the gap, in points, between pages.
-GradlePluginGoogleServicesEnabled (boolean) <br/> {% cdv_platform android %} | *Default: false* <br/>  Set to true to enable the Google Services Gradle plugin.
-GradlePluginGoogleServicesEnabled (semver) <br/> {% cdv_platform android %} | *Default: 4.2.0* <br/>  Set version of Google Services Gradle plugin to be used.
-GradlePluginKotlinEnabled (boolean) <br/> {% cdv_platform android %} | *Default: false* <br/>  Set to true to allow Kotlin files to be built.
-GradlePluginKotlinCodeStyle (string) <br/> {% cdv_platform android %} | *Default: official* <br/> Allowed values: official, obsolete<br/>  Sets how the Kotlin code is formatting for readability.
-GradlePluginKotlinVersion (semver) <br/> {% cdv_platform android %} | *Default: 1.3.50* <br/> Set the version of the Kotlin Gradle plugin to be used.
-InAppBrowserStorageEnabled (boolean) <br/> {% cdv_platform android %} | *Default: true* <br/>  Controls whether pages opened within an InAppBrowser can access the same localStorage and WebSQL storage as pages opened with the default browser.
-InspectableWebview(boolean) <br/> {% cdv_platform android %} {% cdv_platform ios %} | *Default: depends on Debug/Release build* <br/>  On iOS 16.4 or later, enables or disables the webview inspector. Defaults to `true` on debug builds and `false` on release builds. This preference is ignored on iOS 16.3 and earlier; the inspector is always enabled on debug builds and always disabled on release builds.
-KeepRunning(boolean) <br/> {% cdv_platform android %} | *Default: true* <br/>  Determines whether the application stays running in the background even after a [pause](../cordova/events/events.html#pause) event fires. Setting this to false does not kill the app after a [pause](../cordova/events/events.html#pause) event, but simply halts execution of code within the cordova webview while the app is in the background.
-KeyboardDisplayRequiresUserAction(boolean) <br/> {% cdv_platform ios %} | *Default: true* <br/>  Set to false to allow the keyboard to appear when calling focus() on form inputs.
-LoadUrlTimeoutValue(number in milliseconds) <br/> {% cdv_platform android %} | *Default: 20000, 20 seconds* <br/>  When loading a page, the amount of time to wait before throwing a timeout error.
-LoadingDialog(string) <br/> {% cdv_platform android %} | *Default: null* <br/>  If set, displays a dialog with the specified title and message, and a spinner, when loading the first page of an application. The title and message are separated by a comma in this value string, and that comma is removed before the dialog is displayed.
-LogLevel(string) <br/> {% cdv_platform android %} | *Default: DEBUG* <br/> Allowed values: ERROR, WARN, INFO, DEBUG, VERBOSE <br/>  Sets the minimum log level through which log messages from your application will be filtered.
-MediaPlaybackAllowsAirPlay(boolean) <br/> {% cdv_platform ios %} | *Default: true* <br/>  Set to false to prevent Air Play from being used in this view. Available in default UIWebView and WKWebView.
-MediaPlaybackRequiresUserAction(boolean) <br/> {% cdv_platform ios %} | *Default: false* <br/>  Set to true to prevent HTML5 videos or audios from playing automatically with the autoplay attribute or via JavaScript.
-Orientation(string) | *Default: default* <br/> Allowed values: default, landscape, portrait <br/> Allows you to lock orientation and prevent the interface from rotating in response to changes in orientation. <br/> **NOTE:** The default value means Cordova will strip the orientation preference entry from the platform's manifest/configuration file allowing the platform to fallback to its default behavior. For iOS, to specify both portrait & landscape mode you would use the platform specific value 'all'.
-OverrideUserAgent(string) <br/> {% cdv_platform android %} {% cdv_platform ios %} | If set, the value will replace the old UserAgent of webview. It is helpful to identify the request from app/browser when requesting remote pages. Use with caution, this may cause compatibility issues with web servers. For most cases, use AppendUserAgent instead.
-PageLength(float) <br/> {% cdv_platform ios %} | *Default: 0* <br/>  The size of each page, in points, in the direction that the pages flow. When PaginationMode is right to left or left to right, this property represents the width of each page. When PaginationMode is topToBottom or bottomToTop, this property represents the height of each page. The default value is 0, which means the layout uses the size of the viewport to determine the dimensions of the page.
-PaginationBreakingMode(string) <br/> {% cdv_platform ios %} | *Default: page* <br/> Allowed values: page, column <br/>  Valid values are page and column.The manner in which column- or page-breaking occurs. This property determines whether certain CSS properties regarding column- and page-breaking are honored or ignored. When this property is set to column, the content respects the CSS properties related to column-breaking in place of page-breaking.
-PaginationMode(string) <br/> {% cdv_platform ios %} | *Default: unpaginated* <br/> Allowed values: unpaginated, leftToRight, topToBottom, bottomToTop, rightToLeft <br/>  This property determines whether content in the web view is broken up into pages that fill the view one screen at a time,or shown as one long scrolling view. If set to a paginated form, this property toggles a paginated layout on the content, causing the web view to use the values of PageLength and GapBetweenPages to relayout its content.
-PreferredContentMode(string) <br/> {% cdv_platform ios %} | *Default: auto* <br/>  Sets the content mode (user agent) for the WebView and InAppBrowsers WebView on iPads. Valid values are: `mobile` and `desktop`.
-InAppBrowserStatusBarStyle(string) <br/> {% cdv_platform ios %} | *Default: default* <br/>  Set text color style of the StatusBar for InAppBrowser for iOS. Valid values are: `lightcontent` and `default`.
-SetFullscreen(boolean) <br/> {% cdv_platform android %} | *Default: false* <br/>  Same as the Fullscreen parameter in the global configuration of this xml file. This Android-specific element is deprecated in favor of the global Fullscreen element, and will be removed in a future version.
-ShowTitle(boolean) <br/> {% cdv_platform android %} | *Default: false* <br/>  Show the title at the top of the screen.
-Suppresses3DTouchGesture(boolean) <br/> {% cdv_platform ios %} | *Default: false* <br/>  Set to true to avoid 3D Touch capable iOS devices rendering a magnifying glass widget when the user applies force while longpressing the webview. Test your app thoroughly since this disables onclick handlers, but plays nice with ontouchend. If this setting is true, SuppressesLongPressGesture will effectively be true as well.
-SuppressesIncrementalRendering(boolean) <br/> {% cdv_platform ios %} | *Default: false* <br/>  Set to true to wait until all content has been received before it renders to the screen.
-SuppressesLongPressGesture(boolean) <br/> {% cdv_platform ios %} | *Default: false* <br/>  Set to true to avoid iOS9+ rendering a magnifying glass widget when the user longpresses the webview. Test your app thoroughly since this may interfere with text selection capabilities.
-SwiftVersion(string) <br/> {% cdv_platform ios %} | *Default: (empty)* <br /> Set to specify the Swift Version.
-TopActivityIndicator(string) <br/> {% cdv_platform ios %} | *Default: gray* <br/> Allowed values: whiteLarge, white, gray. <br/>   <br/> Controls the appearance of the small spinning icon in the status bar that indicates significant processor activity.
-UIWebViewDecelerationSpeed(string) <br/> {% cdv_platform ios %} | *Default: normal* <br/> Allowed values: normal, fast <br/>  This property controls the deceleration speed of momentum scrolling. normal is the default speed for most native apps, and fast is the default for Mobile Safari.
-deployment-target(string) <br/> {% cdv_platform ios %} | This sets the IPHONEOS_DEPLOYMENT_TARGET in the build, which ultimately translates to the MinimumOSVersion in the ipa. For more details please refer to Apple's documentation on Deployment Target Settings
-target-device(string) <br/> {% cdv_platform ios %} | *Default: universal* <br/> Allowed values: handset, tablet, universal <br/>  This property maps directly to TARGETED_DEVICE_FAMILY in the xcode project. Note that if you target universal (which is the default) you will need to supply screen shots for both iPhone and iPad or your app may be rejected.
+AllowInlineMediaPlayback<br/>{% cdv_vartype boolean %} {% cdv_platform ios %} | *Default: false* <br/>  Set to true to allow HTML5 media playback to appear inline within the screen layout, using browser-supplied controls rather than native controls. For this to work, add the ```playsinline``` attribute to any ```<video>``` elements. *NOTE*: Prior to iOS 10, ```<video>``` elements need to use the ```webkit-playsinline``` attribute name instead.
+AllowNewWindows<br/>{% cdv_vartype boolean %} {% cdv_platform ios %} | *Default: false* <br/> Set to true to allow JavaScript `window.open` and HTML `target="_blank"` links to open a new view overlaying the web view.
+AndroidLaunchMode<br/>{% cdv_vartype string %} {% cdv_platform android %} | *Default: singleTop* <br/> Allowed values: standard, singleTop, singleTask, singleInstance <br/>  Sets the Activity android:launchMode attribute. This changes what happens when the app is launched from app icon or intent and is already running.
+AndroidInsecureFileModeEnabled<br/>{% cdv_vartype boolean %} {% cdv_platform android %} | *Default: false* <br/>  If set to `true` loading `file:///` URLs is allowed. __Note__: Enabling this setting allows malicious scripts loaded in a `file:///` context to launch cross-site scripting attacks, either accessing arbitrary local files including WebView cookies, app private data or even credentials used on arbitrary web sites.
+android-maxSdkVersion<br/>{% cdv_vartype number %} {% cdv_platform android %} | *Default: Not Specified* <br/>  Sets the `maxSdkVersion` attribute of the `<uses-sdk>` tag in the project's `AndroidManifest.xml` (see [here][uses-sdk]).
+android-minSdkVersion<br/>{% cdv_vartype number %} {% cdv_platform android %} | *Default: Dependent on cordova-android Version* <br/>  Sets the `minSdkVersion` attribute of the `<uses-sdk>` tag in the project's `AndroidManifest.xml` (see [here][uses-sdk]).
+android-targetSdkVersion<br/>{% cdv_vartype number %} {% cdv_platform android %} | *Default: Dependent on cordova-android Version* <br/>  Sets the `targetSdkVersion` attribute of the `<uses-sdk>` tag in the project's `AndroidManifest.xml` (see [here][uses-sdk]).
+AppendUserAgent<br/>{% cdv_vartype string %} {% cdv_platform android %} {% cdv_platform ios %} | If set, the value will append to the end of old UserAgent of webview. When using with OverrideUserAgent, this value will be ignored.
+BackgroundColor<br/>{% cdv_vartype string %} {% cdv_platform android %} {% cdv_platform ios %} | Sets the app's background color. Supports a four-byte hex value, with the first byte representing the alpha channel, and standard RGB values for the following three bytes. <br/>__Note__: `transparent` value will set the application tile background to the accent color on Windows.
+BackupWebStorage<br/>{% cdv_vartype string %} {% cdv_platform ios %} | *Default: cloud* <br/> Allowed values: none, local, cloud. <br/>   Set to cloud to allow web storage data to backup via iCloud. Set to local to allow only local backups via iTunes sync. Set to none prevent web storage backups.
+CordovaWebViewEngine<br/>{% cdv_vartype string %} {% cdv_platform ios %} | *Default: CDVWebViewEngine* <br/>  This sets the WebView engine plugin to be used to render the host app. The plugin must conform to the CDVWebViewEngineProtocol protocol. The 'value' here should match the 'feature' name of the WebView engine plugin that is installed. This preference usually would be set by the WebView engine plugin that is installed, automatically.
+DefaultVolumeStream<br/>{% cdv_vartype string %} {% cdv_platform android %} | *Default: default* <br/>  Added in cordova-android 3.7.0, This preference sets which volume the hardware volume buttons link to. By default this is "call" for phones and "media" for tablets. Set this to "media" to have your app's volume buttons always change the media volume. Note that when using Cordova's media plugin, the volume buttons will dynamically change to controlling the media volume when any Media objects are active.
+DisallowOverscroll<br/>{% cdv_vartype boolean %} {% cdv_platform ios %} {% cdv_platform android %} | *Default: false* <br/>  Set to **true** if you don't want the interface to display any feedback when users scroll past the beginning or end of content. On iOS, overscroll gestures cause content to bounce back to its original position. on Android, they produce a more subtle glowing effect along the top or bottom edge of the content. <br/>
+EnableViewportScale<br/>{% cdv_vartype boolean %} {% cdv_platform ios %} | *Default: false* <br/>   Set to true to allow a viewport meta tag to either disable or restrict the range of user scaling, which is enabled by default. Place a viewport such as the following in the HTML to disable scaling and fit content flexibly within the rendering WebView: <br/> ```<meta name='viewport' content='width=device-width, initial-scale=1, user-scalable=no' />```
+ErrorUrl<br/>{% cdv_vartype url %} {% cdv_platform android %} | *Default: null* <br/>  If set, will display the referenced page upon an error in the application instead of a dialog with the title "Application Error".
+ErrorUrl<br/>{% cdv_vartype string %} {% cdv_platform ios %} | If set, will display the referenced local page upon an error in the application.
+FullScreen<br/>{% cdv_vartype boolean %} {% cdv_platform android %} | *Default: false* <br/>  Allows you to hide the status bar at the top of the screen. <br/> __Note__: Recommended platform-agnostic way to achieve this is to use the [StatusBar plugin][statusbar_plugin].
+GapBetweenPages<br/>{% cdv_vartype float %} {% cdv_platform ios %} | *Default: 0* <br/>  The size of the gap, in points, between pages.
+GradlePluginGoogleServicesEnabled<br/>{% cdv_vartype boolean %} {% cdv_platform android %} | *Default: false* <br/>  Set to true to enable the Google Services Gradle plugin.
+GradlePluginGoogleServicesEnabled<br/>{% cdv_vartype semver %} {% cdv_platform android %} | *Default: 4.2.0* <br/>  Set version of Google Services Gradle plugin to be used.
+GradlePluginKotlinEnabled<br/>{% cdv_vartype boolean %} {% cdv_platform android %} | *Default: false* <br/>  Set to true to allow Kotlin files to be built.
+GradlePluginKotlinCodeStyle <br/>{% cdv_vartype string %} {% cdv_platform android %} | *Default: official* <br/> Allowed values: official, obsolete<br/>  Sets how the Kotlin code is formatting for readability.
+GradlePluginKotlinVersion<br/>{% cdv_vartype semver %} {% cdv_platform android %} | *Default: 1.3.50* <br/> Set the version of the Kotlin Gradle plugin to be used.
+InAppBrowserStorageEnabled<br/>{% cdv_vartype boolean %} {% cdv_platform android %} | *Default: true* <br/>  Controls whether pages opened within an InAppBrowser can access the same localStorage and WebSQL storage as pages opened with the default browser.
+InspectableWebview<br/>{% cdv_vartype boolean %} {% cdv_platform android %} {% cdv_platform ios %} | *Default: depends on Debug/Release build* <br/>  On iOS 16.4 or later, enables or disables the webview inspector. Defaults to `true` on debug builds and `false` on release builds. This preference is ignored on iOS 16.3 and earlier; the inspector is always enabled on debug builds and always disabled on release builds.
+KeepRunning<br/>{% cdv_vartype boolean %} {% cdv_platform android %} | *Default: true* <br/>  Determines whether the application stays running in the background even after a [pause](../cordova/events/events.html#pause) event fires. Setting this to false does not kill the app after a [pause](../cordova/events/events.html#pause) event, but simply halts execution of code within the cordova webview while the app is in the background.
+KeyboardDisplayRequiresUserAction<br/>{% cdv_vartype boolean %} {% cdv_platform ios %} | *Default: true* <br/>  Set to false to allow the keyboard to appear when calling focus() on form inputs.
+LoadUrlTimeoutValue<br/>{% cdv_vartype number %} {% cdv_platform android %} | *Default: 20000, 20 seconds* <br/>  When loading a page, the amount of time in miliseconds to wait before throwing a timeout error.
+LoadingDialog<br/>{% cdv_vartype string %} {% cdv_platform android %} | *Default: null* <br/>  If set, displays a dialog with the specified title and message, and a spinner, when loading the first page of an application. The title and message are separated by a comma in this value string, and that comma is removed before the dialog is displayed.
+LogLevel<br/>{% cdv_vartype string %} {% cdv_platform android %} | *Default: DEBUG* <br/> Allowed values: ERROR, WARN, INFO, DEBUG, VERBOSE <br/>  Sets the minimum log level through which log messages from your application will be filtered.
+MediaPlaybackAllowsAirPlay<br/>{% cdv_vartype boolean %} {% cdv_platform ios %} | *Default: true* <br/>  Set to false to prevent Air Play from being used in this view. Available in default UIWebView and WKWebView.
+MediaPlaybackRequiresUserAction<br/>{% cdv_vartype boolean %} {% cdv_platform ios %} | *Default: false* <br/>  Set to true to prevent HTML5 videos or audios from playing automatically with the autoplay attribute or via JavaScript.
+Orientation<br/>{% cdv_vartype string %} | *Default: default* <br/> Allowed values: default, landscape, portrait <br/> Allows you to lock orientation and prevent the interface from rotating in response to changes in orientation. <br/> **NOTE:** The default value means Cordova will strip the orientation preference entry from the platform's manifest/configuration file allowing the platform to fallback to its default behavior. For iOS, to specify both portrait & landscape mode you would use the platform specific value 'all'.
+OverrideUserAgent<br/>{% cdv_vartype string %} {% cdv_platform android %} {% cdv_platform ios %} | If set, the value will replace the old UserAgent of webview. It is helpful to identify the request from app/browser when requesting remote pages. Use with caution, this may cause compatibility issues with web servers. For most cases, use AppendUserAgent instead.
+PageLength<br/>{% cdv_vartype float %} {% cdv_platform ios %} | *Default: 0* <br/>  The size of each page, in points, in the direction that the pages flow. When PaginationMode is right to left or left to right, this property represents the width of each page. When PaginationMode is topToBottom or bottomToTop, this property represents the height of each page. The default value is 0, which means the layout uses the size of the viewport to determine the dimensions of the page.
+PaginationBreakingMode<br/>{% cdv_vartype string %} {% cdv_platform ios %} | *Default: page* <br/> Allowed values: page, column <br/>  Valid values are page and column.The manner in which column- or page-breaking occurs. This property determines whether certain CSS properties regarding column- and page-breaking are honored or ignored. When this property is set to column, the content respects the CSS properties related to column-breaking in place of page-breaking.
+PaginationMode<br/>{% cdv_vartype string %} {% cdv_platform ios %} | *Default: unpaginated* <br/> Allowed values: unpaginated, leftToRight, topToBottom, bottomToTop, rightToLeft <br/>  This property determines whether content in the web view is broken up into pages that fill the view one screen at a time,or shown as one long scrolling view. If set to a paginated form, this property toggles a paginated layout on the content, causing the web view to use the values of PageLength and GapBetweenPages to relayout its content.
+PreferredContentMode<br/>{% cdv_vartype string %} {% cdv_platform ios %} | *Default: auto* <br/>  Sets the content mode (user agent) for the WebView and InAppBrowsers WebView on iPads. Valid values are: `mobile` and `desktop`.
+InAppBrowserStatusBarStyle<br/>{% cdv_vartype string %} {% cdv_platform ios %} | *Default: default* <br/>  Set text color style of the StatusBar for InAppBrowser for iOS. Valid values are: `lightcontent` and `default`.
+SetFullscreen<br/>{% cdv_vartype boolean %} {% cdv_platform android %} | *Default: false* <br/>  Same as the Fullscreen parameter in the global configuration of this xml file. This Android-specific element is deprecated in favor of the global Fullscreen element, and will be removed in a future version.
+ShowTitle<br/>{% cdv_vartype boolean %} {% cdv_platform android %} | *Default: false* <br/>  Show the title at the top of the screen.
+Suppresses3DTouchGesture<br/>{% cdv_vartype boolean %} {% cdv_platform ios %} | *Default: false* <br/>  Set to true to avoid 3D Touch capable iOS devices rendering a magnifying glass widget when the user applies force while longpressing the webview. Test your app thoroughly since this disables onclick handlers, but plays nice with ontouchend. If this setting is true, SuppressesLongPressGesture will effectively be true as well.
+SuppressesIncrementalRendering<br/>{% cdv_vartype boolean %} {% cdv_platform ios %} | *Default: false* <br/>  Set to true to wait until all content has been received before it renders to the screen.
+SuppressesLongPressGesture<br/>{% cdv_vartype boolean %} {% cdv_platform ios %} | *Default: false* <br/>  Set to true to avoid iOS9+ rendering a magnifying glass widget when the user longpresses the webview. Test your app thoroughly since this may interfere with text selection capabilities.
+SwiftVersion<br/>{% cdv_vartype string %} {% cdv_platform ios %} | *Default: (empty)* <br /> Set to specify the Swift Version.
+TopActivityIndicator<br/>{% cdv_vartype string %} {% cdv_platform ios %} | *Default: gray* <br/> Allowed values: whiteLarge, white, gray. <br/>   <br/> Controls the appearance of the small spinning icon in the status bar that indicates significant processor activity.
+UIWebViewDecelerationSpeed<br/>{% cdv_vartype string %} {% cdv_platform ios %} | *Default: normal* <br/> Allowed values: normal, fast <br/>  This property controls the deceleration speed of momentum scrolling. normal is the default speed for most native apps, and fast is the default for Mobile Safari.
+deployment-target<br/>{% cdv_vartype string %} {% cdv_platform ios %} | This sets the IPHONEOS_DEPLOYMENT_TARGET in the build, which ultimately translates to the MinimumOSVersion in the ipa. For more details please refer to Apple's documentation on Deployment Target Settings
+target-device<br/>{% cdv_vartype string %} {% cdv_platform ios %} | *Default: universal* <br/> Allowed values: handset, tablet, universal <br/>  This property maps directly to TARGETED_DEVICE_FAMILY in the xcode project. Note that if you target universal (which is the default) you will need to supply screen shots for both iPhone and iPad or your app may be rejected.
 
 Examples:
 
@@ -384,7 +384,7 @@ NOTE: Most of the time, you do NOT want to set this directly.
 
 Attributes(type) <br/> <span class="sub-header">Only for platform:</span> | Description
 ----------------- | ------------
-name(string) | *Required* <br/> The name of the plugin to enable.
+name<br/>{% cdv_vartype string %} | *Required* <br/> The name of the plugin to enable.
 
 
 ### param
@@ -392,7 +392,7 @@ Used to specify certain plugin parameters such as: what package to retrieve the 
 
 Attributes(type) <br/> <span class="sub-header">Only for platform:</span> | Description
 ----------------- | ------------
-name(string) <br/> {% cdv_platform ios %} {% cdv_platform android %} | *Required* <br/> Allowed values: android-package, ios-package, onload. <br/>  'ios-package' and 'android-package' are used to specify the name of the package (as specified by the 'value' attribute) to be used to initialize the plugin code, while 'onload' is used to specify whether the corresponding plugin (as specified in the 'value' attribute) is to be instantiated when the controller is initialized.
+name<br/>{% cdv_vartype string %} {% cdv_platform ios %} {% cdv_platform android %} | *Required* <br/> Allowed values: android-package, ios-package, onload. <br/>  'ios-package' and 'android-package' are used to specify the name of the package (as specified by the 'value' attribute) to be used to initialize the plugin code, while 'onload' is used to specify whether the corresponding plugin (as specified in the 'value' attribute) is to be instantiated when the controller is initialized.
 value(string or boolean) <br/> {% cdv_platform ios %} {% cdv_platform android %} | *Required* <br/>  Specifies the name of the package to be used to initialize the plugin code (when the 'name' attribute is android-package or ios-package), specifies the name of the plugin to be loaded during controller initialization (when 'name' attribute is set to 'onload').
 
 
@@ -417,7 +417,7 @@ When using the CLI to build applications, it is sometimes necessary to specify p
 
 Attributes(type) <br/> <span class="sub-header">Only for platform:</span> | Description
 ----------------- | ------------
-name(string) | *Required* <br/> The platform whose preferences are being defined.
+name<br/>{% cdv_vartype string %} | *Required* <br/> The platform whose preferences are being defined.
 
 Examples:
 
@@ -435,8 +435,8 @@ default Cordova functionality. See [Hooks Guide](../guide/appdev/hooks/index.htm
 
 Attributes(type) <br/> <span class="sub-header">Only for platform:</span> | Description
 ----------------- | ------------
-type(string) | *Required* <br/> Specifies the action during which the custom script is to be called.
-src(string) | *Required* <br/> Specifies the location of the script to be called when a specific action occurs.
+type<br/>{% cdv_vartype string %} | *Required* <br/> Specifies the action during which the custom script is to be called.
+src<br/>{% cdv_vartype string %} | *Required* <br/> Specifies the location of the script to be called when a specific action occurs.
 
 Examples:
 
@@ -450,8 +450,8 @@ This tag installs resource files into your platform, and is similar to the same 
 
 Attributes(type) <br/> <span class="sub-header">Only for platform:</span> | Description
 ---------------- | ------------
-src(string) <br/> {% cdv_platform ios %} {% cdv_platform android %}| *Required* <br/> Location of the file relative to `config.xml`.
-target(string) | Path to where the file will be copied in your directory.
+src<br/>{% cdv_vartype string %} {% cdv_platform ios %} {% cdv_platform android %}| *Required* <br/> Location of the file relative to `config.xml`.
+target<br/>{% cdv_vartype string %} | Path to where the file will be copied in your directory.
 
 Examples:
 

--- a/www/static/css-src/main.scss
+++ b/www/static/css-src/main.scss
@@ -234,6 +234,47 @@ code {
     width: 21px;
 }
 
+.cdv-var-type {
+    display: inline-block;
+    font-size: 1.2rem;
+    padding: 5px;
+    border-radius: 5px;
+    height: 25px;
+
+    background-color: #bfbfbf;
+    color: #333333;
+
+    &.number {
+        background-color: #3ce4c5;
+        color: #333333;
+    }
+
+    &.string {
+        background-color: #3ccde4;
+        color: #333333;
+    }
+
+    &.boolean {
+        background-color: #3c78e4;
+        color: #ffffff;
+    }
+
+    &.object {
+        background-color: #3c51e4;
+        color: #ffffff;
+    }
+
+    &.float {
+        background-color: #7c3ce4;
+        color: #ffffff;
+    }
+
+    &.array {
+        background-color: #b33ce4;
+        color: #333333;
+    }
+}
+
 @import 'home';
 @import 'blog';
 @import 'plugins';


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Distinguish variable type with better tagging design.

### Description
<!-- Describe your changes in detail -->

Added Liquid Tag for var types & CSS styling.

Usage :`{% cdv_vartype <type> %}`
Example: `{% cdv_vartype string %}`

**Valid options:**

* `number`
* `string`
* `boolean`
* `object`
* `float`
* `array`

Anything else provided gets a grey tag. For example `Semver`, `Url` etc. 

<img width="722" alt="tags-newline" src="https://github.com/apache/cordova-docs/assets/1029107/e26a63d5-1272-4971-880b-72a98961fcd3">

### Testing
<!-- Please describe in detail how you tested your changes. -->

`npm run serve`
