### PR TITLE
doc: update default description for <access> allowlist

### DIFF
--- a/www/docs/en/11.x/guide/appdev/allowlist/index.md
+++ b/www/docs/en/11.x/guide/appdev/allowlist/index.md
@@ -58,7 +58,7 @@ In `config.xml`, add `<access>` tags, like this:
 <access origin="*" />
 ```
 
-Without any `<access>` tags, only requests to `file://` URLs are allowed. However, the default Cordova application includes `<access origin="*">` by default.
+Without any `<access>` tags, only requests to the location where the app content is served are allowed.
 
 Note: Allow List cannot block network redirects from a allow listed remote website (i.e. `http` or `https`) to a non-allowlisted website. Use CSP rules to mitigate redirects to non-allowlisted websites for webviews that support CSP.
 

--- a/www/docs/en/12.x/guide/appdev/allowlist/index.md
+++ b/www/docs/en/12.x/guide/appdev/allowlist/index.md
@@ -58,7 +58,7 @@ In `config.xml`, add `<access>` tags, like this:
 <access origin="*" />
 ```
 
-Without any `<access>` tags, only requests to `file://` URLs are allowed. However, the default Cordova application includes `<access origin="*">` by default.
+Without any `<access>` tags, only requests to the location where the app content is served are allowed.
 
 Note: Allow List cannot block network redirects from a allow listed remote website (i.e. `http` or `https`) to a non-allowlisted website. Use CSP rules to mitigate redirects to non-allowlisted websites for webviews that support CSP.
 

--- a/www/docs/en/dev/guide/appdev/allowlist/index.md
+++ b/www/docs/en/dev/guide/appdev/allowlist/index.md
@@ -58,7 +58,7 @@ In `config.xml`, add `<access>` tags, like this:
 <access origin="*" />
 ```
 
-Without any `<access>` tags, only requests to `file://` URLs are allowed. However, the default Cordova application includes `<access origin="*">` by default.
+Without any `<access>` tags, only requests to the location where the app content is served are allowed.
 
 Note: Allow List cannot block network redirects from a allow listed remote website (i.e. `http` or `https`) to a non-allowlisted website. Use CSP rules to mitigate redirects to non-allowlisted websites for webviews that support CSP.
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

https://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Fixes #1337

### Description
<!-- Describe your changes in detail -->

Starting from Cordova-CLI 11, the default Cordova app's `config.xml` no longer sets `<access origin="*">`.

This PR removes that statement and updates the explanation regarding which requests are allowed when the `access` tag is not defined.

Cordova-CLI 11 depends on Cordova-Lib 11, which contains a list of pinned platform versions. At these pinned versions, both Cordova-iOS and Cordova-Android support custom schemes, allowing app content to be served from either the `file` protocol or a custom scheme.

### Testing
<!-- Please describe in detail how you tested your changes. -->

N/A

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
