### PR TITLE
doc(android): document ZSH setup for macOS Catalina and newer

### DIFF
--- a/www/docs/en/dev/guide/platforms/android/index.md
+++ b/www/docs/en/dev/guide/platforms/android/index.md
@@ -282,29 +282,48 @@ It is also recommended to update the `PATH` environment variable to include the 
 
 _**Note:** The directories above are generally located in the Android SDK ROOT._
 
-#### macOS and Linux
+#### Linux and macOS
 
-On a Mac or Linux, with a text editor, create or modify the `~/.bash_profile` file.
+On Linux or macOS versions prior to Catalina, use any text editor to create or modify the `~/.bash_profile` file.
+<br>On macOS Catalina and newer, create or modify the `~/.zprofile` file, as the default shell has changed.
 
-To set an environment variable, add a line that uses `export` like so (substitute the path with your local installation):
+Add the following line to your shell's profile to set up the `ANDROID_HOME` environment variable.
+    
+**Linux:**
 
 ```bash
-export ANDROID_HOME=/Development/android-sdk/
+export ANDROID_HOME=~/Android/Sdk
 ```
 
-To update your `PATH`, add a line resembling the following (substitute the paths with your local Android SDK installation's location):
+**macOS:**
+
+```bash
+export ANDROID_HOME=~/Library/Android/sdk
+```
+
+The above examples point to the standard paths where the Android SDK is typically stored. Depending on your environment configuration, the path may differ. Be sure to confirm that the path exist or adjust them to match your local installation.
+
+After setting the `ANDROID_HOME` environment variable, update the `PATH` variable to include directories containing various Android-related binaries.
 
 ```bash
 export PATH=$PATH:$ANDROID_HOME/platform-tools/
 export PATH=$PATH:$ANDROID_HOME/cmdline-tools/latest/bin/
-export PATH=$PATH:$ANDROID_HOME/build-tools
+export PATH=$PATH:$ANDROID_HOME/build-tools/
 export PATH=$PATH:$ANDROID_HOME/emulator/
 ```
 
 Reload your terminal to see this change reflected or run the following command:
 
+**Linux and macOS older then Catalina:**
+
 ```bash
 source ~/.bash_profile
+```
+
+**macOS Catalina and newer:**
+
+```bash
+source ~/.zprofile
 ```
 
 #### Windows


### PR DESCRIPTION
On macOS Catalina and newer, Apple switched from Bash to ZSH. The new file for ".bash_profile" is ".zprofile".

Also the AnroidSDK path is different on a current macOS with the latest Android Studio, but I don't know since when this was changed, or if it was always like this.

### Platforms affected
Android on macOS

### Motivation and Context
Environment variables on newer macOS system must stored on `.zprofile` instead of `.bash_profile`

### Description

### Testing

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
