### PR TITLE
fix: Remove pod http attribute from docs

### DIFF
--- a/www/docs/en/dev/plugin_ref/spec.md
+++ b/www/docs/en/dev/plugin_ref/spec.md
@@ -556,7 +556,6 @@ branch<br />{% cdv_vartype string %} | Pod `branch` option.
 tag<br />{% cdv_vartype string %} | Pod `tag` option.
 commit<br />{% cdv_vartype string %} | Pod `commit` option.
 configurations<br />{% cdv_vartype string %} | Pod `configurations` option. For multiple values, separate them with a comma.
-http<br />{% cdv_vartype string %} | Pod `http` option.
 path<br />{% cdv_vartype string %} | Pod `path` option. Pod located on the local file system.
 options<br />{% cdv_vartype string %} | Pod options declared in raw format. If declared, the other Pod options are overwritten.<br/>Example: `options=":git => 'https://github.com/Alamofire/Alamofire.git', :tag => '3.1.1'"`
 


### PR DESCRIPTION
### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/apache/cordova-ios/issues/916


### Description
<!-- Describe your changes in detail -->
Removed the `http` option from the pod documentation. This is not a valid option for a pod declaration in a Podfile, and has never actually been handled by cordova-ios.

### Checklist
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
