### PR TITLE
doc: update version pattern <cli version>-<year>.<month>

### DIFF
--- a/doc/working-on-docs.md
+++ b/doc/working-on-docs.md
@@ -15,8 +15,6 @@ The following command can quickly sync the `dev` docs with the current latest do
 npm run update-docs
 ```
 
-Read more [here](https://github.com/apache/cordova-docs/blob/master/gulpfile.js#L212).
-
 ## Create new snapshot from `dev`
 
 The following commands can be used to create a new snapshot of `dev` docs:

--- a/doc/working-on-docs.md
+++ b/doc/working-on-docs.md
@@ -7,24 +7,68 @@
 * This can also be executed via `gulpfile.js` task `fetch`, by running `gulp fetch` which pulls in the files to `dev/en/{file dest}`.
 * Most auto-generated files have a comment tag at the top of the file to indicate that they come from elsewhere.
 
-## Update latest (x.y) from `dev`
+## Update current docs from `dev`
 
-Normal build doesn't update latest (7.x) from dev version of docs. You will need to do this manually using `gulp snapshot`. Read more [here](https://github.com/apache/cordova-docs/blob/master/gulpfile.js#L212).
+The following command can quickly sync the `dev` docs with the current latest docs:
 
-## Create new version of the docs
+```bash
+npm run update-docs
+```
 
-To increment the documentation version (e.g. `X.X.X`, either use the gulp task:
+Read more [here](https://github.com/apache/cordova-docs/blob/master/gulpfile.js#L212).
 
-    gulp newversion --version X.X.X
+## Create new snapshot from `dev`
 
-or manually run the `incrementversion.js` script:
+The following commands can be used to create a new snapshot of `dev` docs:
 
-    node ./tools/bin/incrementversion.js www/docs X.X.X
+```bash
+npx gulp newversion
+npx gulp newversion --bumpCli
+```
 
-To only run for a specific language (__this should only happen when translation is intentionally left out for a given version__), specify the language to the Gulp task as follows:
+Please read the section, [Preparing Doc Release Scenarios](#Preparing-Doc-Release-Scenarios), below to understand which command fits your scenario.
 
-    gulp newversion --version X.X.X --language YY
+## Preparing Doc Release Scenarios
 
-or manually, to the script, as follows:
+When preparing to release docs, there are two things to be aware of, the version of Cordova CLI and if the changes warrants for a new doc version.
 
-    node ./tools/bin/incrementversion.js www/docs X.X.X YY
+Here are a few scenarios that will help decide how if we are updating an existing snapshot of creating a new one.
+
+1. Are we preparing to release new docs because there was a major release of Cordova CLI?
+
+    If the answer is **yes**, then we will be creating a new version of docs with the following command:
+
+    ```bash
+    npx gulp newversion --bumpCli
+    ```
+
+    If the current released docs version is `12.x` and we are preparing for Cordova-CLI 13.x, the above command will create `13.x-2024.10`.
+
+    > Notice: The year and month will be appended automatically.
+
+2. Are we preparing to release new docs because there was a minor or patch release of Cordova CLI?
+
+    If the answer is **yes**, then we do not need to make a new snapshot. In this case, we can update an existing snapshot with the following command:
+
+    ```bash
+    npm run update-docs
+    ```
+
+    > Notice: In this scenario we are expecting the version to already exist. If it was missing, then we would have to create a new snapshot but in most cases it should never be missing.
+
+3. Are we preparing docs for a major release to one or more of Cordova's platforms while the CLI version was unchanged?
+
+    If the answer is **yes**, then we need to make a new snapshot, but we do not need to bump the CLI major. We can do this with the following command:
+
+    ```bash
+    npx gulp newversion
+    ```
+
+    If the current doc snapshot is `12.x`, then the above command will create a new snapshot with the same CLI major version but the appended date will be different.
+
+    E.g. `12.x-2024.10`
+
+    > Notice:
+    >
+    > *`12.x` and older does not have date appended. Any newly created snapshots will append the date value.
+    > * If we already have `12.x-2024.10` and the month is still the same, we should use senario 2. `npm run update-docs`.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -67,9 +67,17 @@ const YAML_FRONT_MATTER = '---\n---\n';
 const WATCH_INTERVAL = 1000; // in milliseconds
 const VERSION_VAR_NAME = 'latest_docs_version';
 const LATEST_DOCS_VERSION = fs.readFileSync(VERSION_FILE, 'utf-8').trim();
-const NEXT_DOCS_VERSION = nextversion.getNextVersion(LATEST_DOCS_VERSION);
-const LANGUAGES = listdirsSync(DOCS_DIR);
 
+// '--bumpCli' flag hat determins if the next version is major CLI or new date release.
+const bumpCli = argv.bumpCli || false;
+const NEXT_DOCS_VERSION = nextversion.getNextVersion(bumpCli, LATEST_DOCS_VERSION);
+
+if (fs.existsSync(path.join(DOCS_DIR, 'en', NEXT_DOCS_VERSION))) {
+    logger(styleText(['red'], '[ERROR] ')) + `The targeted docs version ""${NEXT_DOCS_VERSION}"" already exist. Are you trying to update the existing snapshot? Use "npm run update-docs".`);
+    process.exit(1);
+}
+
+const LANGUAGES = listdirsSync(DOCS_DIR);
 const PROD_BY_DEFAULT = false;
 
 // compute/get/set/adjust passed options

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -71,12 +71,6 @@ const LATEST_DOCS_VERSION = fs.readFileSync(VERSION_FILE, 'utf-8').trim();
 // '--bumpCli' flag hat determins if the next version is major CLI or new date release.
 const bumpCli = argv.bumpCli || false;
 const NEXT_DOCS_VERSION = nextversion.getNextVersion(bumpCli, LATEST_DOCS_VERSION);
-
-if (fs.existsSync(path.join(DOCS_DIR, 'en', NEXT_DOCS_VERSION))) {
-    logger(styleText(['red'], '[ERROR] ')) + `The targeted docs version ""${NEXT_DOCS_VERSION}"" already exist. Are you trying to update the existing snapshot? Use "npm run update-docs".`);
-    process.exit(1);
-}
-
 const LANGUAGES = listdirsSync(DOCS_DIR);
 const PROD_BY_DEFAULT = false;
 
@@ -389,6 +383,11 @@ module.exports.lint = function lint () {
 };
 
 module.exports.newversion = gulp.series(fetch, function newVersion (done) {
+    if (fs.existsSync(path.join(DOCS_DIR, 'en', NEXT_DOCS_VERSION))) {
+        logger(styleText(['red'], '[ERROR] ') + `The targeted docs version ""${NEXT_DOCS_VERSION}"" already exist. Are you trying to update the existing snapshot? Use "npm run update-docs".`);
+        process.exit(1);
+    }
+
     copyDocsVersion('dev', NEXT_DOCS_VERSION, function (error) {
         if (error) {
             console.error(error);

--- a/tools/bin/nextversion.js
+++ b/tools/bin/nextversion.js
@@ -17,7 +17,9 @@
 
 'use strict';
 
-function getNextVersion (previousVersion) {
+function getNextVersion (bumpCli, previousVersion) {
+    bumpCli = bumpCli || false;
+
     // get previous version number
     // NOTE:
     //      only versions of the form N.x are accepted
@@ -28,7 +30,9 @@ function getNextVersion (previousVersion) {
 
     // get next major version
     const previousMajor = previousVersionMatch[1];
-    const nextMajor = parseInt(previousMajor) + 1;
+    const nextMajor = bumpCli
+        ? parseInt(previousMajor) + 1
+        : parseInt(previousMajor);
 
     // create next version
     const currentDate = new Date();
@@ -41,7 +45,9 @@ function getNextVersion (previousVersion) {
 
 function main () {
     // get arg
-    const previousVersion = process.argv[2];
+    const shouldBumpCli = process.argv[2] || false;
+    const previousVersion = process.argv[3];
+
     if (!previousVersion) {
         console.error('no version specified');
         process.exit(1);
@@ -50,7 +56,7 @@ function main () {
     // try to get the next version
     let nextVersion = null;
     try {
-        nextVersion = getNextVersion(previousVersion);
+        nextVersion = getNextVersion(shouldBumpCli, previousVersion);
     } catch (e) {
         console.error(e);
         process.exit(1);

--- a/tools/bin/nextversion.js
+++ b/tools/bin/nextversion.js
@@ -21,7 +21,7 @@ function getNextVersion (previousVersion) {
     // get previous version number
     // NOTE:
     //      only versions of the form N.x are accepted
-    const previousVersionMatch = previousVersion.match(/^(\d+)\.x$/);
+    const previousVersionMatch = previousVersion.match(/^(\d+)\.x(-\d{4}.\d{2})?$/);
     if (!previousVersionMatch) {
         throw Error('invalid version');
     }
@@ -31,7 +31,10 @@ function getNextVersion (previousVersion) {
     const nextMajor = parseInt(previousMajor) + 1;
 
     // create next version
-    const nextVersion = nextMajor + '.x';
+    const currentDate = new Date();
+    const currentYear = currentDate.getFullYear();
+    const currentMonth = (currentDate.getMonth() + 1).toString().padStart(2, '0');
+    const nextVersion = `${nextMajor}.x-${currentYear}.${currentMonth}`;
 
     return nextVersion;
 }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

https://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Support new versioning pattern for docs.

### Description
<!-- Describe your changes in detail -->

Updated tooling that updates current released docs and creating new snapshots to support current and new version pattern.

New pattern: `<cli version>-<year{4}>.<month{2}>`

Example: `12.x-2024.10`

### Testing
<!-- Please describe in detail how you tested your changes. -->

`npx gulp newversion`

* Creates new snapshot
* Updates `VERSION` file with new current version
* with `--bumpCli` flag
  * Confirm new snapshot to contain directory with new pattern `13.x-2024.10`
  * Confirm new snapshot to create new toc file with new pattern `en_13-x-2024-10-src.yml`
* without `--bumpCli` flag
  * Confirm new snapshot to contain directory with new pattern `12.x-2024.10`
  * Confirm new snapshot to create new toc file with new pattern `en_12-x-2024-10-src.yml`
* without `--bumpCli` flag and snapshot already existed
  * Errors and stops with error message: `[ERROR] The targeted docs version "12.x-2024.10" already exist. Are you trying to update the existing snapshot? Use "npm run update-docs".` 

`npm run update-docs`

* Existing version pattern
  * Confirm that `12.x` is updated based on version defined in `VERSION`
* New version pattern
  * Confirm that `13.x-2024.10` is updated based on version defined in `VERSION`


### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
