### PR TITLE
Two corrections to the "Icons" page

### DIFF
--- a/www/docs/en/dev/config_ref/images.md
+++ b/www/docs/en/dev/config_ref/images.md
@@ -34,7 +34,7 @@ When working in the CLI you can define application icon(s) via the `<icon>` elem
 If you do not specify an icon, the Apache Cordova logo is used.
 
 ```xml
-    <icon src="res/ios/icon.png" platform="ios" width="57" height="57" density="mdpi" />
+    <icon src="res/ios/icon.png" platform="ios" width="57" height="57" />
 ```
 
 Attributes    | Description
@@ -43,7 +43,7 @@ src           | *Required* <br/> Location of the image file, relative to your pr
 platform      | *Optional* <br/> Target platform
 width         | *Optional* <br/> Icon width in pixels
 height        | *Optional* <br/> Icon height in pixels
-target        | *Optional* <br/> {% cdv_platform electron %} <br/> Set target to supply unique icons for `application` and `installer`
+target        | *Optional* <br/> {% cdv_platform electron %} <br/> Set target to supply unique icons for `app` and `installer`
 
 The following configuration can be used to define a single default icon
 which will be used for all platforms.


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

https://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

"Icons" page (iOS and Electron)

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

1) The "`density`" parameter is for Android not for iOS
2) The correct value is "`app`" not "`application`"


### Description
<!-- Describe your changes in detail -->

1) Removed "`density`" from the example
2) Corrected from "`application`" to "`app`"

### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
