### PR TITLE
Updates to Norman Breau's profile

### DIFF
--- a/www/_members/normanbreau.md
+++ b/www/_members/normanbreau.md
@@ -1,9 +1,8 @@
 ---
 name: Norman Breau
-subtitle: "<strong>PMC Member</strong> since Aug. 2019 and App developer"
+subtitle: "<strong>PMC Member</strong> since Aug. 2019"
 imageurl: https://avatars.githubusercontent.com/u/11200662?s=256&v=4
-twitter: https://twitter.com/NormanBreau
 homepage: https://breautek.com
 ---
 
-At his day job, he maintains road asset management software that runs on mobile devices powered by Cordova. During his free time he contributes to Apache by helping manage tickets, providing support on Slack, and providing patches when possible.
+At his day job, he maintains road asset management software that runs on mobile devices powered by Cordova. During his free time he contributes to Apache by helping manage tickets, providing support on Apache Cordova Discussions, and providing patches when possible.


### PR DESCRIPTION
Just made a few updates to my profile on the Teams page.

- Removed twitter link since I deactivated my account there.
- Removed "and App developer" just because it sounds weird grammatically.
- Replaced Slack reference with Apache Cordova Discussions. 