### PR TITLE
Fix DOAP syntax

### DIFF
--- a/www/infra/doap_Cordova.rdf
+++ b/www/infra/doap_Cordova.rdf
@@ -2,8 +2,8 @@
 <?xml-stylesheet type="text/xsl"?>
 <rdf:RDF xml:lang="en"
          xmlns="http://usefulinc.com/ns/doap#"
-         xmlns:rdf="https://www.w3.org/1999/02/22-rdf-syntax-ns#"
-         xmlns:asfext="https://projects.apache.org/ns/asfext#"
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:asfext="http://projects.apache.org/ns/asfext#"
          xmlns:foaf="http://xmlns.com/foaf/0.1/">
 <!--
     Licensed to the Apache Software Foundation (ASF) under one or more


### PR DESCRIPTION
### Platforms affected

### Motivation and Context

Some RDF tools trip on the Cordova DOAP

### Description

The XML namespace prefix needs to match exactly, and the official namespace is specified as `http`, so we need to follow that.

### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
