### PR TITLE
chore(docs): Strip Google Analytics from archived docs

### DIFF
--- a/archive/docs/de/10.x/config_ref/images.html
+++ b/archive/docs/de/10.x/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/config_ref/index.html
+++ b/archive/docs/de/10.x/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/cordova/events/events.backbutton.html
+++ b/archive/docs/de/10.x/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/cordova/events/events.deviceready.html
+++ b/archive/docs/de/10.x/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/cordova/events/events.endcallbutton.html
+++ b/archive/docs/de/10.x/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/cordova/events/events.html
+++ b/archive/docs/de/10.x/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/cordova/events/events.menubutton.html
+++ b/archive/docs/de/10.x/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/cordova/events/events.pause.html
+++ b/archive/docs/de/10.x/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/cordova/events/events.resume.html
+++ b/archive/docs/de/10.x/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/cordova/events/events.searchbutton.html
+++ b/archive/docs/de/10.x/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/cordova/events/events.startcallbutton.html
+++ b/archive/docs/de/10.x/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/de/10.x/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/de/10.x/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/cordova/storage/storage.html
+++ b/archive/docs/de/10.x/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/guide/appdev/hooks/index.html
+++ b/archive/docs/de/10.x/guide/appdev/hooks/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/guide/appdev/privacy/index.html
+++ b/archive/docs/de/10.x/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/guide/appdev/security/index.html
+++ b/archive/docs/de/10.x/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/guide/appdev/whitelist/index.html
+++ b/archive/docs/de/10.x/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/guide/cli/index.html
+++ b/archive/docs/de/10.x/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/guide/hybrid/plugins/index.html
+++ b/archive/docs/de/10.x/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/guide/hybrid/webviews/index.html
+++ b/archive/docs/de/10.x/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/guide/next/index.html
+++ b/archive/docs/de/10.x/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/guide/overview/index.html
+++ b/archive/docs/de/10.x/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/de/10.x/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/de/10.x/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/guide/platforms/android/config.html
+++ b/archive/docs/de/10.x/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/guide/platforms/android/index.html
+++ b/archive/docs/de/10.x/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/guide/platforms/android/plugin.html
+++ b/archive/docs/de/10.x/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/guide/platforms/android/webview.html
+++ b/archive/docs/de/10.x/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/guide/platforms/blackberry/config.html
+++ b/archive/docs/de/10.x/guide/platforms/blackberry/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/guide/platforms/blackberry10/config.html
+++ b/archive/docs/de/10.x/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/guide/platforms/blackberry10/home.html
+++ b/archive/docs/de/10.x/guide/platforms/blackberry10/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/guide/platforms/blackberry10/index.html
+++ b/archive/docs/de/10.x/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/de/10.x/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/de/10.x/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/guide/platforms/blackberry10/upgrade.html
+++ b/archive/docs/de/10.x/guide/platforms/blackberry10/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/guide/platforms/ios/config.html
+++ b/archive/docs/de/10.x/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/guide/platforms/ios/index.html
+++ b/archive/docs/de/10.x/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/guide/platforms/ios/plugin.html
+++ b/archive/docs/de/10.x/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/guide/platforms/ios/tools.html
+++ b/archive/docs/de/10.x/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/guide/platforms/ios/upgrading.html
+++ b/archive/docs/de/10.x/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/guide/platforms/ios/webview.html
+++ b/archive/docs/de/10.x/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/guide/platforms/ubuntu/index.html
+++ b/archive/docs/de/10.x/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/guide/platforms/win8/index.html
+++ b/archive/docs/de/10.x/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/guide/platforms/win8/plugin.html
+++ b/archive/docs/de/10.x/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/guide/platforms/win8/upgrading.html
+++ b/archive/docs/de/10.x/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/guide/platforms/wp8/home.html
+++ b/archive/docs/de/10.x/guide/platforms/wp8/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/guide/platforms/wp8/index.html
+++ b/archive/docs/de/10.x/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/guide/platforms/wp8/parallels.html
+++ b/archive/docs/de/10.x/guide/platforms/wp8/parallels.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/guide/platforms/wp8/plugin.html
+++ b/archive/docs/de/10.x/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/de/10.x/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/guide/platforms/wp8/upgrading.html
+++ b/archive/docs/de/10.x/guide/platforms/wp8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/guide/platforms/wp8/webview.html
+++ b/archive/docs/de/10.x/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/guide/support/index.html
+++ b/archive/docs/de/10.x/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/index.html
+++ b/archive/docs/de/10.x/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/de/10.x/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/plugin_ref/plugman.html
+++ b/archive/docs/de/10.x/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/10.x/plugin_ref/spec.html
+++ b/archive/docs/de/10.x/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/config_ref/images.html
+++ b/archive/docs/de/3.1.0/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/config_ref/index.html
+++ b/archive/docs/de/3.1.0/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/accelerometer/acceleration/acceleration.html
+++ b/archive/docs/de/3.1.0/cordova/accelerometer/acceleration/acceleration.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/accelerometer/accelerometer.clearWatch.html
+++ b/archive/docs/de/3.1.0/cordova/accelerometer/accelerometer.clearWatch.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/accelerometer/accelerometer.getCurrentAcceleration.html
+++ b/archive/docs/de/3.1.0/cordova/accelerometer/accelerometer.getCurrentAcceleration.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/accelerometer/accelerometer.html
+++ b/archive/docs/de/3.1.0/cordova/accelerometer/accelerometer.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/accelerometer/accelerometer.watchAcceleration.html
+++ b/archive/docs/de/3.1.0/cordova/accelerometer/accelerometer.watchAcceleration.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/accelerometer/parameters/accelerometerError.html
+++ b/archive/docs/de/3.1.0/cordova/accelerometer/parameters/accelerometerError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/accelerometer/parameters/accelerometerOptions.html
+++ b/archive/docs/de/3.1.0/cordova/accelerometer/parameters/accelerometerOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/accelerometer/parameters/accelerometerSuccess.html
+++ b/archive/docs/de/3.1.0/cordova/accelerometer/parameters/accelerometerSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/camera/camera.getPicture.html
+++ b/archive/docs/de/3.1.0/cordova/camera/camera.getPicture.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/camera/camera.html
+++ b/archive/docs/de/3.1.0/cordova/camera/camera.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/compass/compass.clearWatch.html
+++ b/archive/docs/de/3.1.0/cordova/compass/compass.clearWatch.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/compass/compass.clearWatchFilter.html
+++ b/archive/docs/de/3.1.0/cordova/compass/compass.clearWatchFilter.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/compass/compass.getCurrentHeading.html
+++ b/archive/docs/de/3.1.0/cordova/compass/compass.getCurrentHeading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/compass/compass.html
+++ b/archive/docs/de/3.1.0/cordova/compass/compass.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/compass/compass.watchHeading.html
+++ b/archive/docs/de/3.1.0/cordova/compass/compass.watchHeading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/compass/compass.watchHeadingFilter.html
+++ b/archive/docs/de/3.1.0/cordova/compass/compass.watchHeadingFilter.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/compass/parameters/compassError.html
+++ b/archive/docs/de/3.1.0/cordova/compass/parameters/compassError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/compass/parameters/compassHeading.html
+++ b/archive/docs/de/3.1.0/cordova/compass/parameters/compassHeading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/compass/parameters/compassOptions.html
+++ b/archive/docs/de/3.1.0/cordova/compass/parameters/compassOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/compass/parameters/compassSuccess.html
+++ b/archive/docs/de/3.1.0/cordova/compass/parameters/compassSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/connection/connection.html
+++ b/archive/docs/de/3.1.0/cordova/connection/connection.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/connection/connection.type.html
+++ b/archive/docs/de/3.1.0/cordova/connection/connection.type.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/contacts/Contact/contact.html
+++ b/archive/docs/de/3.1.0/cordova/contacts/Contact/contact.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/contacts/ContactAddress/contactaddress.html
+++ b/archive/docs/de/3.1.0/cordova/contacts/ContactAddress/contactaddress.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/contacts/ContactError/contactError.html
+++ b/archive/docs/de/3.1.0/cordova/contacts/ContactError/contactError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/contacts/ContactField/contactfield.html
+++ b/archive/docs/de/3.1.0/cordova/contacts/ContactField/contactfield.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/contacts/ContactFindOptions/contactfindoptions.html
+++ b/archive/docs/de/3.1.0/cordova/contacts/ContactFindOptions/contactfindoptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/contacts/ContactName/contactname.html
+++ b/archive/docs/de/3.1.0/cordova/contacts/ContactName/contactname.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/contacts/ContactOrganization/contactorganization.html
+++ b/archive/docs/de/3.1.0/cordova/contacts/ContactOrganization/contactorganization.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/contacts/contacts.create.html
+++ b/archive/docs/de/3.1.0/cordova/contacts/contacts.create.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/contacts/contacts.html
+++ b/archive/docs/de/3.1.0/cordova/contacts/contacts.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/contacts/parameters/contactError.html
+++ b/archive/docs/de/3.1.0/cordova/contacts/parameters/contactError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/contacts/parameters/contactFields.html
+++ b/archive/docs/de/3.1.0/cordova/contacts/parameters/contactFields.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/contacts/parameters/contactFindOptions.html
+++ b/archive/docs/de/3.1.0/cordova/contacts/parameters/contactFindOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/contacts/parameters/contactSuccess.html
+++ b/archive/docs/de/3.1.0/cordova/contacts/parameters/contactSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/device/device.html
+++ b/archive/docs/de/3.1.0/cordova/device/device.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/device/device.model.html
+++ b/archive/docs/de/3.1.0/cordova/device/device.model.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/device/device.name.html
+++ b/archive/docs/de/3.1.0/cordova/device/device.name.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/events/events.backbutton.html
+++ b/archive/docs/de/3.1.0/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/events/events.batterycritical.html
+++ b/archive/docs/de/3.1.0/cordova/events/events.batterycritical.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/events/events.batterylow.html
+++ b/archive/docs/de/3.1.0/cordova/events/events.batterylow.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/events/events.batterystatus.html
+++ b/archive/docs/de/3.1.0/cordova/events/events.batterystatus.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/events/events.deviceready.html
+++ b/archive/docs/de/3.1.0/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/events/events.endcallbutton.html
+++ b/archive/docs/de/3.1.0/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/events/events.html
+++ b/archive/docs/de/3.1.0/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/events/events.menubutton.html
+++ b/archive/docs/de/3.1.0/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/events/events.offline.html
+++ b/archive/docs/de/3.1.0/cordova/events/events.offline.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/events/events.online.html
+++ b/archive/docs/de/3.1.0/cordova/events/events.online.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/events/events.pause.html
+++ b/archive/docs/de/3.1.0/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/events/events.resume.html
+++ b/archive/docs/de/3.1.0/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/events/events.searchbutton.html
+++ b/archive/docs/de/3.1.0/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/events/events.startcallbutton.html
+++ b/archive/docs/de/3.1.0/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/de/3.1.0/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/de/3.1.0/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/file/directoryentry/directoryentry.html
+++ b/archive/docs/de/3.1.0/cordova/file/directoryentry/directoryentry.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/file/directoryreader/directoryreader.html
+++ b/archive/docs/de/3.1.0/cordova/file/directoryreader/directoryreader.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/file/file.html
+++ b/archive/docs/de/3.1.0/cordova/file/file.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/file/fileentry/fileentry.html
+++ b/archive/docs/de/3.1.0/cordova/file/fileentry/fileentry.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/file/fileerror/fileerror.html
+++ b/archive/docs/de/3.1.0/cordova/file/fileerror/fileerror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/file/fileobj/fileobj.html
+++ b/archive/docs/de/3.1.0/cordova/file/fileobj/fileobj.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/file/filereader/filereader.html
+++ b/archive/docs/de/3.1.0/cordova/file/filereader/filereader.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/file/filesystem/filesystem.html
+++ b/archive/docs/de/3.1.0/cordova/file/filesystem/filesystem.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/file/filetransfer/filetransfer.html
+++ b/archive/docs/de/3.1.0/cordova/file/filetransfer/filetransfer.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/file/filetransfererror/filetransfererror.html
+++ b/archive/docs/de/3.1.0/cordova/file/filetransfererror/filetransfererror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/file/fileuploadoptions/fileuploadoptions.html
+++ b/archive/docs/de/3.1.0/cordova/file/fileuploadoptions/fileuploadoptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/file/fileuploadresult/fileuploadresult.html
+++ b/archive/docs/de/3.1.0/cordova/file/fileuploadresult/fileuploadresult.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/file/filewriter/filewriter.html
+++ b/archive/docs/de/3.1.0/cordova/file/filewriter/filewriter.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/file/localfilesystem/localfilesystem.html
+++ b/archive/docs/de/3.1.0/cordova/file/localfilesystem/localfilesystem.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/file/metadata/metadata.html
+++ b/archive/docs/de/3.1.0/cordova/file/metadata/metadata.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/geolocation/Coordinates/coordinates.html
+++ b/archive/docs/de/3.1.0/cordova/geolocation/Coordinates/coordinates.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/geolocation/Position/position.html
+++ b/archive/docs/de/3.1.0/cordova/geolocation/Position/position.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/geolocation/geolocation.clearWatch.html
+++ b/archive/docs/de/3.1.0/cordova/geolocation/geolocation.clearWatch.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/geolocation/geolocation.getCurrentPosition.html
+++ b/archive/docs/de/3.1.0/cordova/geolocation/geolocation.getCurrentPosition.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/geolocation/geolocation.html
+++ b/archive/docs/de/3.1.0/cordova/geolocation/geolocation.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/geolocation/geolocation.watchPosition.html
+++ b/archive/docs/de/3.1.0/cordova/geolocation/geolocation.watchPosition.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/geolocation/parameters/geolocation.options.html
+++ b/archive/docs/de/3.1.0/cordova/geolocation/parameters/geolocation.options.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/geolocation/parameters/geolocationError.html
+++ b/archive/docs/de/3.1.0/cordova/geolocation/parameters/geolocationError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/geolocation/parameters/geolocationSuccess.html
+++ b/archive/docs/de/3.1.0/cordova/geolocation/parameters/geolocationSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/globalization/GlobalizationError/globalizationerror.html
+++ b/archive/docs/de/3.1.0/cordova/globalization/GlobalizationError/globalizationerror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/globalization/globalization.dateToString.html
+++ b/archive/docs/de/3.1.0/cordova/globalization/globalization.dateToString.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/globalization/globalization.getCurrencyPattern.html
+++ b/archive/docs/de/3.1.0/cordova/globalization/globalization.getCurrencyPattern.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/globalization/globalization.getDateNames.html
+++ b/archive/docs/de/3.1.0/cordova/globalization/globalization.getDateNames.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/globalization/globalization.getDatePattern.html
+++ b/archive/docs/de/3.1.0/cordova/globalization/globalization.getDatePattern.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/globalization/globalization.getFirstDayOfWeek.html
+++ b/archive/docs/de/3.1.0/cordova/globalization/globalization.getFirstDayOfWeek.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/globalization/globalization.getLocaleName.html
+++ b/archive/docs/de/3.1.0/cordova/globalization/globalization.getLocaleName.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/globalization/globalization.getNumberPattern.html
+++ b/archive/docs/de/3.1.0/cordova/globalization/globalization.getNumberPattern.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/globalization/globalization.getPreferredLanguage.html
+++ b/archive/docs/de/3.1.0/cordova/globalization/globalization.getPreferredLanguage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/globalization/globalization.html
+++ b/archive/docs/de/3.1.0/cordova/globalization/globalization.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/globalization/globalization.isDayLightSavingsTime.html
+++ b/archive/docs/de/3.1.0/cordova/globalization/globalization.isDayLightSavingsTime.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/globalization/globalization.numberToString.html
+++ b/archive/docs/de/3.1.0/cordova/globalization/globalization.numberToString.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/globalization/globalization.stringToDate.html
+++ b/archive/docs/de/3.1.0/cordova/globalization/globalization.stringToDate.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/globalization/globalization.stringToNumber.html
+++ b/archive/docs/de/3.1.0/cordova/globalization/globalization.stringToNumber.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/inappbrowser/inappbrowser.html
+++ b/archive/docs/de/3.1.0/cordova/inappbrowser/inappbrowser.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/media/capture/CaptureErrorCB.html
+++ b/archive/docs/de/3.1.0/cordova/media/capture/CaptureErrorCB.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/media/capture/ConfigurationData.html
+++ b/archive/docs/de/3.1.0/cordova/media/capture/ConfigurationData.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/media/capture/MediaFile.html
+++ b/archive/docs/de/3.1.0/cordova/media/capture/MediaFile.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/media/capture/MediaFileData.html
+++ b/archive/docs/de/3.1.0/cordova/media/capture/MediaFileData.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/media/capture/capture.html
+++ b/archive/docs/de/3.1.0/cordova/media/capture/capture.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/media/capture/captureAudio.html
+++ b/archive/docs/de/3.1.0/cordova/media/capture/captureAudio.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/media/capture/captureAudioOptions.html
+++ b/archive/docs/de/3.1.0/cordova/media/capture/captureAudioOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/media/capture/captureImage.html
+++ b/archive/docs/de/3.1.0/cordova/media/capture/captureImage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/media/capture/captureImageOptions.html
+++ b/archive/docs/de/3.1.0/cordova/media/capture/captureImageOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/media/capture/captureVideo.html
+++ b/archive/docs/de/3.1.0/cordova/media/capture/captureVideo.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/media/capture/captureVideoOptions.html
+++ b/archive/docs/de/3.1.0/cordova/media/capture/captureVideoOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/media/media.html
+++ b/archive/docs/de/3.1.0/cordova/media/media.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/notification/notification.html
+++ b/archive/docs/de/3.1.0/cordova/notification/notification.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/splashscreen/splashscreen.hide.html
+++ b/archive/docs/de/3.1.0/cordova/splashscreen/splashscreen.hide.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/splashscreen/splashscreen.html
+++ b/archive/docs/de/3.1.0/cordova/splashscreen/splashscreen.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/splashscreen/splashscreen.show.html
+++ b/archive/docs/de/3.1.0/cordova/splashscreen/splashscreen.show.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/storage/database/database.html
+++ b/archive/docs/de/3.1.0/cordova/storage/database/database.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/storage/parameters/display_name.html
+++ b/archive/docs/de/3.1.0/cordova/storage/parameters/display_name.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/storage/parameters/name.html
+++ b/archive/docs/de/3.1.0/cordova/storage/parameters/name.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/storage/parameters/size.html
+++ b/archive/docs/de/3.1.0/cordova/storage/parameters/size.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/storage/parameters/version.html
+++ b/archive/docs/de/3.1.0/cordova/storage/parameters/version.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/storage/sqlerror/sqlerror.html
+++ b/archive/docs/de/3.1.0/cordova/storage/sqlerror/sqlerror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/storage/sqlresultset/sqlresultset.html
+++ b/archive/docs/de/3.1.0/cordova/storage/sqlresultset/sqlresultset.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/storage/sqlresultsetrowlist/sqlresultsetrowlist.html
+++ b/archive/docs/de/3.1.0/cordova/storage/sqlresultsetrowlist/sqlresultsetrowlist.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/storage/sqltransaction/sqltransaction.html
+++ b/archive/docs/de/3.1.0/cordova/storage/sqltransaction/sqltransaction.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/storage/storage.html
+++ b/archive/docs/de/3.1.0/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/cordova/storage/storage.opendatabase.html
+++ b/archive/docs/de/3.1.0/cordova/storage/storage.opendatabase.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/guide/appdev/privacy/index.html
+++ b/archive/docs/de/3.1.0/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/guide/appdev/whitelist/index.html
+++ b/archive/docs/de/3.1.0/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/guide/cli/index.html
+++ b/archive/docs/de/3.1.0/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/guide/hybrid/plugins/index.html
+++ b/archive/docs/de/3.1.0/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/guide/hybrid/webviews/index.html
+++ b/archive/docs/de/3.1.0/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/guide/overview/index.html
+++ b/archive/docs/de/3.1.0/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/guide/platforms/android/config.html
+++ b/archive/docs/de/3.1.0/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/guide/platforms/android/index.html
+++ b/archive/docs/de/3.1.0/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/guide/platforms/android/plugin.html
+++ b/archive/docs/de/3.1.0/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/guide/platforms/android/tools.html
+++ b/archive/docs/de/3.1.0/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/guide/platforms/android/upgrading.html
+++ b/archive/docs/de/3.1.0/guide/platforms/android/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/guide/platforms/android/webview.html
+++ b/archive/docs/de/3.1.0/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/guide/platforms/blackberry/index.html
+++ b/archive/docs/de/3.1.0/guide/platforms/blackberry/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/guide/platforms/blackberry/plugin.html
+++ b/archive/docs/de/3.1.0/guide/platforms/blackberry/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/guide/platforms/blackberry/tools.html
+++ b/archive/docs/de/3.1.0/guide/platforms/blackberry/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/guide/platforms/blackberry10/config.html
+++ b/archive/docs/de/3.1.0/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/guide/platforms/blackberry10/index.html
+++ b/archive/docs/de/3.1.0/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/de/3.1.0/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/de/3.1.0/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/guide/platforms/blackberry10/upgrading.html
+++ b/archive/docs/de/3.1.0/guide/platforms/blackberry10/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/guide/platforms/index.html
+++ b/archive/docs/de/3.1.0/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/guide/platforms/ios/config.html
+++ b/archive/docs/de/3.1.0/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/guide/platforms/ios/index.html
+++ b/archive/docs/de/3.1.0/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/guide/platforms/ios/plugin.html
+++ b/archive/docs/de/3.1.0/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/guide/platforms/ios/tools.html
+++ b/archive/docs/de/3.1.0/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/guide/platforms/ios/upgrading.html
+++ b/archive/docs/de/3.1.0/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/guide/platforms/ios/webview.html
+++ b/archive/docs/de/3.1.0/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/guide/platforms/tizen/index.html
+++ b/archive/docs/de/3.1.0/guide/platforms/tizen/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/guide/platforms/win8/index.html
+++ b/archive/docs/de/3.1.0/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/guide/platforms/win8/tools.html
+++ b/archive/docs/de/3.1.0/guide/platforms/win8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/guide/platforms/win8/upgrading.html
+++ b/archive/docs/de/3.1.0/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/guide/platforms/wp7/index.html
+++ b/archive/docs/de/3.1.0/guide/platforms/wp7/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/guide/platforms/wp8/index.html
+++ b/archive/docs/de/3.1.0/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/guide/platforms/wp8/plugin.html
+++ b/archive/docs/de/3.1.0/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/guide/platforms/wp8/tools.html
+++ b/archive/docs/de/3.1.0/guide/platforms/wp8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/guide/platforms/wp8/upgrading.html
+++ b/archive/docs/de/3.1.0/guide/platforms/wp8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/index.html
+++ b/archive/docs/de/3.1.0/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.1.0/plugin_ref/spec.html
+++ b/archive/docs/de/3.1.0/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/config_ref/images.html
+++ b/archive/docs/de/3.4.0/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/config_ref/index.html
+++ b/archive/docs/de/3.4.0/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/cordova/events/events.backbutton.html
+++ b/archive/docs/de/3.4.0/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/cordova/events/events.deviceready.html
+++ b/archive/docs/de/3.4.0/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/cordova/events/events.endcallbutton.html
+++ b/archive/docs/de/3.4.0/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/cordova/events/events.html
+++ b/archive/docs/de/3.4.0/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/cordova/events/events.menubutton.html
+++ b/archive/docs/de/3.4.0/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/cordova/events/events.pause.html
+++ b/archive/docs/de/3.4.0/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/cordova/events/events.resume.html
+++ b/archive/docs/de/3.4.0/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/cordova/events/events.searchbutton.html
+++ b/archive/docs/de/3.4.0/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/cordova/events/events.startcallbutton.html
+++ b/archive/docs/de/3.4.0/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/de/3.4.0/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/de/3.4.0/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/cordova/plugins/pluginapis.html
+++ b/archive/docs/de/3.4.0/cordova/plugins/pluginapis.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/cordova/storage/storage.html
+++ b/archive/docs/de/3.4.0/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/guide/appdev/privacy/index.html
+++ b/archive/docs/de/3.4.0/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/guide/appdev/whitelist/index.html
+++ b/archive/docs/de/3.4.0/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/guide/cli/index.html
+++ b/archive/docs/de/3.4.0/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/guide/hybrid/plugins/index.html
+++ b/archive/docs/de/3.4.0/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/guide/hybrid/webviews/index.html
+++ b/archive/docs/de/3.4.0/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/guide/overview/index.html
+++ b/archive/docs/de/3.4.0/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/guide/platforms/amazonfireos/config.html
+++ b/archive/docs/de/3.4.0/guide/platforms/amazonfireos/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/guide/platforms/amazonfireos/index.html
+++ b/archive/docs/de/3.4.0/guide/platforms/amazonfireos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/de/3.4.0/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/de/3.4.0/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/guide/platforms/android/config.html
+++ b/archive/docs/de/3.4.0/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/guide/platforms/android/index.html
+++ b/archive/docs/de/3.4.0/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/guide/platforms/android/plugin.html
+++ b/archive/docs/de/3.4.0/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/guide/platforms/android/tools.html
+++ b/archive/docs/de/3.4.0/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/guide/platforms/android/upgrading.html
+++ b/archive/docs/de/3.4.0/guide/platforms/android/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/guide/platforms/android/webview.html
+++ b/archive/docs/de/3.4.0/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/guide/platforms/blackberry/index.html
+++ b/archive/docs/de/3.4.0/guide/platforms/blackberry/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/guide/platforms/blackberry/plugin.html
+++ b/archive/docs/de/3.4.0/guide/platforms/blackberry/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/guide/platforms/blackberry/tools.html
+++ b/archive/docs/de/3.4.0/guide/platforms/blackberry/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/guide/platforms/blackberry/upgrading.html
+++ b/archive/docs/de/3.4.0/guide/platforms/blackberry/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/guide/platforms/blackberry10/config.html
+++ b/archive/docs/de/3.4.0/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/guide/platforms/blackberry10/index.html
+++ b/archive/docs/de/3.4.0/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/de/3.4.0/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/de/3.4.0/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/guide/platforms/index.html
+++ b/archive/docs/de/3.4.0/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/guide/platforms/ios/config.html
+++ b/archive/docs/de/3.4.0/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/guide/platforms/ios/index.html
+++ b/archive/docs/de/3.4.0/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/guide/platforms/ios/plugin.html
+++ b/archive/docs/de/3.4.0/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/guide/platforms/ios/tools.html
+++ b/archive/docs/de/3.4.0/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/guide/platforms/ios/upgrading.html
+++ b/archive/docs/de/3.4.0/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/guide/platforms/ios/webview.html
+++ b/archive/docs/de/3.4.0/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/guide/platforms/tizen/index.html
+++ b/archive/docs/de/3.4.0/guide/platforms/tizen/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/guide/platforms/ubuntu/index.html
+++ b/archive/docs/de/3.4.0/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/guide/platforms/win8/index.html
+++ b/archive/docs/de/3.4.0/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/guide/platforms/win8/tools.html
+++ b/archive/docs/de/3.4.0/guide/platforms/win8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/guide/platforms/win8/upgrading.html
+++ b/archive/docs/de/3.4.0/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/guide/platforms/wp7/index.html
+++ b/archive/docs/de/3.4.0/guide/platforms/wp7/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/guide/platforms/wp8/index.html
+++ b/archive/docs/de/3.4.0/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/guide/platforms/wp8/plugin.html
+++ b/archive/docs/de/3.4.0/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/guide/platforms/wp8/tools.html
+++ b/archive/docs/de/3.4.0/guide/platforms/wp8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/guide/platforms/wp8/upgrading.html
+++ b/archive/docs/de/3.4.0/guide/platforms/wp8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/guide/support/index.html
+++ b/archive/docs/de/3.4.0/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/index.html
+++ b/archive/docs/de/3.4.0/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/plugin_ref/plugman.html
+++ b/archive/docs/de/3.4.0/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.4.0/plugin_ref/spec.html
+++ b/archive/docs/de/3.4.0/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/config_ref/images.html
+++ b/archive/docs/de/3.5.0/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/config_ref/index.html
+++ b/archive/docs/de/3.5.0/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/cordova/events/events.backbutton.html
+++ b/archive/docs/de/3.5.0/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/cordova/events/events.deviceready.html
+++ b/archive/docs/de/3.5.0/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/cordova/events/events.endcallbutton.html
+++ b/archive/docs/de/3.5.0/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/cordova/events/events.html
+++ b/archive/docs/de/3.5.0/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/cordova/events/events.menubutton.html
+++ b/archive/docs/de/3.5.0/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/cordova/events/events.pause.html
+++ b/archive/docs/de/3.5.0/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/cordova/events/events.resume.html
+++ b/archive/docs/de/3.5.0/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/cordova/events/events.searchbutton.html
+++ b/archive/docs/de/3.5.0/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/cordova/events/events.startcallbutton.html
+++ b/archive/docs/de/3.5.0/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/de/3.5.0/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/de/3.5.0/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/cordova/plugins/pluginapis.html
+++ b/archive/docs/de/3.5.0/cordova/plugins/pluginapis.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/cordova/storage/storage.html
+++ b/archive/docs/de/3.5.0/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/guide/appdev/privacy/index.html
+++ b/archive/docs/de/3.5.0/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/guide/appdev/whitelist/index.html
+++ b/archive/docs/de/3.5.0/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/guide/cli/index.html
+++ b/archive/docs/de/3.5.0/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/guide/hybrid/plugins/index.html
+++ b/archive/docs/de/3.5.0/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/guide/hybrid/webviews/index.html
+++ b/archive/docs/de/3.5.0/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/guide/overview/index.html
+++ b/archive/docs/de/3.5.0/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/guide/platforms/amazonfireos/config.html
+++ b/archive/docs/de/3.5.0/guide/platforms/amazonfireos/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/guide/platforms/amazonfireos/index.html
+++ b/archive/docs/de/3.5.0/guide/platforms/amazonfireos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/de/3.5.0/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/de/3.5.0/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/guide/platforms/android/config.html
+++ b/archive/docs/de/3.5.0/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/guide/platforms/android/index.html
+++ b/archive/docs/de/3.5.0/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/guide/platforms/android/plugin.html
+++ b/archive/docs/de/3.5.0/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/guide/platforms/android/tools.html
+++ b/archive/docs/de/3.5.0/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/guide/platforms/android/upgrading.html
+++ b/archive/docs/de/3.5.0/guide/platforms/android/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/guide/platforms/android/webview.html
+++ b/archive/docs/de/3.5.0/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/guide/platforms/blackberry/index.html
+++ b/archive/docs/de/3.5.0/guide/platforms/blackberry/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/guide/platforms/blackberry/plugin.html
+++ b/archive/docs/de/3.5.0/guide/platforms/blackberry/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/guide/platforms/blackberry/tools.html
+++ b/archive/docs/de/3.5.0/guide/platforms/blackberry/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/guide/platforms/blackberry/upgrading.html
+++ b/archive/docs/de/3.5.0/guide/platforms/blackberry/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/guide/platforms/blackberry10/config.html
+++ b/archive/docs/de/3.5.0/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/guide/platforms/blackberry10/index.html
+++ b/archive/docs/de/3.5.0/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/de/3.5.0/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/de/3.5.0/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/guide/platforms/index.html
+++ b/archive/docs/de/3.5.0/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/guide/platforms/ios/config.html
+++ b/archive/docs/de/3.5.0/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/guide/platforms/ios/index.html
+++ b/archive/docs/de/3.5.0/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/guide/platforms/ios/plugin.html
+++ b/archive/docs/de/3.5.0/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/guide/platforms/ios/tools.html
+++ b/archive/docs/de/3.5.0/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/guide/platforms/ios/upgrading.html
+++ b/archive/docs/de/3.5.0/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/guide/platforms/ios/webview.html
+++ b/archive/docs/de/3.5.0/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/guide/platforms/tizen/index.html
+++ b/archive/docs/de/3.5.0/guide/platforms/tizen/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/guide/platforms/ubuntu/index.html
+++ b/archive/docs/de/3.5.0/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/guide/platforms/win8/index.html
+++ b/archive/docs/de/3.5.0/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/guide/platforms/win8/tools.html
+++ b/archive/docs/de/3.5.0/guide/platforms/win8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/guide/platforms/win8/upgrading.html
+++ b/archive/docs/de/3.5.0/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/guide/platforms/wp7/index.html
+++ b/archive/docs/de/3.5.0/guide/platforms/wp7/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/guide/platforms/wp8/index.html
+++ b/archive/docs/de/3.5.0/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/guide/platforms/wp8/plugin.html
+++ b/archive/docs/de/3.5.0/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/guide/platforms/wp8/tools.html
+++ b/archive/docs/de/3.5.0/guide/platforms/wp8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/guide/platforms/wp8/upgrading.html
+++ b/archive/docs/de/3.5.0/guide/platforms/wp8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/guide/support/index.html
+++ b/archive/docs/de/3.5.0/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/index.html
+++ b/archive/docs/de/3.5.0/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/plugin_ref/plugman.html
+++ b/archive/docs/de/3.5.0/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/3.5.0/plugin_ref/spec.html
+++ b/archive/docs/de/3.5.0/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/config_ref/images.html
+++ b/archive/docs/de/5.4.0/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/config_ref/index.html
+++ b/archive/docs/de/5.4.0/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/cordova/events/events.backbutton.html
+++ b/archive/docs/de/5.4.0/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/cordova/events/events.deviceready.html
+++ b/archive/docs/de/5.4.0/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/cordova/events/events.endcallbutton.html
+++ b/archive/docs/de/5.4.0/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/cordova/events/events.html
+++ b/archive/docs/de/5.4.0/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/cordova/events/events.menubutton.html
+++ b/archive/docs/de/5.4.0/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/cordova/events/events.pause.html
+++ b/archive/docs/de/5.4.0/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/cordova/events/events.resume.html
+++ b/archive/docs/de/5.4.0/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/cordova/events/events.searchbutton.html
+++ b/archive/docs/de/5.4.0/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/cordova/events/events.startcallbutton.html
+++ b/archive/docs/de/5.4.0/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/de/5.4.0/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/de/5.4.0/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/cordova/plugins/pluginapis.html
+++ b/archive/docs/de/5.4.0/cordova/plugins/pluginapis.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/cordova/storage/storage.html
+++ b/archive/docs/de/5.4.0/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/guide/appdev/privacy/index.html
+++ b/archive/docs/de/5.4.0/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/guide/appdev/security/index.html
+++ b/archive/docs/de/5.4.0/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/guide/appdev/whitelist/index.html
+++ b/archive/docs/de/5.4.0/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/guide/cli/index.html
+++ b/archive/docs/de/5.4.0/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/guide/hybrid/plugins/index.html
+++ b/archive/docs/de/5.4.0/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/guide/hybrid/webviews/index.html
+++ b/archive/docs/de/5.4.0/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/guide/next/index.html
+++ b/archive/docs/de/5.4.0/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/guide/overview/index.html
+++ b/archive/docs/de/5.4.0/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/guide/platforms/amazonfireos/config.html
+++ b/archive/docs/de/5.4.0/guide/platforms/amazonfireos/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/guide/platforms/amazonfireos/index.html
+++ b/archive/docs/de/5.4.0/guide/platforms/amazonfireos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/de/5.4.0/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/de/5.4.0/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/guide/platforms/android/config.html
+++ b/archive/docs/de/5.4.0/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/guide/platforms/android/index.html
+++ b/archive/docs/de/5.4.0/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/guide/platforms/android/plugin.html
+++ b/archive/docs/de/5.4.0/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/guide/platforms/android/tools.html
+++ b/archive/docs/de/5.4.0/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/guide/platforms/android/upgrading.html
+++ b/archive/docs/de/5.4.0/guide/platforms/android/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/guide/platforms/android/webview.html
+++ b/archive/docs/de/5.4.0/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/guide/platforms/blackberry/config.html
+++ b/archive/docs/de/5.4.0/guide/platforms/blackberry/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/guide/platforms/blackberry/upgrading.html
+++ b/archive/docs/de/5.4.0/guide/platforms/blackberry/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/guide/platforms/blackberry10/config.html
+++ b/archive/docs/de/5.4.0/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/guide/platforms/blackberry10/index.html
+++ b/archive/docs/de/5.4.0/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/de/5.4.0/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/de/5.4.0/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/guide/platforms/firefoxos/index.html
+++ b/archive/docs/de/5.4.0/guide/platforms/firefoxos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/guide/platforms/index.html
+++ b/archive/docs/de/5.4.0/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/guide/platforms/ios/config.html
+++ b/archive/docs/de/5.4.0/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/guide/platforms/ios/index.html
+++ b/archive/docs/de/5.4.0/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/guide/platforms/ios/plugin.html
+++ b/archive/docs/de/5.4.0/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/guide/platforms/ios/tools.html
+++ b/archive/docs/de/5.4.0/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/guide/platforms/ios/upgrading.html
+++ b/archive/docs/de/5.4.0/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/guide/platforms/ios/webview.html
+++ b/archive/docs/de/5.4.0/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/guide/platforms/tizen/index.html
+++ b/archive/docs/de/5.4.0/guide/platforms/tizen/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/guide/platforms/ubuntu/index.html
+++ b/archive/docs/de/5.4.0/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/guide/platforms/win8/index.html
+++ b/archive/docs/de/5.4.0/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/guide/platforms/win8/packaging.html
+++ b/archive/docs/de/5.4.0/guide/platforms/win8/packaging.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/guide/platforms/win8/plugin.html
+++ b/archive/docs/de/5.4.0/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/guide/platforms/win8/upgrading.html
+++ b/archive/docs/de/5.4.0/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/guide/platforms/wp8/index.html
+++ b/archive/docs/de/5.4.0/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/guide/platforms/wp8/parallels.html
+++ b/archive/docs/de/5.4.0/guide/platforms/wp8/parallels.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/guide/platforms/wp8/plugin.html
+++ b/archive/docs/de/5.4.0/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/guide/platforms/wp8/upgrading.html
+++ b/archive/docs/de/5.4.0/guide/platforms/wp8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/guide/platforms/wp8/webview.html
+++ b/archive/docs/de/5.4.0/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/guide/support/index.html
+++ b/archive/docs/de/5.4.0/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/index.html
+++ b/archive/docs/de/5.4.0/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/de/5.4.0/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/plugin_ref/plugman.html
+++ b/archive/docs/de/5.4.0/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/5.4.0/plugin_ref/spec.html
+++ b/archive/docs/de/5.4.0/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/config_ref/images.html
+++ b/archive/docs/de/6.x/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/config_ref/index.html
+++ b/archive/docs/de/6.x/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/cordova/events/events.backbutton.html
+++ b/archive/docs/de/6.x/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/cordova/events/events.deviceready.html
+++ b/archive/docs/de/6.x/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/cordova/events/events.endcallbutton.html
+++ b/archive/docs/de/6.x/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/cordova/events/events.html
+++ b/archive/docs/de/6.x/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/cordova/events/events.menubutton.html
+++ b/archive/docs/de/6.x/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/cordova/events/events.pause.html
+++ b/archive/docs/de/6.x/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/cordova/events/events.resume.html
+++ b/archive/docs/de/6.x/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/cordova/events/events.searchbutton.html
+++ b/archive/docs/de/6.x/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/cordova/events/events.startcallbutton.html
+++ b/archive/docs/de/6.x/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/de/6.x/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/de/6.x/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/cordova/storage/storage.html
+++ b/archive/docs/de/6.x/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/guide/appdev/hooks/index.html
+++ b/archive/docs/de/6.x/guide/appdev/hooks/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/guide/appdev/privacy/index.html
+++ b/archive/docs/de/6.x/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/guide/appdev/security/index.html
+++ b/archive/docs/de/6.x/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/guide/appdev/whitelist/index.html
+++ b/archive/docs/de/6.x/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/guide/cli/index.html
+++ b/archive/docs/de/6.x/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/guide/hybrid/plugins/index.html
+++ b/archive/docs/de/6.x/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/guide/hybrid/webviews/index.html
+++ b/archive/docs/de/6.x/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/guide/next/index.html
+++ b/archive/docs/de/6.x/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/guide/overview/index.html
+++ b/archive/docs/de/6.x/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/de/6.x/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/de/6.x/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/guide/platforms/android/config.html
+++ b/archive/docs/de/6.x/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/guide/platforms/android/index.html
+++ b/archive/docs/de/6.x/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/guide/platforms/android/plugin.html
+++ b/archive/docs/de/6.x/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/guide/platforms/android/webview.html
+++ b/archive/docs/de/6.x/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/guide/platforms/blackberry/config.html
+++ b/archive/docs/de/6.x/guide/platforms/blackberry/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/guide/platforms/blackberry10/config.html
+++ b/archive/docs/de/6.x/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/guide/platforms/blackberry10/home.html
+++ b/archive/docs/de/6.x/guide/platforms/blackberry10/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/guide/platforms/blackberry10/index.html
+++ b/archive/docs/de/6.x/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/de/6.x/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/de/6.x/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/guide/platforms/blackberry10/upgrade.html
+++ b/archive/docs/de/6.x/guide/platforms/blackberry10/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/guide/platforms/ios/config.html
+++ b/archive/docs/de/6.x/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/guide/platforms/ios/index.html
+++ b/archive/docs/de/6.x/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/guide/platforms/ios/plugin.html
+++ b/archive/docs/de/6.x/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/guide/platforms/ios/tools.html
+++ b/archive/docs/de/6.x/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/guide/platforms/ios/upgrading.html
+++ b/archive/docs/de/6.x/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/guide/platforms/ios/webview.html
+++ b/archive/docs/de/6.x/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/guide/platforms/ubuntu/index.html
+++ b/archive/docs/de/6.x/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/guide/platforms/win8/index.html
+++ b/archive/docs/de/6.x/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/guide/platforms/win8/plugin.html
+++ b/archive/docs/de/6.x/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/guide/platforms/win8/upgrading.html
+++ b/archive/docs/de/6.x/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/guide/platforms/wp8/home.html
+++ b/archive/docs/de/6.x/guide/platforms/wp8/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/guide/platforms/wp8/index.html
+++ b/archive/docs/de/6.x/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/guide/platforms/wp8/parallels.html
+++ b/archive/docs/de/6.x/guide/platforms/wp8/parallels.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/guide/platforms/wp8/plugin.html
+++ b/archive/docs/de/6.x/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/de/6.x/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/guide/platforms/wp8/upgrading.html
+++ b/archive/docs/de/6.x/guide/platforms/wp8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/guide/platforms/wp8/webview.html
+++ b/archive/docs/de/6.x/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/guide/support/index.html
+++ b/archive/docs/de/6.x/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/index.html
+++ b/archive/docs/de/6.x/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/de/6.x/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/plugin_ref/plugman.html
+++ b/archive/docs/de/6.x/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/6.x/plugin_ref/spec.html
+++ b/archive/docs/de/6.x/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/config_ref/images.html
+++ b/archive/docs/de/7.x/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/config_ref/index.html
+++ b/archive/docs/de/7.x/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/cordova/events/events.backbutton.html
+++ b/archive/docs/de/7.x/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/cordova/events/events.deviceready.html
+++ b/archive/docs/de/7.x/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/cordova/events/events.endcallbutton.html
+++ b/archive/docs/de/7.x/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/cordova/events/events.html
+++ b/archive/docs/de/7.x/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/cordova/events/events.menubutton.html
+++ b/archive/docs/de/7.x/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/cordova/events/events.pause.html
+++ b/archive/docs/de/7.x/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/cordova/events/events.resume.html
+++ b/archive/docs/de/7.x/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/cordova/events/events.searchbutton.html
+++ b/archive/docs/de/7.x/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/cordova/events/events.startcallbutton.html
+++ b/archive/docs/de/7.x/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/de/7.x/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/de/7.x/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/cordova/storage/storage.html
+++ b/archive/docs/de/7.x/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/guide/appdev/hooks/index.html
+++ b/archive/docs/de/7.x/guide/appdev/hooks/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/guide/appdev/privacy/index.html
+++ b/archive/docs/de/7.x/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/guide/appdev/security/index.html
+++ b/archive/docs/de/7.x/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/guide/appdev/whitelist/index.html
+++ b/archive/docs/de/7.x/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/guide/cli/index.html
+++ b/archive/docs/de/7.x/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/guide/hybrid/plugins/index.html
+++ b/archive/docs/de/7.x/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/guide/hybrid/webviews/index.html
+++ b/archive/docs/de/7.x/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/guide/next/index.html
+++ b/archive/docs/de/7.x/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/guide/overview/index.html
+++ b/archive/docs/de/7.x/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/de/7.x/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/de/7.x/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/guide/platforms/android/config.html
+++ b/archive/docs/de/7.x/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/guide/platforms/android/index.html
+++ b/archive/docs/de/7.x/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/guide/platforms/android/plugin.html
+++ b/archive/docs/de/7.x/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/guide/platforms/android/webview.html
+++ b/archive/docs/de/7.x/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/guide/platforms/blackberry/config.html
+++ b/archive/docs/de/7.x/guide/platforms/blackberry/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/guide/platforms/blackberry10/config.html
+++ b/archive/docs/de/7.x/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/guide/platforms/blackberry10/home.html
+++ b/archive/docs/de/7.x/guide/platforms/blackberry10/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/guide/platforms/blackberry10/index.html
+++ b/archive/docs/de/7.x/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/de/7.x/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/de/7.x/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/guide/platforms/blackberry10/upgrade.html
+++ b/archive/docs/de/7.x/guide/platforms/blackberry10/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/guide/platforms/ios/config.html
+++ b/archive/docs/de/7.x/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/guide/platforms/ios/index.html
+++ b/archive/docs/de/7.x/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/guide/platforms/ios/plugin.html
+++ b/archive/docs/de/7.x/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/guide/platforms/ios/tools.html
+++ b/archive/docs/de/7.x/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/guide/platforms/ios/upgrading.html
+++ b/archive/docs/de/7.x/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/guide/platforms/ios/webview.html
+++ b/archive/docs/de/7.x/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/guide/platforms/ubuntu/index.html
+++ b/archive/docs/de/7.x/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/guide/platforms/win8/index.html
+++ b/archive/docs/de/7.x/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/guide/platforms/win8/plugin.html
+++ b/archive/docs/de/7.x/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/guide/platforms/win8/upgrading.html
+++ b/archive/docs/de/7.x/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/guide/platforms/wp8/home.html
+++ b/archive/docs/de/7.x/guide/platforms/wp8/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/guide/platforms/wp8/index.html
+++ b/archive/docs/de/7.x/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/guide/platforms/wp8/parallels.html
+++ b/archive/docs/de/7.x/guide/platforms/wp8/parallels.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/guide/platforms/wp8/plugin.html
+++ b/archive/docs/de/7.x/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/de/7.x/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/guide/platforms/wp8/upgrading.html
+++ b/archive/docs/de/7.x/guide/platforms/wp8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/guide/platforms/wp8/webview.html
+++ b/archive/docs/de/7.x/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/guide/support/index.html
+++ b/archive/docs/de/7.x/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/index.html
+++ b/archive/docs/de/7.x/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/de/7.x/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/plugin_ref/plugman.html
+++ b/archive/docs/de/7.x/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/7.x/plugin_ref/spec.html
+++ b/archive/docs/de/7.x/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/config_ref/images.html
+++ b/archive/docs/de/8.x/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/config_ref/index.html
+++ b/archive/docs/de/8.x/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/cordova/events/events.backbutton.html
+++ b/archive/docs/de/8.x/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/cordova/events/events.deviceready.html
+++ b/archive/docs/de/8.x/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/cordova/events/events.endcallbutton.html
+++ b/archive/docs/de/8.x/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/cordova/events/events.html
+++ b/archive/docs/de/8.x/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/cordova/events/events.menubutton.html
+++ b/archive/docs/de/8.x/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/cordova/events/events.pause.html
+++ b/archive/docs/de/8.x/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/cordova/events/events.resume.html
+++ b/archive/docs/de/8.x/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/cordova/events/events.searchbutton.html
+++ b/archive/docs/de/8.x/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/cordova/events/events.startcallbutton.html
+++ b/archive/docs/de/8.x/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/de/8.x/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/de/8.x/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/cordova/storage/storage.html
+++ b/archive/docs/de/8.x/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/guide/appdev/hooks/index.html
+++ b/archive/docs/de/8.x/guide/appdev/hooks/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/guide/appdev/privacy/index.html
+++ b/archive/docs/de/8.x/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/guide/appdev/security/index.html
+++ b/archive/docs/de/8.x/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/guide/appdev/whitelist/index.html
+++ b/archive/docs/de/8.x/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/guide/cli/index.html
+++ b/archive/docs/de/8.x/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/guide/hybrid/plugins/index.html
+++ b/archive/docs/de/8.x/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/guide/hybrid/webviews/index.html
+++ b/archive/docs/de/8.x/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/guide/next/index.html
+++ b/archive/docs/de/8.x/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/guide/overview/index.html
+++ b/archive/docs/de/8.x/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/de/8.x/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/de/8.x/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/guide/platforms/android/config.html
+++ b/archive/docs/de/8.x/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/guide/platforms/android/index.html
+++ b/archive/docs/de/8.x/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/guide/platforms/android/plugin.html
+++ b/archive/docs/de/8.x/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/guide/platforms/android/webview.html
+++ b/archive/docs/de/8.x/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/guide/platforms/blackberry/config.html
+++ b/archive/docs/de/8.x/guide/platforms/blackberry/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/guide/platforms/blackberry10/config.html
+++ b/archive/docs/de/8.x/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/guide/platforms/blackberry10/home.html
+++ b/archive/docs/de/8.x/guide/platforms/blackberry10/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/guide/platforms/blackberry10/index.html
+++ b/archive/docs/de/8.x/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/de/8.x/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/de/8.x/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/guide/platforms/blackberry10/upgrade.html
+++ b/archive/docs/de/8.x/guide/platforms/blackberry10/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/guide/platforms/ios/config.html
+++ b/archive/docs/de/8.x/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/guide/platforms/ios/index.html
+++ b/archive/docs/de/8.x/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/guide/platforms/ios/plugin.html
+++ b/archive/docs/de/8.x/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/guide/platforms/ios/tools.html
+++ b/archive/docs/de/8.x/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/guide/platforms/ios/upgrading.html
+++ b/archive/docs/de/8.x/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/guide/platforms/ios/webview.html
+++ b/archive/docs/de/8.x/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/guide/platforms/ubuntu/index.html
+++ b/archive/docs/de/8.x/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/guide/platforms/win8/index.html
+++ b/archive/docs/de/8.x/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/guide/platforms/win8/plugin.html
+++ b/archive/docs/de/8.x/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/guide/platforms/win8/upgrading.html
+++ b/archive/docs/de/8.x/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/guide/platforms/wp8/home.html
+++ b/archive/docs/de/8.x/guide/platforms/wp8/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/guide/platforms/wp8/index.html
+++ b/archive/docs/de/8.x/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/guide/platforms/wp8/parallels.html
+++ b/archive/docs/de/8.x/guide/platforms/wp8/parallels.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/guide/platforms/wp8/plugin.html
+++ b/archive/docs/de/8.x/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/de/8.x/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/guide/platforms/wp8/upgrading.html
+++ b/archive/docs/de/8.x/guide/platforms/wp8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/guide/platforms/wp8/webview.html
+++ b/archive/docs/de/8.x/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/guide/support/index.html
+++ b/archive/docs/de/8.x/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/index.html
+++ b/archive/docs/de/8.x/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/de/8.x/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/plugin_ref/plugman.html
+++ b/archive/docs/de/8.x/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/8.x/plugin_ref/spec.html
+++ b/archive/docs/de/8.x/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/config_ref/images.html
+++ b/archive/docs/de/9.x/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/config_ref/index.html
+++ b/archive/docs/de/9.x/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/cordova/events/events.backbutton.html
+++ b/archive/docs/de/9.x/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/cordova/events/events.deviceready.html
+++ b/archive/docs/de/9.x/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/cordova/events/events.endcallbutton.html
+++ b/archive/docs/de/9.x/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/cordova/events/events.html
+++ b/archive/docs/de/9.x/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/cordova/events/events.menubutton.html
+++ b/archive/docs/de/9.x/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/cordova/events/events.pause.html
+++ b/archive/docs/de/9.x/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/cordova/events/events.resume.html
+++ b/archive/docs/de/9.x/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/cordova/events/events.searchbutton.html
+++ b/archive/docs/de/9.x/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/cordova/events/events.startcallbutton.html
+++ b/archive/docs/de/9.x/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/de/9.x/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/de/9.x/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/cordova/storage/storage.html
+++ b/archive/docs/de/9.x/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/guide/appdev/hooks/index.html
+++ b/archive/docs/de/9.x/guide/appdev/hooks/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/guide/appdev/privacy/index.html
+++ b/archive/docs/de/9.x/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/guide/appdev/security/index.html
+++ b/archive/docs/de/9.x/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/guide/appdev/whitelist/index.html
+++ b/archive/docs/de/9.x/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/guide/cli/index.html
+++ b/archive/docs/de/9.x/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/guide/hybrid/plugins/index.html
+++ b/archive/docs/de/9.x/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/guide/hybrid/webviews/index.html
+++ b/archive/docs/de/9.x/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/guide/next/index.html
+++ b/archive/docs/de/9.x/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/guide/overview/index.html
+++ b/archive/docs/de/9.x/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/de/9.x/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/de/9.x/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/guide/platforms/android/config.html
+++ b/archive/docs/de/9.x/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/guide/platforms/android/index.html
+++ b/archive/docs/de/9.x/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/guide/platforms/android/plugin.html
+++ b/archive/docs/de/9.x/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/guide/platforms/android/webview.html
+++ b/archive/docs/de/9.x/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/guide/platforms/blackberry/config.html
+++ b/archive/docs/de/9.x/guide/platforms/blackberry/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/guide/platforms/blackberry10/config.html
+++ b/archive/docs/de/9.x/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/guide/platforms/blackberry10/home.html
+++ b/archive/docs/de/9.x/guide/platforms/blackberry10/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/guide/platforms/blackberry10/index.html
+++ b/archive/docs/de/9.x/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/de/9.x/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/de/9.x/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/guide/platforms/blackberry10/upgrade.html
+++ b/archive/docs/de/9.x/guide/platforms/blackberry10/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/guide/platforms/ios/config.html
+++ b/archive/docs/de/9.x/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/guide/platforms/ios/index.html
+++ b/archive/docs/de/9.x/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/guide/platforms/ios/plugin.html
+++ b/archive/docs/de/9.x/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/guide/platforms/ios/tools.html
+++ b/archive/docs/de/9.x/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/guide/platforms/ios/upgrading.html
+++ b/archive/docs/de/9.x/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/guide/platforms/ios/webview.html
+++ b/archive/docs/de/9.x/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/guide/platforms/ubuntu/index.html
+++ b/archive/docs/de/9.x/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/guide/platforms/win8/index.html
+++ b/archive/docs/de/9.x/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/guide/platforms/win8/plugin.html
+++ b/archive/docs/de/9.x/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/guide/platforms/win8/upgrading.html
+++ b/archive/docs/de/9.x/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/guide/platforms/wp8/home.html
+++ b/archive/docs/de/9.x/guide/platforms/wp8/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/guide/platforms/wp8/index.html
+++ b/archive/docs/de/9.x/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/guide/platforms/wp8/parallels.html
+++ b/archive/docs/de/9.x/guide/platforms/wp8/parallels.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/guide/platforms/wp8/plugin.html
+++ b/archive/docs/de/9.x/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/de/9.x/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/guide/platforms/wp8/upgrading.html
+++ b/archive/docs/de/9.x/guide/platforms/wp8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/guide/platforms/wp8/webview.html
+++ b/archive/docs/de/9.x/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/guide/support/index.html
+++ b/archive/docs/de/9.x/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/index.html
+++ b/archive/docs/de/9.x/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/de/9.x/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/plugin_ref/plugman.html
+++ b/archive/docs/de/9.x/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/de/9.x/plugin_ref/spec.html
+++ b/archive/docs/de/9.x/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/config_ref/images.html
+++ b/archive/docs/es/10.x/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/config_ref/index.html
+++ b/archive/docs/es/10.x/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/cordova/events/events.backbutton.html
+++ b/archive/docs/es/10.x/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/cordova/events/events.deviceready.html
+++ b/archive/docs/es/10.x/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/cordova/events/events.endcallbutton.html
+++ b/archive/docs/es/10.x/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/cordova/events/events.html
+++ b/archive/docs/es/10.x/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/cordova/events/events.menubutton.html
+++ b/archive/docs/es/10.x/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/cordova/events/events.pause.html
+++ b/archive/docs/es/10.x/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/cordova/events/events.resume.html
+++ b/archive/docs/es/10.x/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/cordova/events/events.searchbutton.html
+++ b/archive/docs/es/10.x/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/cordova/events/events.startcallbutton.html
+++ b/archive/docs/es/10.x/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/es/10.x/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/es/10.x/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/es/10.x/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/cordova/storage/storage.html
+++ b/archive/docs/es/10.x/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/guide/appdev/hooks/index.html
+++ b/archive/docs/es/10.x/guide/appdev/hooks/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/guide/appdev/privacy/index.html
+++ b/archive/docs/es/10.x/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/guide/appdev/security/index.html
+++ b/archive/docs/es/10.x/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/guide/appdev/whitelist/index.html
+++ b/archive/docs/es/10.x/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/guide/cli/index.html
+++ b/archive/docs/es/10.x/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/guide/hybrid/plugins/index.html
+++ b/archive/docs/es/10.x/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/guide/hybrid/webviews/index.html
+++ b/archive/docs/es/10.x/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/guide/next/index.html
+++ b/archive/docs/es/10.x/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/guide/overview/index.html
+++ b/archive/docs/es/10.x/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/guide/platforms/amazonfireos/config.html
+++ b/archive/docs/es/10.x/guide/platforms/amazonfireos/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/guide/platforms/amazonfireos/index.html
+++ b/archive/docs/es/10.x/guide/platforms/amazonfireos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/es/10.x/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/es/10.x/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/guide/platforms/android/config.html
+++ b/archive/docs/es/10.x/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/guide/platforms/android/index.html
+++ b/archive/docs/es/10.x/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/guide/platforms/android/plugin.html
+++ b/archive/docs/es/10.x/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/guide/platforms/android/tools.html
+++ b/archive/docs/es/10.x/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/guide/platforms/android/upgrading.html
+++ b/archive/docs/es/10.x/guide/platforms/android/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/guide/platforms/android/webview.html
+++ b/archive/docs/es/10.x/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/guide/platforms/blackberry/upgrading.html
+++ b/archive/docs/es/10.x/guide/platforms/blackberry/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/guide/platforms/blackberry10/config.html
+++ b/archive/docs/es/10.x/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/guide/platforms/blackberry10/home.html
+++ b/archive/docs/es/10.x/guide/platforms/blackberry10/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/guide/platforms/blackberry10/index.html
+++ b/archive/docs/es/10.x/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/es/10.x/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/es/10.x/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/guide/platforms/blackberry10/upgrade.html
+++ b/archive/docs/es/10.x/guide/platforms/blackberry10/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/guide/platforms/firefoxos/index.html
+++ b/archive/docs/es/10.x/guide/platforms/firefoxos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/guide/platforms/index.html
+++ b/archive/docs/es/10.x/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/guide/platforms/ios/config.html
+++ b/archive/docs/es/10.x/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/guide/platforms/ios/index.html
+++ b/archive/docs/es/10.x/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/guide/platforms/ios/plugin.html
+++ b/archive/docs/es/10.x/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/guide/platforms/ios/tools.html
+++ b/archive/docs/es/10.x/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/guide/platforms/ios/upgrading.html
+++ b/archive/docs/es/10.x/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/guide/platforms/ios/webview.html
+++ b/archive/docs/es/10.x/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/guide/platforms/tizen/index.html
+++ b/archive/docs/es/10.x/guide/platforms/tizen/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/guide/platforms/ubuntu/index.html
+++ b/archive/docs/es/10.x/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/guide/platforms/win8/index.html
+++ b/archive/docs/es/10.x/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/guide/platforms/win8/packaging.html
+++ b/archive/docs/es/10.x/guide/platforms/win8/packaging.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/guide/platforms/win8/plugin.html
+++ b/archive/docs/es/10.x/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/guide/platforms/win8/upgrading.html
+++ b/archive/docs/es/10.x/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/guide/platforms/wp8/home.html
+++ b/archive/docs/es/10.x/guide/platforms/wp8/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/guide/platforms/wp8/index.html
+++ b/archive/docs/es/10.x/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/guide/platforms/wp8/plugin.html
+++ b/archive/docs/es/10.x/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/es/10.x/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/guide/platforms/wp8/webview.html
+++ b/archive/docs/es/10.x/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/guide/support/index.html
+++ b/archive/docs/es/10.x/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/index.html
+++ b/archive/docs/es/10.x/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/es/10.x/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/plugin_ref/plugman.html
+++ b/archive/docs/es/10.x/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/10.x/plugin_ref/spec.html
+++ b/archive/docs/es/10.x/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/config_ref/images.html
+++ b/archive/docs/es/3.1.0/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/config_ref/index.html
+++ b/archive/docs/es/3.1.0/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/accelerometer/accelerometer.clearWatch.html
+++ b/archive/docs/es/3.1.0/cordova/accelerometer/accelerometer.clearWatch.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/accelerometer/accelerometer.getCurrentAcceleration.html
+++ b/archive/docs/es/3.1.0/cordova/accelerometer/accelerometer.getCurrentAcceleration.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/accelerometer/accelerometer.html
+++ b/archive/docs/es/3.1.0/cordova/accelerometer/accelerometer.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/accelerometer/accelerometer.watchAcceleration.html
+++ b/archive/docs/es/3.1.0/cordova/accelerometer/accelerometer.watchAcceleration.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/accelerometer/parameters/accelerometerError.html
+++ b/archive/docs/es/3.1.0/cordova/accelerometer/parameters/accelerometerError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/accelerometer/parameters/accelerometerOptions.html
+++ b/archive/docs/es/3.1.0/cordova/accelerometer/parameters/accelerometerOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/accelerometer/parameters/accelerometerSuccess.html
+++ b/archive/docs/es/3.1.0/cordova/accelerometer/parameters/accelerometerSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/camera/camera.getPicture.html
+++ b/archive/docs/es/3.1.0/cordova/camera/camera.getPicture.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/camera/camera.html
+++ b/archive/docs/es/3.1.0/cordova/camera/camera.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/compass/compass.clearWatch.html
+++ b/archive/docs/es/3.1.0/cordova/compass/compass.clearWatch.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/compass/compass.clearWatchFilter.html
+++ b/archive/docs/es/3.1.0/cordova/compass/compass.clearWatchFilter.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/compass/compass.getCurrentHeading.html
+++ b/archive/docs/es/3.1.0/cordova/compass/compass.getCurrentHeading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/compass/compass.html
+++ b/archive/docs/es/3.1.0/cordova/compass/compass.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/compass/compass.watchHeading.html
+++ b/archive/docs/es/3.1.0/cordova/compass/compass.watchHeading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/compass/compass.watchHeadingFilter.html
+++ b/archive/docs/es/3.1.0/cordova/compass/compass.watchHeadingFilter.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/compass/parameters/compassError.html
+++ b/archive/docs/es/3.1.0/cordova/compass/parameters/compassError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/compass/parameters/compassHeading.html
+++ b/archive/docs/es/3.1.0/cordova/compass/parameters/compassHeading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/compass/parameters/compassOptions.html
+++ b/archive/docs/es/3.1.0/cordova/compass/parameters/compassOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/compass/parameters/compassSuccess.html
+++ b/archive/docs/es/3.1.0/cordova/compass/parameters/compassSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/connection/connection.html
+++ b/archive/docs/es/3.1.0/cordova/connection/connection.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/connection/connection.type.html
+++ b/archive/docs/es/3.1.0/cordova/connection/connection.type.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/contacts/ContactAddress/contactaddress.html
+++ b/archive/docs/es/3.1.0/cordova/contacts/ContactAddress/contactaddress.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/contacts/ContactError/contactError.html
+++ b/archive/docs/es/3.1.0/cordova/contacts/ContactError/contactError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/contacts/ContactField/contactfield.html
+++ b/archive/docs/es/3.1.0/cordova/contacts/ContactField/contactfield.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/contacts/ContactFindOptions/contactfindoptions.html
+++ b/archive/docs/es/3.1.0/cordova/contacts/ContactFindOptions/contactfindoptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/contacts/ContactName/contactname.html
+++ b/archive/docs/es/3.1.0/cordova/contacts/ContactName/contactname.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/contacts/ContactOrganization/contactorganization.html
+++ b/archive/docs/es/3.1.0/cordova/contacts/ContactOrganization/contactorganization.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/contacts/contacts.create.html
+++ b/archive/docs/es/3.1.0/cordova/contacts/contacts.create.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/contacts/contacts.find.html
+++ b/archive/docs/es/3.1.0/cordova/contacts/contacts.find.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/contacts/contacts.html
+++ b/archive/docs/es/3.1.0/cordova/contacts/contacts.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/contacts/parameters/contactError.html
+++ b/archive/docs/es/3.1.0/cordova/contacts/parameters/contactError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/contacts/parameters/contactFields.html
+++ b/archive/docs/es/3.1.0/cordova/contacts/parameters/contactFields.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/contacts/parameters/contactFindOptions.html
+++ b/archive/docs/es/3.1.0/cordova/contacts/parameters/contactFindOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/contacts/parameters/contactSuccess.html
+++ b/archive/docs/es/3.1.0/cordova/contacts/parameters/contactSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/device/device.cordova.html
+++ b/archive/docs/es/3.1.0/cordova/device/device.cordova.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/device/device.html
+++ b/archive/docs/es/3.1.0/cordova/device/device.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/device/device.model.html
+++ b/archive/docs/es/3.1.0/cordova/device/device.model.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/device/device.name.html
+++ b/archive/docs/es/3.1.0/cordova/device/device.name.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/device/device.platform.html
+++ b/archive/docs/es/3.1.0/cordova/device/device.platform.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/device/device.uuid.html
+++ b/archive/docs/es/3.1.0/cordova/device/device.uuid.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/device/device.version.html
+++ b/archive/docs/es/3.1.0/cordova/device/device.version.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/events/events.backbutton.html
+++ b/archive/docs/es/3.1.0/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/events/events.batterycritical.html
+++ b/archive/docs/es/3.1.0/cordova/events/events.batterycritical.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/events/events.batterylow.html
+++ b/archive/docs/es/3.1.0/cordova/events/events.batterylow.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/events/events.batterystatus.html
+++ b/archive/docs/es/3.1.0/cordova/events/events.batterystatus.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/events/events.deviceready.html
+++ b/archive/docs/es/3.1.0/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/events/events.endcallbutton.html
+++ b/archive/docs/es/3.1.0/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/events/events.html
+++ b/archive/docs/es/3.1.0/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/events/events.menubutton.html
+++ b/archive/docs/es/3.1.0/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/events/events.offline.html
+++ b/archive/docs/es/3.1.0/cordova/events/events.offline.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/events/events.online.html
+++ b/archive/docs/es/3.1.0/cordova/events/events.online.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/events/events.pause.html
+++ b/archive/docs/es/3.1.0/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/events/events.resume.html
+++ b/archive/docs/es/3.1.0/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/events/events.searchbutton.html
+++ b/archive/docs/es/3.1.0/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/events/events.startcallbutton.html
+++ b/archive/docs/es/3.1.0/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/es/3.1.0/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/es/3.1.0/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/file/directoryentry/directoryentry.html
+++ b/archive/docs/es/3.1.0/cordova/file/directoryentry/directoryentry.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/file/directoryreader/directoryreader.html
+++ b/archive/docs/es/3.1.0/cordova/file/directoryreader/directoryreader.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/file/file.html
+++ b/archive/docs/es/3.1.0/cordova/file/file.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/file/fileentry/fileentry.html
+++ b/archive/docs/es/3.1.0/cordova/file/fileentry/fileentry.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/file/fileerror/fileerror.html
+++ b/archive/docs/es/3.1.0/cordova/file/fileerror/fileerror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/file/fileobj/fileobj.html
+++ b/archive/docs/es/3.1.0/cordova/file/fileobj/fileobj.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/file/filereader/filereader.html
+++ b/archive/docs/es/3.1.0/cordova/file/filereader/filereader.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/file/filetransfer/filetransfer.html
+++ b/archive/docs/es/3.1.0/cordova/file/filetransfer/filetransfer.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/file/filetransfererror/filetransfererror.html
+++ b/archive/docs/es/3.1.0/cordova/file/filetransfererror/filetransfererror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/file/fileuploadoptions/fileuploadoptions.html
+++ b/archive/docs/es/3.1.0/cordova/file/fileuploadoptions/fileuploadoptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/file/fileuploadresult/fileuploadresult.html
+++ b/archive/docs/es/3.1.0/cordova/file/fileuploadresult/fileuploadresult.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/file/filewriter/filewriter.html
+++ b/archive/docs/es/3.1.0/cordova/file/filewriter/filewriter.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/file/localfilesystem/localfilesystem.html
+++ b/archive/docs/es/3.1.0/cordova/file/localfilesystem/localfilesystem.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/geolocation/PositionError/positionError.html
+++ b/archive/docs/es/3.1.0/cordova/geolocation/PositionError/positionError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/geolocation/geolocation.clearWatch.html
+++ b/archive/docs/es/3.1.0/cordova/geolocation/geolocation.clearWatch.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/geolocation/geolocation.getCurrentPosition.html
+++ b/archive/docs/es/3.1.0/cordova/geolocation/geolocation.getCurrentPosition.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/geolocation/geolocation.html
+++ b/archive/docs/es/3.1.0/cordova/geolocation/geolocation.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/geolocation/geolocation.watchPosition.html
+++ b/archive/docs/es/3.1.0/cordova/geolocation/geolocation.watchPosition.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/geolocation/parameters/geolocation.options.html
+++ b/archive/docs/es/3.1.0/cordova/geolocation/parameters/geolocation.options.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/geolocation/parameters/geolocationError.html
+++ b/archive/docs/es/3.1.0/cordova/geolocation/parameters/geolocationError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/geolocation/parameters/geolocationSuccess.html
+++ b/archive/docs/es/3.1.0/cordova/geolocation/parameters/geolocationSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/globalization/GlobalizationError/globalizationerror.html
+++ b/archive/docs/es/3.1.0/cordova/globalization/GlobalizationError/globalizationerror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/globalization/globalization.dateToString.html
+++ b/archive/docs/es/3.1.0/cordova/globalization/globalization.dateToString.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/globalization/globalization.getCurrencyPattern.html
+++ b/archive/docs/es/3.1.0/cordova/globalization/globalization.getCurrencyPattern.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/globalization/globalization.getDateNames.html
+++ b/archive/docs/es/3.1.0/cordova/globalization/globalization.getDateNames.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/globalization/globalization.getDatePattern.html
+++ b/archive/docs/es/3.1.0/cordova/globalization/globalization.getDatePattern.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/globalization/globalization.getFirstDayOfWeek.html
+++ b/archive/docs/es/3.1.0/cordova/globalization/globalization.getFirstDayOfWeek.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/globalization/globalization.getLocaleName.html
+++ b/archive/docs/es/3.1.0/cordova/globalization/globalization.getLocaleName.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/globalization/globalization.getNumberPattern.html
+++ b/archive/docs/es/3.1.0/cordova/globalization/globalization.getNumberPattern.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/globalization/globalization.getPreferredLanguage.html
+++ b/archive/docs/es/3.1.0/cordova/globalization/globalization.getPreferredLanguage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/globalization/globalization.html
+++ b/archive/docs/es/3.1.0/cordova/globalization/globalization.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/globalization/globalization.isDayLightSavingsTime.html
+++ b/archive/docs/es/3.1.0/cordova/globalization/globalization.isDayLightSavingsTime.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/globalization/globalization.numberToString.html
+++ b/archive/docs/es/3.1.0/cordova/globalization/globalization.numberToString.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/globalization/globalization.stringToDate.html
+++ b/archive/docs/es/3.1.0/cordova/globalization/globalization.stringToDate.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/globalization/globalization.stringToNumber.html
+++ b/archive/docs/es/3.1.0/cordova/globalization/globalization.stringToNumber.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/inappbrowser/inappbrowser.html
+++ b/archive/docs/es/3.1.0/cordova/inappbrowser/inappbrowser.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/media/capture/CaptureErrorCB.html
+++ b/archive/docs/es/3.1.0/cordova/media/capture/CaptureErrorCB.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/media/capture/ConfigurationData.html
+++ b/archive/docs/es/3.1.0/cordova/media/capture/ConfigurationData.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/media/capture/MediaFile.html
+++ b/archive/docs/es/3.1.0/cordova/media/capture/MediaFile.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/media/capture/MediaFileData.html
+++ b/archive/docs/es/3.1.0/cordova/media/capture/MediaFileData.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/media/capture/capture.html
+++ b/archive/docs/es/3.1.0/cordova/media/capture/capture.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/media/capture/captureAudio.html
+++ b/archive/docs/es/3.1.0/cordova/media/capture/captureAudio.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/media/capture/captureAudioOptions.html
+++ b/archive/docs/es/3.1.0/cordova/media/capture/captureAudioOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/media/capture/captureImage.html
+++ b/archive/docs/es/3.1.0/cordova/media/capture/captureImage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/media/capture/captureImageOptions.html
+++ b/archive/docs/es/3.1.0/cordova/media/capture/captureImageOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/media/capture/captureVideo.html
+++ b/archive/docs/es/3.1.0/cordova/media/capture/captureVideo.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/media/capture/captureVideoOptions.html
+++ b/archive/docs/es/3.1.0/cordova/media/capture/captureVideoOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/media/media.html
+++ b/archive/docs/es/3.1.0/cordova/media/media.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/notification/notification.html
+++ b/archive/docs/es/3.1.0/cordova/notification/notification.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/splashscreen/splashscreen.html
+++ b/archive/docs/es/3.1.0/cordova/splashscreen/splashscreen.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/storage/database/database.html
+++ b/archive/docs/es/3.1.0/cordova/storage/database/database.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/es/3.1.0/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/storage/parameters/display_name.html
+++ b/archive/docs/es/3.1.0/cordova/storage/parameters/display_name.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/storage/parameters/size.html
+++ b/archive/docs/es/3.1.0/cordova/storage/parameters/size.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/storage/parameters/version.html
+++ b/archive/docs/es/3.1.0/cordova/storage/parameters/version.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/storage/sqlerror/sqlerror.html
+++ b/archive/docs/es/3.1.0/cordova/storage/sqlerror/sqlerror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/storage/sqlresultset/sqlresultset.html
+++ b/archive/docs/es/3.1.0/cordova/storage/sqlresultset/sqlresultset.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/storage/sqlresultsetrowlist/sqlresultsetrowlist.html
+++ b/archive/docs/es/3.1.0/cordova/storage/sqlresultsetrowlist/sqlresultsetrowlist.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/storage/sqltransaction/sqltransaction.html
+++ b/archive/docs/es/3.1.0/cordova/storage/sqltransaction/sqltransaction.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/storage/storage.html
+++ b/archive/docs/es/3.1.0/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/cordova/storage/storage.opendatabase.html
+++ b/archive/docs/es/3.1.0/cordova/storage/storage.opendatabase.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/guide/appdev/privacy/index.html
+++ b/archive/docs/es/3.1.0/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/guide/appdev/whitelist/index.html
+++ b/archive/docs/es/3.1.0/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/guide/cli/index.html
+++ b/archive/docs/es/3.1.0/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/guide/hybrid/plugins/index.html
+++ b/archive/docs/es/3.1.0/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/guide/hybrid/webviews/index.html
+++ b/archive/docs/es/3.1.0/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/guide/overview/index.html
+++ b/archive/docs/es/3.1.0/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/guide/platforms/android/config.html
+++ b/archive/docs/es/3.1.0/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/guide/platforms/android/index.html
+++ b/archive/docs/es/3.1.0/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/guide/platforms/android/plugin.html
+++ b/archive/docs/es/3.1.0/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/guide/platforms/android/tools.html
+++ b/archive/docs/es/3.1.0/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/guide/platforms/android/upgrading.html
+++ b/archive/docs/es/3.1.0/guide/platforms/android/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/guide/platforms/android/webview.html
+++ b/archive/docs/es/3.1.0/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/guide/platforms/blackberry/config.html
+++ b/archive/docs/es/3.1.0/guide/platforms/blackberry/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/guide/platforms/blackberry/index.html
+++ b/archive/docs/es/3.1.0/guide/platforms/blackberry/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/guide/platforms/blackberry/tools.html
+++ b/archive/docs/es/3.1.0/guide/platforms/blackberry/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/guide/platforms/blackberry10/config.html
+++ b/archive/docs/es/3.1.0/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/guide/platforms/blackberry10/index.html
+++ b/archive/docs/es/3.1.0/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/es/3.1.0/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/es/3.1.0/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/guide/platforms/blackberry10/upgrading.html
+++ b/archive/docs/es/3.1.0/guide/platforms/blackberry10/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/guide/platforms/index.html
+++ b/archive/docs/es/3.1.0/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/guide/platforms/ios/config.html
+++ b/archive/docs/es/3.1.0/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/guide/platforms/ios/plugin.html
+++ b/archive/docs/es/3.1.0/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/guide/platforms/ios/tools.html
+++ b/archive/docs/es/3.1.0/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/guide/platforms/ios/upgrading.html
+++ b/archive/docs/es/3.1.0/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/guide/platforms/ios/webview.html
+++ b/archive/docs/es/3.1.0/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/guide/platforms/tizen/index.html
+++ b/archive/docs/es/3.1.0/guide/platforms/tizen/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/guide/platforms/win8/index.html
+++ b/archive/docs/es/3.1.0/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/guide/platforms/win8/tools.html
+++ b/archive/docs/es/3.1.0/guide/platforms/win8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/guide/platforms/win8/upgrading.html
+++ b/archive/docs/es/3.1.0/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/guide/platforms/wp7/index.html
+++ b/archive/docs/es/3.1.0/guide/platforms/wp7/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/guide/platforms/wp8/index.html
+++ b/archive/docs/es/3.1.0/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/guide/platforms/wp8/plugin.html
+++ b/archive/docs/es/3.1.0/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/guide/platforms/wp8/tools.html
+++ b/archive/docs/es/3.1.0/guide/platforms/wp8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/guide/platforms/wp8/upgrading.html
+++ b/archive/docs/es/3.1.0/guide/platforms/wp8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/index.html
+++ b/archive/docs/es/3.1.0/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.1.0/plugin_ref/spec.html
+++ b/archive/docs/es/3.1.0/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.4.0/config_ref/images.html
+++ b/archive/docs/es/3.4.0/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.4.0/config_ref/index.html
+++ b/archive/docs/es/3.4.0/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.4.0/cordova/events/events.backbutton.html
+++ b/archive/docs/es/3.4.0/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.4.0/cordova/events/events.deviceready.html
+++ b/archive/docs/es/3.4.0/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.4.0/cordova/events/events.endcallbutton.html
+++ b/archive/docs/es/3.4.0/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.4.0/cordova/events/events.html
+++ b/archive/docs/es/3.4.0/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.4.0/cordova/events/events.menubutton.html
+++ b/archive/docs/es/3.4.0/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.4.0/cordova/events/events.pause.html
+++ b/archive/docs/es/3.4.0/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.4.0/cordova/events/events.resume.html
+++ b/archive/docs/es/3.4.0/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.4.0/cordova/events/events.searchbutton.html
+++ b/archive/docs/es/3.4.0/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.4.0/cordova/events/events.startcallbutton.html
+++ b/archive/docs/es/3.4.0/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.4.0/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/es/3.4.0/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.4.0/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/es/3.4.0/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.4.0/cordova/plugins/pluginapis.html
+++ b/archive/docs/es/3.4.0/cordova/plugins/pluginapis.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.4.0/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/es/3.4.0/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.4.0/cordova/storage/storage.html
+++ b/archive/docs/es/3.4.0/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.4.0/guide/appdev/privacy/index.html
+++ b/archive/docs/es/3.4.0/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.4.0/guide/appdev/whitelist/index.html
+++ b/archive/docs/es/3.4.0/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.4.0/guide/cli/index.html
+++ b/archive/docs/es/3.4.0/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.4.0/guide/hybrid/plugins/index.html
+++ b/archive/docs/es/3.4.0/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.4.0/guide/hybrid/webviews/index.html
+++ b/archive/docs/es/3.4.0/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.4.0/guide/overview/index.html
+++ b/archive/docs/es/3.4.0/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.4.0/guide/platforms/amazonfireos/config.html
+++ b/archive/docs/es/3.4.0/guide/platforms/amazonfireos/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.4.0/guide/platforms/amazonfireos/index.html
+++ b/archive/docs/es/3.4.0/guide/platforms/amazonfireos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.4.0/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/es/3.4.0/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.4.0/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/es/3.4.0/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.4.0/guide/platforms/android/config.html
+++ b/archive/docs/es/3.4.0/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.4.0/guide/platforms/android/index.html
+++ b/archive/docs/es/3.4.0/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.4.0/guide/platforms/android/plugin.html
+++ b/archive/docs/es/3.4.0/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.4.0/guide/platforms/android/tools.html
+++ b/archive/docs/es/3.4.0/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.4.0/guide/platforms/android/upgrading.html
+++ b/archive/docs/es/3.4.0/guide/platforms/android/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.4.0/guide/platforms/android/webview.html
+++ b/archive/docs/es/3.4.0/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.4.0/guide/platforms/blackberry/index.html
+++ b/archive/docs/es/3.4.0/guide/platforms/blackberry/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.4.0/guide/platforms/blackberry/upgrading.html
+++ b/archive/docs/es/3.4.0/guide/platforms/blackberry/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.4.0/guide/platforms/blackberry10/config.html
+++ b/archive/docs/es/3.4.0/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.4.0/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/es/3.4.0/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.4.0/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/es/3.4.0/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.4.0/guide/platforms/blackberry10/upgrading.html
+++ b/archive/docs/es/3.4.0/guide/platforms/blackberry10/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.4.0/guide/platforms/index.html
+++ b/archive/docs/es/3.4.0/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.4.0/guide/platforms/ios/config.html
+++ b/archive/docs/es/3.4.0/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.4.0/guide/platforms/ios/plugin.html
+++ b/archive/docs/es/3.4.0/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.4.0/guide/platforms/ios/tools.html
+++ b/archive/docs/es/3.4.0/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.4.0/guide/platforms/ios/upgrading.html
+++ b/archive/docs/es/3.4.0/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.4.0/guide/platforms/ios/webview.html
+++ b/archive/docs/es/3.4.0/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.4.0/guide/platforms/tizen/index.html
+++ b/archive/docs/es/3.4.0/guide/platforms/tizen/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.4.0/guide/platforms/ubuntu/index.html
+++ b/archive/docs/es/3.4.0/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.4.0/guide/platforms/win8/index.html
+++ b/archive/docs/es/3.4.0/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.4.0/guide/platforms/win8/tools.html
+++ b/archive/docs/es/3.4.0/guide/platforms/win8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.4.0/guide/platforms/win8/upgrading.html
+++ b/archive/docs/es/3.4.0/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.4.0/guide/platforms/wp7/index.html
+++ b/archive/docs/es/3.4.0/guide/platforms/wp7/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.4.0/guide/platforms/wp8/index.html
+++ b/archive/docs/es/3.4.0/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.4.0/guide/platforms/wp8/plugin.html
+++ b/archive/docs/es/3.4.0/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.4.0/guide/platforms/wp8/tools.html
+++ b/archive/docs/es/3.4.0/guide/platforms/wp8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.4.0/guide/platforms/wp8/upgrading.html
+++ b/archive/docs/es/3.4.0/guide/platforms/wp8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.4.0/guide/support/index.html
+++ b/archive/docs/es/3.4.0/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.4.0/index.html
+++ b/archive/docs/es/3.4.0/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.5.0/config_ref/images.html
+++ b/archive/docs/es/3.5.0/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.5.0/config_ref/index.html
+++ b/archive/docs/es/3.5.0/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.5.0/cordova/events/events.backbutton.html
+++ b/archive/docs/es/3.5.0/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.5.0/cordova/events/events.deviceready.html
+++ b/archive/docs/es/3.5.0/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.5.0/cordova/events/events.endcallbutton.html
+++ b/archive/docs/es/3.5.0/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.5.0/cordova/events/events.html
+++ b/archive/docs/es/3.5.0/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.5.0/cordova/events/events.menubutton.html
+++ b/archive/docs/es/3.5.0/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.5.0/cordova/events/events.pause.html
+++ b/archive/docs/es/3.5.0/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.5.0/cordova/events/events.resume.html
+++ b/archive/docs/es/3.5.0/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.5.0/cordova/events/events.searchbutton.html
+++ b/archive/docs/es/3.5.0/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.5.0/cordova/events/events.startcallbutton.html
+++ b/archive/docs/es/3.5.0/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.5.0/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/es/3.5.0/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.5.0/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/es/3.5.0/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.5.0/cordova/plugins/pluginapis.html
+++ b/archive/docs/es/3.5.0/cordova/plugins/pluginapis.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.5.0/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/es/3.5.0/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.5.0/cordova/storage/storage.html
+++ b/archive/docs/es/3.5.0/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.5.0/guide/appdev/privacy/index.html
+++ b/archive/docs/es/3.5.0/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.5.0/guide/appdev/whitelist/index.html
+++ b/archive/docs/es/3.5.0/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.5.0/guide/cli/index.html
+++ b/archive/docs/es/3.5.0/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.5.0/guide/hybrid/plugins/index.html
+++ b/archive/docs/es/3.5.0/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.5.0/guide/hybrid/webviews/index.html
+++ b/archive/docs/es/3.5.0/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.5.0/guide/overview/index.html
+++ b/archive/docs/es/3.5.0/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.5.0/guide/platforms/amazonfireos/config.html
+++ b/archive/docs/es/3.5.0/guide/platforms/amazonfireos/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.5.0/guide/platforms/amazonfireos/index.html
+++ b/archive/docs/es/3.5.0/guide/platforms/amazonfireos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.5.0/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/es/3.5.0/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.5.0/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/es/3.5.0/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.5.0/guide/platforms/android/config.html
+++ b/archive/docs/es/3.5.0/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.5.0/guide/platforms/android/index.html
+++ b/archive/docs/es/3.5.0/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.5.0/guide/platforms/android/plugin.html
+++ b/archive/docs/es/3.5.0/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.5.0/guide/platforms/android/tools.html
+++ b/archive/docs/es/3.5.0/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.5.0/guide/platforms/android/upgrading.html
+++ b/archive/docs/es/3.5.0/guide/platforms/android/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.5.0/guide/platforms/android/webview.html
+++ b/archive/docs/es/3.5.0/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.5.0/guide/platforms/blackberry/index.html
+++ b/archive/docs/es/3.5.0/guide/platforms/blackberry/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.5.0/guide/platforms/blackberry/upgrading.html
+++ b/archive/docs/es/3.5.0/guide/platforms/blackberry/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.5.0/guide/platforms/blackberry10/config.html
+++ b/archive/docs/es/3.5.0/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.5.0/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/es/3.5.0/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.5.0/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/es/3.5.0/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.5.0/guide/platforms/blackberry10/upgrading.html
+++ b/archive/docs/es/3.5.0/guide/platforms/blackberry10/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.5.0/guide/platforms/firefoxos/index.html
+++ b/archive/docs/es/3.5.0/guide/platforms/firefoxos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.5.0/guide/platforms/index.html
+++ b/archive/docs/es/3.5.0/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.5.0/guide/platforms/ios/config.html
+++ b/archive/docs/es/3.5.0/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.5.0/guide/platforms/ios/plugin.html
+++ b/archive/docs/es/3.5.0/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.5.0/guide/platforms/ios/tools.html
+++ b/archive/docs/es/3.5.0/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.5.0/guide/platforms/ios/upgrading.html
+++ b/archive/docs/es/3.5.0/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.5.0/guide/platforms/ios/webview.html
+++ b/archive/docs/es/3.5.0/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.5.0/guide/platforms/tizen/index.html
+++ b/archive/docs/es/3.5.0/guide/platforms/tizen/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.5.0/guide/platforms/ubuntu/index.html
+++ b/archive/docs/es/3.5.0/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.5.0/guide/platforms/win8/index.html
+++ b/archive/docs/es/3.5.0/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.5.0/guide/platforms/win8/upgrading.html
+++ b/archive/docs/es/3.5.0/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.5.0/guide/platforms/wp8/index.html
+++ b/archive/docs/es/3.5.0/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.5.0/guide/platforms/wp8/plugin.html
+++ b/archive/docs/es/3.5.0/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.5.0/guide/platforms/wp8/upgrading.html
+++ b/archive/docs/es/3.5.0/guide/platforms/wp8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.5.0/guide/support/index.html
+++ b/archive/docs/es/3.5.0/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/3.5.0/index.html
+++ b/archive/docs/es/3.5.0/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/config_ref/index.html
+++ b/archive/docs/es/5.4.0/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/cordova/events/events.backbutton.html
+++ b/archive/docs/es/5.4.0/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/cordova/events/events.deviceready.html
+++ b/archive/docs/es/5.4.0/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/cordova/events/events.endcallbutton.html
+++ b/archive/docs/es/5.4.0/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/cordova/events/events.html
+++ b/archive/docs/es/5.4.0/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/cordova/events/events.menubutton.html
+++ b/archive/docs/es/5.4.0/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/cordova/events/events.pause.html
+++ b/archive/docs/es/5.4.0/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/cordova/events/events.resume.html
+++ b/archive/docs/es/5.4.0/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/cordova/events/events.searchbutton.html
+++ b/archive/docs/es/5.4.0/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/cordova/events/events.startcallbutton.html
+++ b/archive/docs/es/5.4.0/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/es/5.4.0/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/es/5.4.0/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/cordova/plugins/pluginapis.html
+++ b/archive/docs/es/5.4.0/cordova/plugins/pluginapis.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/es/5.4.0/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/cordova/storage/storage.html
+++ b/archive/docs/es/5.4.0/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/guide/appdev/hooks/index.html
+++ b/archive/docs/es/5.4.0/guide/appdev/hooks/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/guide/appdev/privacy/index.html
+++ b/archive/docs/es/5.4.0/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/guide/appdev/security/index.html
+++ b/archive/docs/es/5.4.0/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/guide/appdev/whitelist/index.html
+++ b/archive/docs/es/5.4.0/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/guide/cli/index.html
+++ b/archive/docs/es/5.4.0/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/guide/hybrid/plugins/index.html
+++ b/archive/docs/es/5.4.0/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/guide/hybrid/webviews/index.html
+++ b/archive/docs/es/5.4.0/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/guide/overview/index.html
+++ b/archive/docs/es/5.4.0/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/guide/platforms/amazonfireos/config.html
+++ b/archive/docs/es/5.4.0/guide/platforms/amazonfireos/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/guide/platforms/amazonfireos/index.html
+++ b/archive/docs/es/5.4.0/guide/platforms/amazonfireos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/es/5.4.0/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/es/5.4.0/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/guide/platforms/android/config.html
+++ b/archive/docs/es/5.4.0/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/guide/platforms/android/index.html
+++ b/archive/docs/es/5.4.0/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/guide/platforms/android/plugin.html
+++ b/archive/docs/es/5.4.0/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/guide/platforms/android/tools.html
+++ b/archive/docs/es/5.4.0/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/guide/platforms/android/upgrading.html
+++ b/archive/docs/es/5.4.0/guide/platforms/android/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/guide/platforms/android/webview.html
+++ b/archive/docs/es/5.4.0/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/guide/platforms/blackberry/upgrading.html
+++ b/archive/docs/es/5.4.0/guide/platforms/blackberry/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/guide/platforms/blackberry10/config.html
+++ b/archive/docs/es/5.4.0/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/guide/platforms/blackberry10/index.html
+++ b/archive/docs/es/5.4.0/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/es/5.4.0/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/es/5.4.0/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/guide/platforms/firefoxos/index.html
+++ b/archive/docs/es/5.4.0/guide/platforms/firefoxos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/guide/platforms/index.html
+++ b/archive/docs/es/5.4.0/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/guide/platforms/ios/config.html
+++ b/archive/docs/es/5.4.0/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/guide/platforms/ios/index.html
+++ b/archive/docs/es/5.4.0/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/guide/platforms/ios/plugin.html
+++ b/archive/docs/es/5.4.0/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/guide/platforms/ios/tools.html
+++ b/archive/docs/es/5.4.0/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/guide/platforms/ios/upgrading.html
+++ b/archive/docs/es/5.4.0/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/guide/platforms/ios/webview.html
+++ b/archive/docs/es/5.4.0/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/guide/platforms/tizen/index.html
+++ b/archive/docs/es/5.4.0/guide/platforms/tizen/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/guide/platforms/ubuntu/index.html
+++ b/archive/docs/es/5.4.0/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/guide/platforms/win8/index.html
+++ b/archive/docs/es/5.4.0/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/guide/platforms/win8/packaging.html
+++ b/archive/docs/es/5.4.0/guide/platforms/win8/packaging.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/guide/platforms/win8/plugin.html
+++ b/archive/docs/es/5.4.0/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/guide/platforms/win8/upgrading.html
+++ b/archive/docs/es/5.4.0/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/guide/platforms/wp8/index.html
+++ b/archive/docs/es/5.4.0/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/guide/platforms/wp8/plugin.html
+++ b/archive/docs/es/5.4.0/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/es/5.4.0/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/guide/platforms/wp8/webview.html
+++ b/archive/docs/es/5.4.0/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/guide/support/index.html
+++ b/archive/docs/es/5.4.0/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/index.html
+++ b/archive/docs/es/5.4.0/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/es/5.4.0/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/plugin_ref/plugman.html
+++ b/archive/docs/es/5.4.0/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/5.4.0/plugin_ref/spec.html
+++ b/archive/docs/es/5.4.0/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/config_ref/images.html
+++ b/archive/docs/es/6.x/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/config_ref/index.html
+++ b/archive/docs/es/6.x/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/cordova/events/events.backbutton.html
+++ b/archive/docs/es/6.x/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/cordova/events/events.deviceready.html
+++ b/archive/docs/es/6.x/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/cordova/events/events.endcallbutton.html
+++ b/archive/docs/es/6.x/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/cordova/events/events.html
+++ b/archive/docs/es/6.x/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/cordova/events/events.menubutton.html
+++ b/archive/docs/es/6.x/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/cordova/events/events.pause.html
+++ b/archive/docs/es/6.x/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/cordova/events/events.resume.html
+++ b/archive/docs/es/6.x/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/cordova/events/events.searchbutton.html
+++ b/archive/docs/es/6.x/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/cordova/events/events.startcallbutton.html
+++ b/archive/docs/es/6.x/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/es/6.x/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/es/6.x/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/es/6.x/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/cordova/storage/storage.html
+++ b/archive/docs/es/6.x/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/guide/appdev/hooks/index.html
+++ b/archive/docs/es/6.x/guide/appdev/hooks/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/guide/appdev/privacy/index.html
+++ b/archive/docs/es/6.x/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/guide/appdev/security/index.html
+++ b/archive/docs/es/6.x/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/guide/appdev/whitelist/index.html
+++ b/archive/docs/es/6.x/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/guide/cli/index.html
+++ b/archive/docs/es/6.x/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/guide/hybrid/plugins/index.html
+++ b/archive/docs/es/6.x/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/guide/hybrid/webviews/index.html
+++ b/archive/docs/es/6.x/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/guide/next/index.html
+++ b/archive/docs/es/6.x/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/guide/overview/index.html
+++ b/archive/docs/es/6.x/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/guide/platforms/amazonfireos/config.html
+++ b/archive/docs/es/6.x/guide/platforms/amazonfireos/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/guide/platforms/amazonfireos/index.html
+++ b/archive/docs/es/6.x/guide/platforms/amazonfireos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/es/6.x/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/es/6.x/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/guide/platforms/android/config.html
+++ b/archive/docs/es/6.x/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/guide/platforms/android/index.html
+++ b/archive/docs/es/6.x/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/guide/platforms/android/plugin.html
+++ b/archive/docs/es/6.x/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/guide/platforms/android/tools.html
+++ b/archive/docs/es/6.x/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/guide/platforms/android/upgrading.html
+++ b/archive/docs/es/6.x/guide/platforms/android/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/guide/platforms/android/webview.html
+++ b/archive/docs/es/6.x/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/guide/platforms/blackberry/upgrading.html
+++ b/archive/docs/es/6.x/guide/platforms/blackberry/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/guide/platforms/blackberry10/config.html
+++ b/archive/docs/es/6.x/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/guide/platforms/blackberry10/home.html
+++ b/archive/docs/es/6.x/guide/platforms/blackberry10/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/guide/platforms/blackberry10/index.html
+++ b/archive/docs/es/6.x/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/es/6.x/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/es/6.x/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/guide/platforms/blackberry10/upgrade.html
+++ b/archive/docs/es/6.x/guide/platforms/blackberry10/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/guide/platforms/firefoxos/index.html
+++ b/archive/docs/es/6.x/guide/platforms/firefoxos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/guide/platforms/index.html
+++ b/archive/docs/es/6.x/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/guide/platforms/ios/config.html
+++ b/archive/docs/es/6.x/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/guide/platforms/ios/index.html
+++ b/archive/docs/es/6.x/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/guide/platforms/ios/plugin.html
+++ b/archive/docs/es/6.x/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/guide/platforms/ios/tools.html
+++ b/archive/docs/es/6.x/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/guide/platforms/ios/upgrading.html
+++ b/archive/docs/es/6.x/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/guide/platforms/ios/webview.html
+++ b/archive/docs/es/6.x/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/guide/platforms/tizen/index.html
+++ b/archive/docs/es/6.x/guide/platforms/tizen/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/guide/platforms/ubuntu/index.html
+++ b/archive/docs/es/6.x/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/guide/platforms/win8/index.html
+++ b/archive/docs/es/6.x/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/guide/platforms/win8/packaging.html
+++ b/archive/docs/es/6.x/guide/platforms/win8/packaging.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/guide/platforms/win8/plugin.html
+++ b/archive/docs/es/6.x/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/guide/platforms/win8/upgrading.html
+++ b/archive/docs/es/6.x/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/guide/platforms/wp8/home.html
+++ b/archive/docs/es/6.x/guide/platforms/wp8/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/guide/platforms/wp8/index.html
+++ b/archive/docs/es/6.x/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/guide/platforms/wp8/plugin.html
+++ b/archive/docs/es/6.x/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/es/6.x/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/guide/platforms/wp8/webview.html
+++ b/archive/docs/es/6.x/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/guide/support/index.html
+++ b/archive/docs/es/6.x/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/index.html
+++ b/archive/docs/es/6.x/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/es/6.x/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/plugin_ref/plugman.html
+++ b/archive/docs/es/6.x/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/6.x/plugin_ref/spec.html
+++ b/archive/docs/es/6.x/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/config_ref/images.html
+++ b/archive/docs/es/7.x/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/config_ref/index.html
+++ b/archive/docs/es/7.x/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/cordova/events/events.backbutton.html
+++ b/archive/docs/es/7.x/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/cordova/events/events.deviceready.html
+++ b/archive/docs/es/7.x/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/cordova/events/events.endcallbutton.html
+++ b/archive/docs/es/7.x/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/cordova/events/events.html
+++ b/archive/docs/es/7.x/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/cordova/events/events.menubutton.html
+++ b/archive/docs/es/7.x/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/cordova/events/events.pause.html
+++ b/archive/docs/es/7.x/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/cordova/events/events.resume.html
+++ b/archive/docs/es/7.x/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/cordova/events/events.searchbutton.html
+++ b/archive/docs/es/7.x/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/cordova/events/events.startcallbutton.html
+++ b/archive/docs/es/7.x/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/es/7.x/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/es/7.x/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/es/7.x/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/cordova/storage/storage.html
+++ b/archive/docs/es/7.x/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/guide/appdev/hooks/index.html
+++ b/archive/docs/es/7.x/guide/appdev/hooks/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/guide/appdev/privacy/index.html
+++ b/archive/docs/es/7.x/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/guide/appdev/security/index.html
+++ b/archive/docs/es/7.x/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/guide/appdev/whitelist/index.html
+++ b/archive/docs/es/7.x/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/guide/cli/index.html
+++ b/archive/docs/es/7.x/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/guide/hybrid/plugins/index.html
+++ b/archive/docs/es/7.x/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/guide/hybrid/webviews/index.html
+++ b/archive/docs/es/7.x/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/guide/next/index.html
+++ b/archive/docs/es/7.x/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/guide/overview/index.html
+++ b/archive/docs/es/7.x/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/guide/platforms/amazonfireos/config.html
+++ b/archive/docs/es/7.x/guide/platforms/amazonfireos/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/guide/platforms/amazonfireos/index.html
+++ b/archive/docs/es/7.x/guide/platforms/amazonfireos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/es/7.x/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/es/7.x/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/guide/platforms/android/config.html
+++ b/archive/docs/es/7.x/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/guide/platforms/android/index.html
+++ b/archive/docs/es/7.x/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/guide/platforms/android/plugin.html
+++ b/archive/docs/es/7.x/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/guide/platforms/android/tools.html
+++ b/archive/docs/es/7.x/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/guide/platforms/android/upgrading.html
+++ b/archive/docs/es/7.x/guide/platforms/android/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/guide/platforms/android/webview.html
+++ b/archive/docs/es/7.x/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/guide/platforms/blackberry/upgrading.html
+++ b/archive/docs/es/7.x/guide/platforms/blackberry/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/guide/platforms/blackberry10/config.html
+++ b/archive/docs/es/7.x/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/guide/platforms/blackberry10/home.html
+++ b/archive/docs/es/7.x/guide/platforms/blackberry10/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/guide/platforms/blackberry10/index.html
+++ b/archive/docs/es/7.x/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/es/7.x/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/es/7.x/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/guide/platforms/blackberry10/upgrade.html
+++ b/archive/docs/es/7.x/guide/platforms/blackberry10/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/guide/platforms/firefoxos/index.html
+++ b/archive/docs/es/7.x/guide/platforms/firefoxos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/guide/platforms/index.html
+++ b/archive/docs/es/7.x/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/guide/platforms/ios/config.html
+++ b/archive/docs/es/7.x/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/guide/platforms/ios/index.html
+++ b/archive/docs/es/7.x/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/guide/platforms/ios/plugin.html
+++ b/archive/docs/es/7.x/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/guide/platforms/ios/tools.html
+++ b/archive/docs/es/7.x/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/guide/platforms/ios/upgrading.html
+++ b/archive/docs/es/7.x/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/guide/platforms/ios/webview.html
+++ b/archive/docs/es/7.x/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/guide/platforms/tizen/index.html
+++ b/archive/docs/es/7.x/guide/platforms/tizen/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/guide/platforms/ubuntu/index.html
+++ b/archive/docs/es/7.x/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/guide/platforms/win8/index.html
+++ b/archive/docs/es/7.x/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/guide/platforms/win8/packaging.html
+++ b/archive/docs/es/7.x/guide/platforms/win8/packaging.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/guide/platforms/win8/plugin.html
+++ b/archive/docs/es/7.x/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/guide/platforms/win8/upgrading.html
+++ b/archive/docs/es/7.x/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/guide/platforms/wp8/home.html
+++ b/archive/docs/es/7.x/guide/platforms/wp8/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/guide/platforms/wp8/index.html
+++ b/archive/docs/es/7.x/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/guide/platforms/wp8/plugin.html
+++ b/archive/docs/es/7.x/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/es/7.x/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/guide/platforms/wp8/webview.html
+++ b/archive/docs/es/7.x/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/guide/support/index.html
+++ b/archive/docs/es/7.x/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/index.html
+++ b/archive/docs/es/7.x/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/es/7.x/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/plugin_ref/plugman.html
+++ b/archive/docs/es/7.x/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/7.x/plugin_ref/spec.html
+++ b/archive/docs/es/7.x/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/config_ref/images.html
+++ b/archive/docs/es/8.x/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/config_ref/index.html
+++ b/archive/docs/es/8.x/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/cordova/events/events.backbutton.html
+++ b/archive/docs/es/8.x/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/cordova/events/events.deviceready.html
+++ b/archive/docs/es/8.x/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/cordova/events/events.endcallbutton.html
+++ b/archive/docs/es/8.x/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/cordova/events/events.html
+++ b/archive/docs/es/8.x/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/cordova/events/events.menubutton.html
+++ b/archive/docs/es/8.x/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/cordova/events/events.pause.html
+++ b/archive/docs/es/8.x/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/cordova/events/events.resume.html
+++ b/archive/docs/es/8.x/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/cordova/events/events.searchbutton.html
+++ b/archive/docs/es/8.x/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/cordova/events/events.startcallbutton.html
+++ b/archive/docs/es/8.x/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/es/8.x/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/es/8.x/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/es/8.x/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/cordova/storage/storage.html
+++ b/archive/docs/es/8.x/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/guide/appdev/hooks/index.html
+++ b/archive/docs/es/8.x/guide/appdev/hooks/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/guide/appdev/privacy/index.html
+++ b/archive/docs/es/8.x/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/guide/appdev/security/index.html
+++ b/archive/docs/es/8.x/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/guide/appdev/whitelist/index.html
+++ b/archive/docs/es/8.x/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/guide/cli/index.html
+++ b/archive/docs/es/8.x/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/guide/hybrid/plugins/index.html
+++ b/archive/docs/es/8.x/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/guide/hybrid/webviews/index.html
+++ b/archive/docs/es/8.x/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/guide/next/index.html
+++ b/archive/docs/es/8.x/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/guide/overview/index.html
+++ b/archive/docs/es/8.x/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/guide/platforms/amazonfireos/config.html
+++ b/archive/docs/es/8.x/guide/platforms/amazonfireos/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/guide/platforms/amazonfireos/index.html
+++ b/archive/docs/es/8.x/guide/platforms/amazonfireos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/es/8.x/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/es/8.x/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/guide/platforms/android/config.html
+++ b/archive/docs/es/8.x/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/guide/platforms/android/index.html
+++ b/archive/docs/es/8.x/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/guide/platforms/android/plugin.html
+++ b/archive/docs/es/8.x/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/guide/platforms/android/tools.html
+++ b/archive/docs/es/8.x/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/guide/platforms/android/upgrading.html
+++ b/archive/docs/es/8.x/guide/platforms/android/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/guide/platforms/android/webview.html
+++ b/archive/docs/es/8.x/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/guide/platforms/blackberry/upgrading.html
+++ b/archive/docs/es/8.x/guide/platforms/blackberry/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/guide/platforms/blackberry10/config.html
+++ b/archive/docs/es/8.x/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/guide/platforms/blackberry10/home.html
+++ b/archive/docs/es/8.x/guide/platforms/blackberry10/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/guide/platforms/blackberry10/index.html
+++ b/archive/docs/es/8.x/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/es/8.x/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/es/8.x/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/guide/platforms/blackberry10/upgrade.html
+++ b/archive/docs/es/8.x/guide/platforms/blackberry10/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/guide/platforms/firefoxos/index.html
+++ b/archive/docs/es/8.x/guide/platforms/firefoxos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/guide/platforms/index.html
+++ b/archive/docs/es/8.x/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/guide/platforms/ios/config.html
+++ b/archive/docs/es/8.x/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/guide/platforms/ios/index.html
+++ b/archive/docs/es/8.x/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/guide/platforms/ios/plugin.html
+++ b/archive/docs/es/8.x/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/guide/platforms/ios/tools.html
+++ b/archive/docs/es/8.x/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/guide/platforms/ios/upgrading.html
+++ b/archive/docs/es/8.x/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/guide/platforms/ios/webview.html
+++ b/archive/docs/es/8.x/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/guide/platforms/tizen/index.html
+++ b/archive/docs/es/8.x/guide/platforms/tizen/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/guide/platforms/ubuntu/index.html
+++ b/archive/docs/es/8.x/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/guide/platforms/win8/index.html
+++ b/archive/docs/es/8.x/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/guide/platforms/win8/packaging.html
+++ b/archive/docs/es/8.x/guide/platforms/win8/packaging.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/guide/platforms/win8/plugin.html
+++ b/archive/docs/es/8.x/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/guide/platforms/win8/upgrading.html
+++ b/archive/docs/es/8.x/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/guide/platforms/wp8/home.html
+++ b/archive/docs/es/8.x/guide/platforms/wp8/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/guide/platforms/wp8/index.html
+++ b/archive/docs/es/8.x/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/guide/platforms/wp8/plugin.html
+++ b/archive/docs/es/8.x/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/es/8.x/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/guide/platforms/wp8/webview.html
+++ b/archive/docs/es/8.x/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/guide/support/index.html
+++ b/archive/docs/es/8.x/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/index.html
+++ b/archive/docs/es/8.x/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/es/8.x/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/plugin_ref/plugman.html
+++ b/archive/docs/es/8.x/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/8.x/plugin_ref/spec.html
+++ b/archive/docs/es/8.x/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/config_ref/images.html
+++ b/archive/docs/es/9.x/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/config_ref/index.html
+++ b/archive/docs/es/9.x/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/cordova/events/events.backbutton.html
+++ b/archive/docs/es/9.x/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/cordova/events/events.deviceready.html
+++ b/archive/docs/es/9.x/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/cordova/events/events.endcallbutton.html
+++ b/archive/docs/es/9.x/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/cordova/events/events.html
+++ b/archive/docs/es/9.x/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/cordova/events/events.menubutton.html
+++ b/archive/docs/es/9.x/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/cordova/events/events.pause.html
+++ b/archive/docs/es/9.x/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/cordova/events/events.resume.html
+++ b/archive/docs/es/9.x/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/cordova/events/events.searchbutton.html
+++ b/archive/docs/es/9.x/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/cordova/events/events.startcallbutton.html
+++ b/archive/docs/es/9.x/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/es/9.x/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/es/9.x/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/es/9.x/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/cordova/storage/storage.html
+++ b/archive/docs/es/9.x/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/guide/appdev/hooks/index.html
+++ b/archive/docs/es/9.x/guide/appdev/hooks/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/guide/appdev/privacy/index.html
+++ b/archive/docs/es/9.x/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/guide/appdev/security/index.html
+++ b/archive/docs/es/9.x/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/guide/appdev/whitelist/index.html
+++ b/archive/docs/es/9.x/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/guide/cli/index.html
+++ b/archive/docs/es/9.x/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/guide/hybrid/plugins/index.html
+++ b/archive/docs/es/9.x/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/guide/hybrid/webviews/index.html
+++ b/archive/docs/es/9.x/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/guide/next/index.html
+++ b/archive/docs/es/9.x/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/guide/overview/index.html
+++ b/archive/docs/es/9.x/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/guide/platforms/amazonfireos/config.html
+++ b/archive/docs/es/9.x/guide/platforms/amazonfireos/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/guide/platforms/amazonfireos/index.html
+++ b/archive/docs/es/9.x/guide/platforms/amazonfireos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/es/9.x/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/es/9.x/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/guide/platforms/android/config.html
+++ b/archive/docs/es/9.x/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/guide/platforms/android/index.html
+++ b/archive/docs/es/9.x/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/guide/platforms/android/plugin.html
+++ b/archive/docs/es/9.x/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/guide/platforms/android/tools.html
+++ b/archive/docs/es/9.x/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/guide/platforms/android/upgrading.html
+++ b/archive/docs/es/9.x/guide/platforms/android/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/guide/platforms/android/webview.html
+++ b/archive/docs/es/9.x/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/guide/platforms/blackberry/upgrading.html
+++ b/archive/docs/es/9.x/guide/platforms/blackberry/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/guide/platforms/blackberry10/config.html
+++ b/archive/docs/es/9.x/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/guide/platforms/blackberry10/home.html
+++ b/archive/docs/es/9.x/guide/platforms/blackberry10/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/guide/platforms/blackberry10/index.html
+++ b/archive/docs/es/9.x/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/es/9.x/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/es/9.x/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/guide/platforms/blackberry10/upgrade.html
+++ b/archive/docs/es/9.x/guide/platforms/blackberry10/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/guide/platforms/firefoxos/index.html
+++ b/archive/docs/es/9.x/guide/platforms/firefoxos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/guide/platforms/index.html
+++ b/archive/docs/es/9.x/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/guide/platforms/ios/config.html
+++ b/archive/docs/es/9.x/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/guide/platforms/ios/index.html
+++ b/archive/docs/es/9.x/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/guide/platforms/ios/plugin.html
+++ b/archive/docs/es/9.x/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/guide/platforms/ios/tools.html
+++ b/archive/docs/es/9.x/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/guide/platforms/ios/upgrading.html
+++ b/archive/docs/es/9.x/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/guide/platforms/ios/webview.html
+++ b/archive/docs/es/9.x/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/guide/platforms/tizen/index.html
+++ b/archive/docs/es/9.x/guide/platforms/tizen/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/guide/platforms/ubuntu/index.html
+++ b/archive/docs/es/9.x/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/guide/platforms/win8/index.html
+++ b/archive/docs/es/9.x/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/guide/platforms/win8/packaging.html
+++ b/archive/docs/es/9.x/guide/platforms/win8/packaging.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/guide/platforms/win8/plugin.html
+++ b/archive/docs/es/9.x/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/guide/platforms/win8/upgrading.html
+++ b/archive/docs/es/9.x/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/guide/platforms/wp8/home.html
+++ b/archive/docs/es/9.x/guide/platforms/wp8/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/guide/platforms/wp8/index.html
+++ b/archive/docs/es/9.x/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/guide/platforms/wp8/plugin.html
+++ b/archive/docs/es/9.x/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/es/9.x/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/guide/platforms/wp8/webview.html
+++ b/archive/docs/es/9.x/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/guide/support/index.html
+++ b/archive/docs/es/9.x/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/index.html
+++ b/archive/docs/es/9.x/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/es/9.x/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/plugin_ref/plugman.html
+++ b/archive/docs/es/9.x/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/es/9.x/plugin_ref/spec.html
+++ b/archive/docs/es/9.x/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/config_ref/images.html
+++ b/archive/docs/fr/10.x/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/config_ref/index.html
+++ b/archive/docs/fr/10.x/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/cordova/events/events.backbutton.html
+++ b/archive/docs/fr/10.x/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/cordova/events/events.deviceready.html
+++ b/archive/docs/fr/10.x/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/cordova/events/events.endcallbutton.html
+++ b/archive/docs/fr/10.x/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/cordova/events/events.html
+++ b/archive/docs/fr/10.x/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/cordova/events/events.menubutton.html
+++ b/archive/docs/fr/10.x/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/cordova/events/events.pause.html
+++ b/archive/docs/fr/10.x/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/cordova/events/events.resume.html
+++ b/archive/docs/fr/10.x/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/cordova/events/events.searchbutton.html
+++ b/archive/docs/fr/10.x/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/cordova/events/events.startcallbutton.html
+++ b/archive/docs/fr/10.x/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/fr/10.x/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/fr/10.x/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/fr/10.x/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/cordova/storage/storage.html
+++ b/archive/docs/fr/10.x/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/guide/appdev/hooks/index.html
+++ b/archive/docs/fr/10.x/guide/appdev/hooks/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/guide/appdev/privacy/index.html
+++ b/archive/docs/fr/10.x/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/guide/appdev/security/index.html
+++ b/archive/docs/fr/10.x/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/guide/appdev/whitelist/index.html
+++ b/archive/docs/fr/10.x/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/guide/cli/index.html
+++ b/archive/docs/fr/10.x/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/guide/hybrid/plugins/index.html
+++ b/archive/docs/fr/10.x/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/guide/hybrid/webviews/index.html
+++ b/archive/docs/fr/10.x/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/guide/next/index.html
+++ b/archive/docs/fr/10.x/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/guide/overview/index.html
+++ b/archive/docs/fr/10.x/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/guide/platforms/amazonfireos/config.html
+++ b/archive/docs/fr/10.x/guide/platforms/amazonfireos/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/guide/platforms/amazonfireos/index.html
+++ b/archive/docs/fr/10.x/guide/platforms/amazonfireos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/fr/10.x/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/fr/10.x/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/guide/platforms/android/index.html
+++ b/archive/docs/fr/10.x/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/guide/platforms/android/plugin.html
+++ b/archive/docs/fr/10.x/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/guide/platforms/android/tools.html
+++ b/archive/docs/fr/10.x/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/guide/platforms/android/upgrading.html
+++ b/archive/docs/fr/10.x/guide/platforms/android/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/guide/platforms/android/webview.html
+++ b/archive/docs/fr/10.x/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/guide/platforms/blackberry/config.html
+++ b/archive/docs/fr/10.x/guide/platforms/blackberry/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/guide/platforms/blackberry10/config.html
+++ b/archive/docs/fr/10.x/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/guide/platforms/blackberry10/home.html
+++ b/archive/docs/fr/10.x/guide/platforms/blackberry10/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/guide/platforms/blackberry10/index.html
+++ b/archive/docs/fr/10.x/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/fr/10.x/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/fr/10.x/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/guide/platforms/blackberry10/upgrade.html
+++ b/archive/docs/fr/10.x/guide/platforms/blackberry10/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/guide/platforms/blackberry10/upgrading.html
+++ b/archive/docs/fr/10.x/guide/platforms/blackberry10/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/guide/platforms/firefoxos/index.html
+++ b/archive/docs/fr/10.x/guide/platforms/firefoxos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/guide/platforms/index.html
+++ b/archive/docs/fr/10.x/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/guide/platforms/ios/config.html
+++ b/archive/docs/fr/10.x/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/guide/platforms/ios/index.html
+++ b/archive/docs/fr/10.x/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/guide/platforms/ios/plugin.html
+++ b/archive/docs/fr/10.x/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/guide/platforms/ios/tools.html
+++ b/archive/docs/fr/10.x/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/guide/platforms/ios/upgrading.html
+++ b/archive/docs/fr/10.x/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/guide/platforms/ios/webview.html
+++ b/archive/docs/fr/10.x/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/guide/platforms/tizen/index.html
+++ b/archive/docs/fr/10.x/guide/platforms/tizen/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/guide/platforms/ubuntu/index.html
+++ b/archive/docs/fr/10.x/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/guide/platforms/win8/index.html
+++ b/archive/docs/fr/10.x/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/guide/platforms/win8/packaging.html
+++ b/archive/docs/fr/10.x/guide/platforms/win8/packaging.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/guide/platforms/win8/plugin.html
+++ b/archive/docs/fr/10.x/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/guide/platforms/win8/upgrading.html
+++ b/archive/docs/fr/10.x/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/guide/platforms/wp8/home.html
+++ b/archive/docs/fr/10.x/guide/platforms/wp8/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/guide/platforms/wp8/index.html
+++ b/archive/docs/fr/10.x/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/guide/platforms/wp8/plugin.html
+++ b/archive/docs/fr/10.x/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/fr/10.x/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/guide/platforms/wp8/webview.html
+++ b/archive/docs/fr/10.x/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/guide/support/index.html
+++ b/archive/docs/fr/10.x/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/index.html
+++ b/archive/docs/fr/10.x/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/fr/10.x/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/plugin_ref/plugman.html
+++ b/archive/docs/fr/10.x/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/10.x/plugin_ref/spec.html
+++ b/archive/docs/fr/10.x/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/config_ref/images.html
+++ b/archive/docs/fr/3.1.0/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/config_ref/index.html
+++ b/archive/docs/fr/3.1.0/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/accelerometer/accelerometer.clearWatch.html
+++ b/archive/docs/fr/3.1.0/cordova/accelerometer/accelerometer.clearWatch.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/accelerometer/accelerometer.getCurrentAcceleration.html
+++ b/archive/docs/fr/3.1.0/cordova/accelerometer/accelerometer.getCurrentAcceleration.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/accelerometer/accelerometer.html
+++ b/archive/docs/fr/3.1.0/cordova/accelerometer/accelerometer.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/accelerometer/accelerometer.watchAcceleration.html
+++ b/archive/docs/fr/3.1.0/cordova/accelerometer/accelerometer.watchAcceleration.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/accelerometer/parameters/accelerometerError.html
+++ b/archive/docs/fr/3.1.0/cordova/accelerometer/parameters/accelerometerError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/accelerometer/parameters/accelerometerOptions.html
+++ b/archive/docs/fr/3.1.0/cordova/accelerometer/parameters/accelerometerOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/accelerometer/parameters/accelerometerSuccess.html
+++ b/archive/docs/fr/3.1.0/cordova/accelerometer/parameters/accelerometerSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/camera/camera.getPicture.html
+++ b/archive/docs/fr/3.1.0/cordova/camera/camera.getPicture.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/camera/camera.html
+++ b/archive/docs/fr/3.1.0/cordova/camera/camera.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/compass/compass.clearWatch.html
+++ b/archive/docs/fr/3.1.0/cordova/compass/compass.clearWatch.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/compass/compass.clearWatchFilter.html
+++ b/archive/docs/fr/3.1.0/cordova/compass/compass.clearWatchFilter.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/compass/compass.getCurrentHeading.html
+++ b/archive/docs/fr/3.1.0/cordova/compass/compass.getCurrentHeading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/compass/compass.html
+++ b/archive/docs/fr/3.1.0/cordova/compass/compass.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/compass/compass.watchHeading.html
+++ b/archive/docs/fr/3.1.0/cordova/compass/compass.watchHeading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/compass/compass.watchHeadingFilter.html
+++ b/archive/docs/fr/3.1.0/cordova/compass/compass.watchHeadingFilter.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/compass/parameters/compassError.html
+++ b/archive/docs/fr/3.1.0/cordova/compass/parameters/compassError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/compass/parameters/compassHeading.html
+++ b/archive/docs/fr/3.1.0/cordova/compass/parameters/compassHeading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/compass/parameters/compassOptions.html
+++ b/archive/docs/fr/3.1.0/cordova/compass/parameters/compassOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/compass/parameters/compassSuccess.html
+++ b/archive/docs/fr/3.1.0/cordova/compass/parameters/compassSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/connection/connection.html
+++ b/archive/docs/fr/3.1.0/cordova/connection/connection.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/connection/connection.type.html
+++ b/archive/docs/fr/3.1.0/cordova/connection/connection.type.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/contacts/Contact/contact.html
+++ b/archive/docs/fr/3.1.0/cordova/contacts/Contact/contact.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/contacts/ContactAddress/contactaddress.html
+++ b/archive/docs/fr/3.1.0/cordova/contacts/ContactAddress/contactaddress.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/contacts/ContactError/contactError.html
+++ b/archive/docs/fr/3.1.0/cordova/contacts/ContactError/contactError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/contacts/ContactField/contactfield.html
+++ b/archive/docs/fr/3.1.0/cordova/contacts/ContactField/contactfield.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/contacts/ContactFindOptions/contactfindoptions.html
+++ b/archive/docs/fr/3.1.0/cordova/contacts/ContactFindOptions/contactfindoptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/contacts/ContactName/contactname.html
+++ b/archive/docs/fr/3.1.0/cordova/contacts/ContactName/contactname.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/contacts/ContactOrganization/contactorganization.html
+++ b/archive/docs/fr/3.1.0/cordova/contacts/ContactOrganization/contactorganization.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/contacts/contacts.create.html
+++ b/archive/docs/fr/3.1.0/cordova/contacts/contacts.create.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/contacts/contacts.html
+++ b/archive/docs/fr/3.1.0/cordova/contacts/contacts.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/contacts/parameters/contactError.html
+++ b/archive/docs/fr/3.1.0/cordova/contacts/parameters/contactError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/contacts/parameters/contactFields.html
+++ b/archive/docs/fr/3.1.0/cordova/contacts/parameters/contactFields.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/contacts/parameters/contactFindOptions.html
+++ b/archive/docs/fr/3.1.0/cordova/contacts/parameters/contactFindOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/contacts/parameters/contactSuccess.html
+++ b/archive/docs/fr/3.1.0/cordova/contacts/parameters/contactSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/device/device.cordova.html
+++ b/archive/docs/fr/3.1.0/cordova/device/device.cordova.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/device/device.html
+++ b/archive/docs/fr/3.1.0/cordova/device/device.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/device/device.model.html
+++ b/archive/docs/fr/3.1.0/cordova/device/device.model.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/device/device.name.html
+++ b/archive/docs/fr/3.1.0/cordova/device/device.name.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/device/device.platform.html
+++ b/archive/docs/fr/3.1.0/cordova/device/device.platform.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/device/device.uuid.html
+++ b/archive/docs/fr/3.1.0/cordova/device/device.uuid.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/device/device.version.html
+++ b/archive/docs/fr/3.1.0/cordova/device/device.version.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/events/events.backbutton.html
+++ b/archive/docs/fr/3.1.0/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/events/events.batterycritical.html
+++ b/archive/docs/fr/3.1.0/cordova/events/events.batterycritical.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/events/events.batterylow.html
+++ b/archive/docs/fr/3.1.0/cordova/events/events.batterylow.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/events/events.batterystatus.html
+++ b/archive/docs/fr/3.1.0/cordova/events/events.batterystatus.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/events/events.deviceready.html
+++ b/archive/docs/fr/3.1.0/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/events/events.endcallbutton.html
+++ b/archive/docs/fr/3.1.0/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/events/events.html
+++ b/archive/docs/fr/3.1.0/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/events/events.menubutton.html
+++ b/archive/docs/fr/3.1.0/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/events/events.offline.html
+++ b/archive/docs/fr/3.1.0/cordova/events/events.offline.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/events/events.online.html
+++ b/archive/docs/fr/3.1.0/cordova/events/events.online.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/events/events.pause.html
+++ b/archive/docs/fr/3.1.0/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/events/events.resume.html
+++ b/archive/docs/fr/3.1.0/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/events/events.searchbutton.html
+++ b/archive/docs/fr/3.1.0/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/events/events.startcallbutton.html
+++ b/archive/docs/fr/3.1.0/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/fr/3.1.0/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/fr/3.1.0/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/file/directoryentry/directoryentry.html
+++ b/archive/docs/fr/3.1.0/cordova/file/directoryentry/directoryentry.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/file/directoryreader/directoryreader.html
+++ b/archive/docs/fr/3.1.0/cordova/file/directoryreader/directoryreader.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/file/file.html
+++ b/archive/docs/fr/3.1.0/cordova/file/file.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/file/fileentry/fileentry.html
+++ b/archive/docs/fr/3.1.0/cordova/file/fileentry/fileentry.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/file/fileerror/fileerror.html
+++ b/archive/docs/fr/3.1.0/cordova/file/fileerror/fileerror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/file/fileobj/fileobj.html
+++ b/archive/docs/fr/3.1.0/cordova/file/fileobj/fileobj.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/file/filereader/filereader.html
+++ b/archive/docs/fr/3.1.0/cordova/file/filereader/filereader.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/file/filetransfer/filetransfer.html
+++ b/archive/docs/fr/3.1.0/cordova/file/filetransfer/filetransfer.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/file/filetransfererror/filetransfererror.html
+++ b/archive/docs/fr/3.1.0/cordova/file/filetransfererror/filetransfererror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/file/fileuploadoptions/fileuploadoptions.html
+++ b/archive/docs/fr/3.1.0/cordova/file/fileuploadoptions/fileuploadoptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/file/fileuploadresult/fileuploadresult.html
+++ b/archive/docs/fr/3.1.0/cordova/file/fileuploadresult/fileuploadresult.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/file/filewriter/filewriter.html
+++ b/archive/docs/fr/3.1.0/cordova/file/filewriter/filewriter.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/geolocation/Position/position.html
+++ b/archive/docs/fr/3.1.0/cordova/geolocation/Position/position.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/geolocation/PositionError/positionError.html
+++ b/archive/docs/fr/3.1.0/cordova/geolocation/PositionError/positionError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/geolocation/geolocation.clearWatch.html
+++ b/archive/docs/fr/3.1.0/cordova/geolocation/geolocation.clearWatch.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/geolocation/geolocation.getCurrentPosition.html
+++ b/archive/docs/fr/3.1.0/cordova/geolocation/geolocation.getCurrentPosition.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/geolocation/geolocation.html
+++ b/archive/docs/fr/3.1.0/cordova/geolocation/geolocation.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/geolocation/geolocation.watchPosition.html
+++ b/archive/docs/fr/3.1.0/cordova/geolocation/geolocation.watchPosition.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/geolocation/parameters/geolocation.options.html
+++ b/archive/docs/fr/3.1.0/cordova/geolocation/parameters/geolocation.options.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/geolocation/parameters/geolocationError.html
+++ b/archive/docs/fr/3.1.0/cordova/geolocation/parameters/geolocationError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/geolocation/parameters/geolocationSuccess.html
+++ b/archive/docs/fr/3.1.0/cordova/geolocation/parameters/geolocationSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/globalization/GlobalizationError/globalizationerror.html
+++ b/archive/docs/fr/3.1.0/cordova/globalization/GlobalizationError/globalizationerror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/globalization/globalization.dateToString.html
+++ b/archive/docs/fr/3.1.0/cordova/globalization/globalization.dateToString.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/globalization/globalization.getCurrencyPattern.html
+++ b/archive/docs/fr/3.1.0/cordova/globalization/globalization.getCurrencyPattern.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/globalization/globalization.getDateNames.html
+++ b/archive/docs/fr/3.1.0/cordova/globalization/globalization.getDateNames.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/globalization/globalization.getDatePattern.html
+++ b/archive/docs/fr/3.1.0/cordova/globalization/globalization.getDatePattern.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/globalization/globalization.getFirstDayOfWeek.html
+++ b/archive/docs/fr/3.1.0/cordova/globalization/globalization.getFirstDayOfWeek.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/globalization/globalization.getLocaleName.html
+++ b/archive/docs/fr/3.1.0/cordova/globalization/globalization.getLocaleName.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/globalization/globalization.getNumberPattern.html
+++ b/archive/docs/fr/3.1.0/cordova/globalization/globalization.getNumberPattern.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/globalization/globalization.getPreferredLanguage.html
+++ b/archive/docs/fr/3.1.0/cordova/globalization/globalization.getPreferredLanguage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/globalization/globalization.html
+++ b/archive/docs/fr/3.1.0/cordova/globalization/globalization.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/globalization/globalization.isDayLightSavingsTime.html
+++ b/archive/docs/fr/3.1.0/cordova/globalization/globalization.isDayLightSavingsTime.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/globalization/globalization.numberToString.html
+++ b/archive/docs/fr/3.1.0/cordova/globalization/globalization.numberToString.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/globalization/globalization.stringToDate.html
+++ b/archive/docs/fr/3.1.0/cordova/globalization/globalization.stringToDate.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/globalization/globalization.stringToNumber.html
+++ b/archive/docs/fr/3.1.0/cordova/globalization/globalization.stringToNumber.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/inappbrowser/inappbrowser.html
+++ b/archive/docs/fr/3.1.0/cordova/inappbrowser/inappbrowser.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/media/capture/CaptureErrorCB.html
+++ b/archive/docs/fr/3.1.0/cordova/media/capture/CaptureErrorCB.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/media/capture/ConfigurationData.html
+++ b/archive/docs/fr/3.1.0/cordova/media/capture/ConfigurationData.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/media/capture/MediaFile.html
+++ b/archive/docs/fr/3.1.0/cordova/media/capture/MediaFile.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/media/capture/MediaFileData.html
+++ b/archive/docs/fr/3.1.0/cordova/media/capture/MediaFileData.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/media/capture/capture.html
+++ b/archive/docs/fr/3.1.0/cordova/media/capture/capture.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/media/capture/captureAudio.html
+++ b/archive/docs/fr/3.1.0/cordova/media/capture/captureAudio.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/media/capture/captureAudioOptions.html
+++ b/archive/docs/fr/3.1.0/cordova/media/capture/captureAudioOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/media/capture/captureImage.html
+++ b/archive/docs/fr/3.1.0/cordova/media/capture/captureImage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/media/capture/captureImageOptions.html
+++ b/archive/docs/fr/3.1.0/cordova/media/capture/captureImageOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/media/capture/captureVideo.html
+++ b/archive/docs/fr/3.1.0/cordova/media/capture/captureVideo.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/media/capture/captureVideoOptions.html
+++ b/archive/docs/fr/3.1.0/cordova/media/capture/captureVideoOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/media/media.html
+++ b/archive/docs/fr/3.1.0/cordova/media/media.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/notification/notification.html
+++ b/archive/docs/fr/3.1.0/cordova/notification/notification.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/splashscreen/splashscreen.hide.html
+++ b/archive/docs/fr/3.1.0/cordova/splashscreen/splashscreen.hide.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/splashscreen/splashscreen.html
+++ b/archive/docs/fr/3.1.0/cordova/splashscreen/splashscreen.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/splashscreen/splashscreen.show.html
+++ b/archive/docs/fr/3.1.0/cordova/splashscreen/splashscreen.show.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/storage/database/database.html
+++ b/archive/docs/fr/3.1.0/cordova/storage/database/database.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/fr/3.1.0/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/storage/parameters/display_name.html
+++ b/archive/docs/fr/3.1.0/cordova/storage/parameters/display_name.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/storage/parameters/name.html
+++ b/archive/docs/fr/3.1.0/cordova/storage/parameters/name.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/storage/parameters/size.html
+++ b/archive/docs/fr/3.1.0/cordova/storage/parameters/size.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/storage/parameters/version.html
+++ b/archive/docs/fr/3.1.0/cordova/storage/parameters/version.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/storage/sqlerror/sqlerror.html
+++ b/archive/docs/fr/3.1.0/cordova/storage/sqlerror/sqlerror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/storage/sqlresultset/sqlresultset.html
+++ b/archive/docs/fr/3.1.0/cordova/storage/sqlresultset/sqlresultset.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/storage/sqlresultsetrowlist/sqlresultsetrowlist.html
+++ b/archive/docs/fr/3.1.0/cordova/storage/sqlresultsetrowlist/sqlresultsetrowlist.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/storage/sqltransaction/sqltransaction.html
+++ b/archive/docs/fr/3.1.0/cordova/storage/sqltransaction/sqltransaction.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/storage/storage.html
+++ b/archive/docs/fr/3.1.0/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/cordova/storage/storage.opendatabase.html
+++ b/archive/docs/fr/3.1.0/cordova/storage/storage.opendatabase.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/guide/appdev/privacy/index.html
+++ b/archive/docs/fr/3.1.0/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/guide/appdev/whitelist/index.html
+++ b/archive/docs/fr/3.1.0/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/guide/cli/index.html
+++ b/archive/docs/fr/3.1.0/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/guide/hybrid/plugins/index.html
+++ b/archive/docs/fr/3.1.0/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/guide/hybrid/webviews/index.html
+++ b/archive/docs/fr/3.1.0/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/guide/overview/index.html
+++ b/archive/docs/fr/3.1.0/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/guide/platforms/android/config.html
+++ b/archive/docs/fr/3.1.0/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/guide/platforms/android/index.html
+++ b/archive/docs/fr/3.1.0/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/guide/platforms/android/plugin.html
+++ b/archive/docs/fr/3.1.0/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/guide/platforms/android/tools.html
+++ b/archive/docs/fr/3.1.0/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/guide/platforms/android/upgrading.html
+++ b/archive/docs/fr/3.1.0/guide/platforms/android/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/guide/platforms/android/webview.html
+++ b/archive/docs/fr/3.1.0/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/guide/platforms/blackberry/index.html
+++ b/archive/docs/fr/3.1.0/guide/platforms/blackberry/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/guide/platforms/blackberry/plugin.html
+++ b/archive/docs/fr/3.1.0/guide/platforms/blackberry/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/guide/platforms/blackberry/tools.html
+++ b/archive/docs/fr/3.1.0/guide/platforms/blackberry/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/guide/platforms/blackberry10/config.html
+++ b/archive/docs/fr/3.1.0/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/guide/platforms/blackberry10/index.html
+++ b/archive/docs/fr/3.1.0/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/fr/3.1.0/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/fr/3.1.0/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/guide/platforms/blackberry10/upgrading.html
+++ b/archive/docs/fr/3.1.0/guide/platforms/blackberry10/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/guide/platforms/index.html
+++ b/archive/docs/fr/3.1.0/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/guide/platforms/ios/config.html
+++ b/archive/docs/fr/3.1.0/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/guide/platforms/ios/index.html
+++ b/archive/docs/fr/3.1.0/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/guide/platforms/ios/plugin.html
+++ b/archive/docs/fr/3.1.0/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/guide/platforms/ios/tools.html
+++ b/archive/docs/fr/3.1.0/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/guide/platforms/ios/upgrading.html
+++ b/archive/docs/fr/3.1.0/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/guide/platforms/ios/webview.html
+++ b/archive/docs/fr/3.1.0/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/guide/platforms/tizen/index.html
+++ b/archive/docs/fr/3.1.0/guide/platforms/tizen/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/guide/platforms/win8/index.html
+++ b/archive/docs/fr/3.1.0/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/guide/platforms/win8/tools.html
+++ b/archive/docs/fr/3.1.0/guide/platforms/win8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/guide/platforms/win8/upgrading.html
+++ b/archive/docs/fr/3.1.0/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/guide/platforms/wp7/index.html
+++ b/archive/docs/fr/3.1.0/guide/platforms/wp7/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/guide/platforms/wp8/index.html
+++ b/archive/docs/fr/3.1.0/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/guide/platforms/wp8/plugin.html
+++ b/archive/docs/fr/3.1.0/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/guide/platforms/wp8/tools.html
+++ b/archive/docs/fr/3.1.0/guide/platforms/wp8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/guide/platforms/wp8/upgrading.html
+++ b/archive/docs/fr/3.1.0/guide/platforms/wp8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/index.html
+++ b/archive/docs/fr/3.1.0/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.1.0/plugin_ref/spec.html
+++ b/archive/docs/fr/3.1.0/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.4.0/config_ref/images.html
+++ b/archive/docs/fr/3.4.0/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.4.0/config_ref/index.html
+++ b/archive/docs/fr/3.4.0/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.4.0/cordova/events/events.backbutton.html
+++ b/archive/docs/fr/3.4.0/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.4.0/cordova/events/events.deviceready.html
+++ b/archive/docs/fr/3.4.0/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.4.0/cordova/events/events.endcallbutton.html
+++ b/archive/docs/fr/3.4.0/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.4.0/cordova/events/events.html
+++ b/archive/docs/fr/3.4.0/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.4.0/cordova/events/events.menubutton.html
+++ b/archive/docs/fr/3.4.0/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.4.0/cordova/events/events.pause.html
+++ b/archive/docs/fr/3.4.0/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.4.0/cordova/events/events.resume.html
+++ b/archive/docs/fr/3.4.0/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.4.0/cordova/events/events.searchbutton.html
+++ b/archive/docs/fr/3.4.0/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.4.0/cordova/events/events.startcallbutton.html
+++ b/archive/docs/fr/3.4.0/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.4.0/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/fr/3.4.0/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.4.0/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/fr/3.4.0/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.4.0/cordova/plugins/pluginapis.html
+++ b/archive/docs/fr/3.4.0/cordova/plugins/pluginapis.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.4.0/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/fr/3.4.0/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.4.0/cordova/storage/storage.html
+++ b/archive/docs/fr/3.4.0/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.4.0/guide/appdev/privacy/index.html
+++ b/archive/docs/fr/3.4.0/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.4.0/guide/appdev/whitelist/index.html
+++ b/archive/docs/fr/3.4.0/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.4.0/guide/cli/index.html
+++ b/archive/docs/fr/3.4.0/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.4.0/guide/hybrid/plugins/index.html
+++ b/archive/docs/fr/3.4.0/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.4.0/guide/hybrid/webviews/index.html
+++ b/archive/docs/fr/3.4.0/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.4.0/guide/overview/index.html
+++ b/archive/docs/fr/3.4.0/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.4.0/guide/platforms/amazonfireos/config.html
+++ b/archive/docs/fr/3.4.0/guide/platforms/amazonfireos/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.4.0/guide/platforms/amazonfireos/index.html
+++ b/archive/docs/fr/3.4.0/guide/platforms/amazonfireos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.4.0/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/fr/3.4.0/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.4.0/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/fr/3.4.0/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.4.0/guide/platforms/android/plugin.html
+++ b/archive/docs/fr/3.4.0/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.4.0/guide/platforms/android/tools.html
+++ b/archive/docs/fr/3.4.0/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.4.0/guide/platforms/android/upgrading.html
+++ b/archive/docs/fr/3.4.0/guide/platforms/android/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.4.0/guide/platforms/android/webview.html
+++ b/archive/docs/fr/3.4.0/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.4.0/guide/platforms/blackberry/config.html
+++ b/archive/docs/fr/3.4.0/guide/platforms/blackberry/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.4.0/guide/platforms/blackberry/upgrading.html
+++ b/archive/docs/fr/3.4.0/guide/platforms/blackberry/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.4.0/guide/platforms/blackberry10/index.html
+++ b/archive/docs/fr/3.4.0/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.4.0/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/fr/3.4.0/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.4.0/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/fr/3.4.0/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.4.0/guide/platforms/index.html
+++ b/archive/docs/fr/3.4.0/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.4.0/guide/platforms/ios/config.html
+++ b/archive/docs/fr/3.4.0/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.4.0/guide/platforms/ios/index.html
+++ b/archive/docs/fr/3.4.0/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.4.0/guide/platforms/ios/plugin.html
+++ b/archive/docs/fr/3.4.0/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.4.0/guide/platforms/ios/tools.html
+++ b/archive/docs/fr/3.4.0/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.4.0/guide/platforms/ios/upgrading.html
+++ b/archive/docs/fr/3.4.0/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.4.0/guide/platforms/ios/webview.html
+++ b/archive/docs/fr/3.4.0/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.4.0/guide/platforms/tizen/index.html
+++ b/archive/docs/fr/3.4.0/guide/platforms/tizen/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.4.0/guide/platforms/ubuntu/index.html
+++ b/archive/docs/fr/3.4.0/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.4.0/guide/platforms/win8/index.html
+++ b/archive/docs/fr/3.4.0/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.4.0/guide/platforms/win8/tools.html
+++ b/archive/docs/fr/3.4.0/guide/platforms/win8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.4.0/guide/platforms/win8/upgrading.html
+++ b/archive/docs/fr/3.4.0/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.4.0/guide/platforms/wp7/index.html
+++ b/archive/docs/fr/3.4.0/guide/platforms/wp7/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.4.0/guide/platforms/wp8/index.html
+++ b/archive/docs/fr/3.4.0/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.4.0/guide/platforms/wp8/plugin.html
+++ b/archive/docs/fr/3.4.0/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.4.0/guide/platforms/wp8/tools.html
+++ b/archive/docs/fr/3.4.0/guide/platforms/wp8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.4.0/guide/platforms/wp8/upgrading.html
+++ b/archive/docs/fr/3.4.0/guide/platforms/wp8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.4.0/guide/support/index.html
+++ b/archive/docs/fr/3.4.0/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.4.0/index.html
+++ b/archive/docs/fr/3.4.0/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.5.0/config_ref/images.html
+++ b/archive/docs/fr/3.5.0/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.5.0/config_ref/index.html
+++ b/archive/docs/fr/3.5.0/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.5.0/cordova/events/events.backbutton.html
+++ b/archive/docs/fr/3.5.0/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.5.0/cordova/events/events.deviceready.html
+++ b/archive/docs/fr/3.5.0/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.5.0/cordova/events/events.endcallbutton.html
+++ b/archive/docs/fr/3.5.0/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.5.0/cordova/events/events.html
+++ b/archive/docs/fr/3.5.0/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.5.0/cordova/events/events.menubutton.html
+++ b/archive/docs/fr/3.5.0/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.5.0/cordova/events/events.pause.html
+++ b/archive/docs/fr/3.5.0/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.5.0/cordova/events/events.resume.html
+++ b/archive/docs/fr/3.5.0/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.5.0/cordova/events/events.searchbutton.html
+++ b/archive/docs/fr/3.5.0/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.5.0/cordova/events/events.startcallbutton.html
+++ b/archive/docs/fr/3.5.0/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.5.0/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/fr/3.5.0/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.5.0/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/fr/3.5.0/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.5.0/cordova/plugins/pluginapis.html
+++ b/archive/docs/fr/3.5.0/cordova/plugins/pluginapis.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.5.0/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/fr/3.5.0/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.5.0/cordova/storage/storage.html
+++ b/archive/docs/fr/3.5.0/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.5.0/guide/appdev/privacy/index.html
+++ b/archive/docs/fr/3.5.0/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.5.0/guide/appdev/whitelist/index.html
+++ b/archive/docs/fr/3.5.0/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.5.0/guide/cli/index.html
+++ b/archive/docs/fr/3.5.0/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.5.0/guide/hybrid/plugins/index.html
+++ b/archive/docs/fr/3.5.0/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.5.0/guide/hybrid/webviews/index.html
+++ b/archive/docs/fr/3.5.0/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.5.0/guide/overview/index.html
+++ b/archive/docs/fr/3.5.0/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.5.0/guide/platforms/amazonfireos/config.html
+++ b/archive/docs/fr/3.5.0/guide/platforms/amazonfireos/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.5.0/guide/platforms/amazonfireos/index.html
+++ b/archive/docs/fr/3.5.0/guide/platforms/amazonfireos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.5.0/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/fr/3.5.0/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.5.0/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/fr/3.5.0/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.5.0/guide/platforms/android/plugin.html
+++ b/archive/docs/fr/3.5.0/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.5.0/guide/platforms/android/tools.html
+++ b/archive/docs/fr/3.5.0/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.5.0/guide/platforms/android/upgrading.html
+++ b/archive/docs/fr/3.5.0/guide/platforms/android/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.5.0/guide/platforms/android/webview.html
+++ b/archive/docs/fr/3.5.0/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.5.0/guide/platforms/blackberry/config.html
+++ b/archive/docs/fr/3.5.0/guide/platforms/blackberry/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.5.0/guide/platforms/blackberry/upgrading.html
+++ b/archive/docs/fr/3.5.0/guide/platforms/blackberry/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.5.0/guide/platforms/blackberry10/index.html
+++ b/archive/docs/fr/3.5.0/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.5.0/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/fr/3.5.0/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.5.0/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/fr/3.5.0/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.5.0/guide/platforms/firefoxos/index.html
+++ b/archive/docs/fr/3.5.0/guide/platforms/firefoxos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.5.0/guide/platforms/index.html
+++ b/archive/docs/fr/3.5.0/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.5.0/guide/platforms/ios/config.html
+++ b/archive/docs/fr/3.5.0/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.5.0/guide/platforms/ios/index.html
+++ b/archive/docs/fr/3.5.0/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.5.0/guide/platforms/ios/plugin.html
+++ b/archive/docs/fr/3.5.0/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.5.0/guide/platforms/ios/tools.html
+++ b/archive/docs/fr/3.5.0/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.5.0/guide/platforms/ios/upgrading.html
+++ b/archive/docs/fr/3.5.0/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.5.0/guide/platforms/ios/webview.html
+++ b/archive/docs/fr/3.5.0/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.5.0/guide/platforms/tizen/index.html
+++ b/archive/docs/fr/3.5.0/guide/platforms/tizen/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.5.0/guide/platforms/ubuntu/index.html
+++ b/archive/docs/fr/3.5.0/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.5.0/guide/platforms/win8/index.html
+++ b/archive/docs/fr/3.5.0/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.5.0/guide/platforms/win8/upgrading.html
+++ b/archive/docs/fr/3.5.0/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.5.0/guide/platforms/wp8/index.html
+++ b/archive/docs/fr/3.5.0/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.5.0/guide/platforms/wp8/plugin.html
+++ b/archive/docs/fr/3.5.0/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.5.0/guide/platforms/wp8/upgrading.html
+++ b/archive/docs/fr/3.5.0/guide/platforms/wp8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.5.0/guide/support/index.html
+++ b/archive/docs/fr/3.5.0/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/3.5.0/index.html
+++ b/archive/docs/fr/3.5.0/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/config_ref/images.html
+++ b/archive/docs/fr/5.4.0/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/config_ref/index.html
+++ b/archive/docs/fr/5.4.0/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/cordova/events/events.backbutton.html
+++ b/archive/docs/fr/5.4.0/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/cordova/events/events.deviceready.html
+++ b/archive/docs/fr/5.4.0/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/cordova/events/events.endcallbutton.html
+++ b/archive/docs/fr/5.4.0/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/cordova/events/events.html
+++ b/archive/docs/fr/5.4.0/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/cordova/events/events.menubutton.html
+++ b/archive/docs/fr/5.4.0/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/cordova/events/events.pause.html
+++ b/archive/docs/fr/5.4.0/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/cordova/events/events.resume.html
+++ b/archive/docs/fr/5.4.0/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/cordova/events/events.searchbutton.html
+++ b/archive/docs/fr/5.4.0/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/cordova/events/events.startcallbutton.html
+++ b/archive/docs/fr/5.4.0/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/fr/5.4.0/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/fr/5.4.0/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/cordova/plugins/pluginapis.html
+++ b/archive/docs/fr/5.4.0/cordova/plugins/pluginapis.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/fr/5.4.0/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/cordova/storage/storage.html
+++ b/archive/docs/fr/5.4.0/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/guide/appdev/hooks/index.html
+++ b/archive/docs/fr/5.4.0/guide/appdev/hooks/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/guide/appdev/privacy/index.html
+++ b/archive/docs/fr/5.4.0/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/guide/appdev/security/index.html
+++ b/archive/docs/fr/5.4.0/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/guide/appdev/whitelist/index.html
+++ b/archive/docs/fr/5.4.0/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/guide/cli/index.html
+++ b/archive/docs/fr/5.4.0/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/guide/hybrid/plugins/index.html
+++ b/archive/docs/fr/5.4.0/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/guide/hybrid/webviews/index.html
+++ b/archive/docs/fr/5.4.0/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/guide/next/index.html
+++ b/archive/docs/fr/5.4.0/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/guide/platforms/amazonfireos/config.html
+++ b/archive/docs/fr/5.4.0/guide/platforms/amazonfireos/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/guide/platforms/amazonfireos/index.html
+++ b/archive/docs/fr/5.4.0/guide/platforms/amazonfireos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/fr/5.4.0/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/fr/5.4.0/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/guide/platforms/android/plugin.html
+++ b/archive/docs/fr/5.4.0/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/guide/platforms/android/tools.html
+++ b/archive/docs/fr/5.4.0/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/guide/platforms/android/upgrading.html
+++ b/archive/docs/fr/5.4.0/guide/platforms/android/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/guide/platforms/android/webview.html
+++ b/archive/docs/fr/5.4.0/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/guide/platforms/blackberry/config.html
+++ b/archive/docs/fr/5.4.0/guide/platforms/blackberry/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/guide/platforms/blackberry10/index.html
+++ b/archive/docs/fr/5.4.0/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/fr/5.4.0/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/fr/5.4.0/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/guide/platforms/blackberry10/upgrading.html
+++ b/archive/docs/fr/5.4.0/guide/platforms/blackberry10/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/guide/platforms/firefoxos/index.html
+++ b/archive/docs/fr/5.4.0/guide/platforms/firefoxos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/guide/platforms/index.html
+++ b/archive/docs/fr/5.4.0/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/guide/platforms/ios/config.html
+++ b/archive/docs/fr/5.4.0/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/guide/platforms/ios/index.html
+++ b/archive/docs/fr/5.4.0/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/guide/platforms/ios/plugin.html
+++ b/archive/docs/fr/5.4.0/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/guide/platforms/ios/tools.html
+++ b/archive/docs/fr/5.4.0/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/guide/platforms/ios/upgrading.html
+++ b/archive/docs/fr/5.4.0/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/guide/platforms/ios/webview.html
+++ b/archive/docs/fr/5.4.0/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/guide/platforms/tizen/index.html
+++ b/archive/docs/fr/5.4.0/guide/platforms/tizen/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/guide/platforms/ubuntu/index.html
+++ b/archive/docs/fr/5.4.0/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/guide/platforms/win8/index.html
+++ b/archive/docs/fr/5.4.0/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/guide/platforms/win8/packaging.html
+++ b/archive/docs/fr/5.4.0/guide/platforms/win8/packaging.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/guide/platforms/win8/plugin.html
+++ b/archive/docs/fr/5.4.0/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/guide/platforms/win8/upgrading.html
+++ b/archive/docs/fr/5.4.0/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/guide/platforms/wp8/index.html
+++ b/archive/docs/fr/5.4.0/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/guide/platforms/wp8/plugin.html
+++ b/archive/docs/fr/5.4.0/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/fr/5.4.0/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/guide/platforms/wp8/webview.html
+++ b/archive/docs/fr/5.4.0/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/guide/support/index.html
+++ b/archive/docs/fr/5.4.0/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/index.html
+++ b/archive/docs/fr/5.4.0/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/fr/5.4.0/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/5.4.0/plugin_ref/spec.html
+++ b/archive/docs/fr/5.4.0/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/config_ref/images.html
+++ b/archive/docs/fr/6.x/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/config_ref/index.html
+++ b/archive/docs/fr/6.x/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/cordova/events/events.backbutton.html
+++ b/archive/docs/fr/6.x/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/cordova/events/events.deviceready.html
+++ b/archive/docs/fr/6.x/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/cordova/events/events.endcallbutton.html
+++ b/archive/docs/fr/6.x/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/cordova/events/events.html
+++ b/archive/docs/fr/6.x/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/cordova/events/events.menubutton.html
+++ b/archive/docs/fr/6.x/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/cordova/events/events.pause.html
+++ b/archive/docs/fr/6.x/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/cordova/events/events.resume.html
+++ b/archive/docs/fr/6.x/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/cordova/events/events.searchbutton.html
+++ b/archive/docs/fr/6.x/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/cordova/events/events.startcallbutton.html
+++ b/archive/docs/fr/6.x/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/fr/6.x/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/fr/6.x/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/fr/6.x/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/cordova/storage/storage.html
+++ b/archive/docs/fr/6.x/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/guide/appdev/hooks/index.html
+++ b/archive/docs/fr/6.x/guide/appdev/hooks/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/guide/appdev/privacy/index.html
+++ b/archive/docs/fr/6.x/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/guide/appdev/security/index.html
+++ b/archive/docs/fr/6.x/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/guide/appdev/whitelist/index.html
+++ b/archive/docs/fr/6.x/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/guide/cli/index.html
+++ b/archive/docs/fr/6.x/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/guide/hybrid/plugins/index.html
+++ b/archive/docs/fr/6.x/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/guide/hybrid/webviews/index.html
+++ b/archive/docs/fr/6.x/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/guide/next/index.html
+++ b/archive/docs/fr/6.x/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/guide/overview/index.html
+++ b/archive/docs/fr/6.x/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/guide/platforms/amazonfireos/config.html
+++ b/archive/docs/fr/6.x/guide/platforms/amazonfireos/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/guide/platforms/amazonfireos/index.html
+++ b/archive/docs/fr/6.x/guide/platforms/amazonfireos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/fr/6.x/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/fr/6.x/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/guide/platforms/android/index.html
+++ b/archive/docs/fr/6.x/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/guide/platforms/android/plugin.html
+++ b/archive/docs/fr/6.x/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/guide/platforms/android/tools.html
+++ b/archive/docs/fr/6.x/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/guide/platforms/android/upgrading.html
+++ b/archive/docs/fr/6.x/guide/platforms/android/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/guide/platforms/android/webview.html
+++ b/archive/docs/fr/6.x/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/guide/platforms/blackberry/config.html
+++ b/archive/docs/fr/6.x/guide/platforms/blackberry/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/guide/platforms/blackberry10/config.html
+++ b/archive/docs/fr/6.x/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/guide/platforms/blackberry10/home.html
+++ b/archive/docs/fr/6.x/guide/platforms/blackberry10/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/guide/platforms/blackberry10/index.html
+++ b/archive/docs/fr/6.x/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/fr/6.x/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/fr/6.x/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/guide/platforms/blackberry10/upgrade.html
+++ b/archive/docs/fr/6.x/guide/platforms/blackberry10/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/guide/platforms/blackberry10/upgrading.html
+++ b/archive/docs/fr/6.x/guide/platforms/blackberry10/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/guide/platforms/firefoxos/index.html
+++ b/archive/docs/fr/6.x/guide/platforms/firefoxos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/guide/platforms/index.html
+++ b/archive/docs/fr/6.x/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/guide/platforms/ios/config.html
+++ b/archive/docs/fr/6.x/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/guide/platforms/ios/index.html
+++ b/archive/docs/fr/6.x/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/guide/platforms/ios/plugin.html
+++ b/archive/docs/fr/6.x/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/guide/platforms/ios/tools.html
+++ b/archive/docs/fr/6.x/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/guide/platforms/ios/upgrading.html
+++ b/archive/docs/fr/6.x/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/guide/platforms/ios/webview.html
+++ b/archive/docs/fr/6.x/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/guide/platforms/tizen/index.html
+++ b/archive/docs/fr/6.x/guide/platforms/tizen/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/guide/platforms/ubuntu/index.html
+++ b/archive/docs/fr/6.x/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/guide/platforms/win8/index.html
+++ b/archive/docs/fr/6.x/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/guide/platforms/win8/packaging.html
+++ b/archive/docs/fr/6.x/guide/platforms/win8/packaging.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/guide/platforms/win8/plugin.html
+++ b/archive/docs/fr/6.x/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/guide/platforms/win8/upgrading.html
+++ b/archive/docs/fr/6.x/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/guide/platforms/wp8/home.html
+++ b/archive/docs/fr/6.x/guide/platforms/wp8/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/guide/platforms/wp8/index.html
+++ b/archive/docs/fr/6.x/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/guide/platforms/wp8/plugin.html
+++ b/archive/docs/fr/6.x/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/fr/6.x/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/guide/platforms/wp8/webview.html
+++ b/archive/docs/fr/6.x/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/guide/support/index.html
+++ b/archive/docs/fr/6.x/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/index.html
+++ b/archive/docs/fr/6.x/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/fr/6.x/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/plugin_ref/plugman.html
+++ b/archive/docs/fr/6.x/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/6.x/plugin_ref/spec.html
+++ b/archive/docs/fr/6.x/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/config_ref/images.html
+++ b/archive/docs/fr/7.x/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/config_ref/index.html
+++ b/archive/docs/fr/7.x/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/cordova/events/events.backbutton.html
+++ b/archive/docs/fr/7.x/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/cordova/events/events.deviceready.html
+++ b/archive/docs/fr/7.x/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/cordova/events/events.endcallbutton.html
+++ b/archive/docs/fr/7.x/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/cordova/events/events.html
+++ b/archive/docs/fr/7.x/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/cordova/events/events.menubutton.html
+++ b/archive/docs/fr/7.x/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/cordova/events/events.pause.html
+++ b/archive/docs/fr/7.x/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/cordova/events/events.resume.html
+++ b/archive/docs/fr/7.x/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/cordova/events/events.searchbutton.html
+++ b/archive/docs/fr/7.x/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/cordova/events/events.startcallbutton.html
+++ b/archive/docs/fr/7.x/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/fr/7.x/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/fr/7.x/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/fr/7.x/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/cordova/storage/storage.html
+++ b/archive/docs/fr/7.x/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/guide/appdev/hooks/index.html
+++ b/archive/docs/fr/7.x/guide/appdev/hooks/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/guide/appdev/privacy/index.html
+++ b/archive/docs/fr/7.x/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/guide/appdev/security/index.html
+++ b/archive/docs/fr/7.x/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/guide/appdev/whitelist/index.html
+++ b/archive/docs/fr/7.x/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/guide/cli/index.html
+++ b/archive/docs/fr/7.x/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/guide/hybrid/plugins/index.html
+++ b/archive/docs/fr/7.x/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/guide/hybrid/webviews/index.html
+++ b/archive/docs/fr/7.x/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/guide/next/index.html
+++ b/archive/docs/fr/7.x/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/guide/overview/index.html
+++ b/archive/docs/fr/7.x/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/guide/platforms/amazonfireos/config.html
+++ b/archive/docs/fr/7.x/guide/platforms/amazonfireos/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/guide/platforms/amazonfireos/index.html
+++ b/archive/docs/fr/7.x/guide/platforms/amazonfireos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/fr/7.x/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/fr/7.x/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/guide/platforms/android/index.html
+++ b/archive/docs/fr/7.x/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/guide/platforms/android/plugin.html
+++ b/archive/docs/fr/7.x/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/guide/platforms/android/tools.html
+++ b/archive/docs/fr/7.x/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/guide/platforms/android/upgrading.html
+++ b/archive/docs/fr/7.x/guide/platforms/android/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/guide/platforms/android/webview.html
+++ b/archive/docs/fr/7.x/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/guide/platforms/blackberry/config.html
+++ b/archive/docs/fr/7.x/guide/platforms/blackberry/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/guide/platforms/blackberry10/config.html
+++ b/archive/docs/fr/7.x/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/guide/platforms/blackberry10/home.html
+++ b/archive/docs/fr/7.x/guide/platforms/blackberry10/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/guide/platforms/blackberry10/index.html
+++ b/archive/docs/fr/7.x/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/fr/7.x/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/fr/7.x/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/guide/platforms/blackberry10/upgrade.html
+++ b/archive/docs/fr/7.x/guide/platforms/blackberry10/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/guide/platforms/blackberry10/upgrading.html
+++ b/archive/docs/fr/7.x/guide/platforms/blackberry10/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/guide/platforms/firefoxos/index.html
+++ b/archive/docs/fr/7.x/guide/platforms/firefoxos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/guide/platforms/index.html
+++ b/archive/docs/fr/7.x/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/guide/platforms/ios/config.html
+++ b/archive/docs/fr/7.x/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/guide/platforms/ios/index.html
+++ b/archive/docs/fr/7.x/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/guide/platforms/ios/plugin.html
+++ b/archive/docs/fr/7.x/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/guide/platforms/ios/tools.html
+++ b/archive/docs/fr/7.x/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/guide/platforms/ios/upgrading.html
+++ b/archive/docs/fr/7.x/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/guide/platforms/ios/webview.html
+++ b/archive/docs/fr/7.x/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/guide/platforms/tizen/index.html
+++ b/archive/docs/fr/7.x/guide/platforms/tizen/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/guide/platforms/ubuntu/index.html
+++ b/archive/docs/fr/7.x/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/guide/platforms/win8/index.html
+++ b/archive/docs/fr/7.x/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/guide/platforms/win8/packaging.html
+++ b/archive/docs/fr/7.x/guide/platforms/win8/packaging.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/guide/platforms/win8/plugin.html
+++ b/archive/docs/fr/7.x/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/guide/platforms/win8/upgrading.html
+++ b/archive/docs/fr/7.x/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/guide/platforms/wp8/home.html
+++ b/archive/docs/fr/7.x/guide/platforms/wp8/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/guide/platforms/wp8/index.html
+++ b/archive/docs/fr/7.x/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/guide/platforms/wp8/plugin.html
+++ b/archive/docs/fr/7.x/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/fr/7.x/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/guide/platforms/wp8/webview.html
+++ b/archive/docs/fr/7.x/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/guide/support/index.html
+++ b/archive/docs/fr/7.x/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/index.html
+++ b/archive/docs/fr/7.x/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/fr/7.x/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/plugin_ref/plugman.html
+++ b/archive/docs/fr/7.x/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/7.x/plugin_ref/spec.html
+++ b/archive/docs/fr/7.x/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/config_ref/images.html
+++ b/archive/docs/fr/8.x/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/config_ref/index.html
+++ b/archive/docs/fr/8.x/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/cordova/events/events.backbutton.html
+++ b/archive/docs/fr/8.x/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/cordova/events/events.deviceready.html
+++ b/archive/docs/fr/8.x/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/cordova/events/events.endcallbutton.html
+++ b/archive/docs/fr/8.x/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/cordova/events/events.html
+++ b/archive/docs/fr/8.x/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/cordova/events/events.menubutton.html
+++ b/archive/docs/fr/8.x/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/cordova/events/events.pause.html
+++ b/archive/docs/fr/8.x/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/cordova/events/events.resume.html
+++ b/archive/docs/fr/8.x/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/cordova/events/events.searchbutton.html
+++ b/archive/docs/fr/8.x/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/cordova/events/events.startcallbutton.html
+++ b/archive/docs/fr/8.x/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/fr/8.x/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/fr/8.x/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/fr/8.x/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/cordova/storage/storage.html
+++ b/archive/docs/fr/8.x/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/guide/appdev/hooks/index.html
+++ b/archive/docs/fr/8.x/guide/appdev/hooks/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/guide/appdev/privacy/index.html
+++ b/archive/docs/fr/8.x/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/guide/appdev/security/index.html
+++ b/archive/docs/fr/8.x/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/guide/appdev/whitelist/index.html
+++ b/archive/docs/fr/8.x/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/guide/cli/index.html
+++ b/archive/docs/fr/8.x/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/guide/hybrid/plugins/index.html
+++ b/archive/docs/fr/8.x/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/guide/hybrid/webviews/index.html
+++ b/archive/docs/fr/8.x/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/guide/next/index.html
+++ b/archive/docs/fr/8.x/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/guide/overview/index.html
+++ b/archive/docs/fr/8.x/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/guide/platforms/amazonfireos/config.html
+++ b/archive/docs/fr/8.x/guide/platforms/amazonfireos/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/guide/platforms/amazonfireos/index.html
+++ b/archive/docs/fr/8.x/guide/platforms/amazonfireos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/fr/8.x/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/fr/8.x/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/guide/platforms/android/index.html
+++ b/archive/docs/fr/8.x/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/guide/platforms/android/plugin.html
+++ b/archive/docs/fr/8.x/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/guide/platforms/android/tools.html
+++ b/archive/docs/fr/8.x/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/guide/platforms/android/upgrading.html
+++ b/archive/docs/fr/8.x/guide/platforms/android/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/guide/platforms/android/webview.html
+++ b/archive/docs/fr/8.x/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/guide/platforms/blackberry/config.html
+++ b/archive/docs/fr/8.x/guide/platforms/blackberry/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/guide/platforms/blackberry10/config.html
+++ b/archive/docs/fr/8.x/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/guide/platforms/blackberry10/home.html
+++ b/archive/docs/fr/8.x/guide/platforms/blackberry10/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/guide/platforms/blackberry10/index.html
+++ b/archive/docs/fr/8.x/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/fr/8.x/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/fr/8.x/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/guide/platforms/blackberry10/upgrade.html
+++ b/archive/docs/fr/8.x/guide/platforms/blackberry10/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/guide/platforms/blackberry10/upgrading.html
+++ b/archive/docs/fr/8.x/guide/platforms/blackberry10/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/guide/platforms/firefoxos/index.html
+++ b/archive/docs/fr/8.x/guide/platforms/firefoxos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/guide/platforms/index.html
+++ b/archive/docs/fr/8.x/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/guide/platforms/ios/config.html
+++ b/archive/docs/fr/8.x/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/guide/platforms/ios/index.html
+++ b/archive/docs/fr/8.x/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/guide/platforms/ios/plugin.html
+++ b/archive/docs/fr/8.x/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/guide/platforms/ios/tools.html
+++ b/archive/docs/fr/8.x/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/guide/platforms/ios/upgrading.html
+++ b/archive/docs/fr/8.x/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/guide/platforms/ios/webview.html
+++ b/archive/docs/fr/8.x/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/guide/platforms/tizen/index.html
+++ b/archive/docs/fr/8.x/guide/platforms/tizen/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/guide/platforms/ubuntu/index.html
+++ b/archive/docs/fr/8.x/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/guide/platforms/win8/index.html
+++ b/archive/docs/fr/8.x/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/guide/platforms/win8/packaging.html
+++ b/archive/docs/fr/8.x/guide/platforms/win8/packaging.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/guide/platforms/win8/plugin.html
+++ b/archive/docs/fr/8.x/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/guide/platforms/win8/upgrading.html
+++ b/archive/docs/fr/8.x/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/guide/platforms/wp8/home.html
+++ b/archive/docs/fr/8.x/guide/platforms/wp8/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/guide/platforms/wp8/index.html
+++ b/archive/docs/fr/8.x/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/guide/platforms/wp8/plugin.html
+++ b/archive/docs/fr/8.x/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/fr/8.x/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/guide/platforms/wp8/webview.html
+++ b/archive/docs/fr/8.x/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/guide/support/index.html
+++ b/archive/docs/fr/8.x/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/index.html
+++ b/archive/docs/fr/8.x/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/fr/8.x/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/plugin_ref/plugman.html
+++ b/archive/docs/fr/8.x/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/8.x/plugin_ref/spec.html
+++ b/archive/docs/fr/8.x/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/config_ref/images.html
+++ b/archive/docs/fr/9.x/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/config_ref/index.html
+++ b/archive/docs/fr/9.x/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/cordova/events/events.backbutton.html
+++ b/archive/docs/fr/9.x/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/cordova/events/events.deviceready.html
+++ b/archive/docs/fr/9.x/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/cordova/events/events.endcallbutton.html
+++ b/archive/docs/fr/9.x/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/cordova/events/events.html
+++ b/archive/docs/fr/9.x/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/cordova/events/events.menubutton.html
+++ b/archive/docs/fr/9.x/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/cordova/events/events.pause.html
+++ b/archive/docs/fr/9.x/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/cordova/events/events.resume.html
+++ b/archive/docs/fr/9.x/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/cordova/events/events.searchbutton.html
+++ b/archive/docs/fr/9.x/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/cordova/events/events.startcallbutton.html
+++ b/archive/docs/fr/9.x/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/fr/9.x/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/fr/9.x/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/fr/9.x/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/cordova/storage/storage.html
+++ b/archive/docs/fr/9.x/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/guide/appdev/hooks/index.html
+++ b/archive/docs/fr/9.x/guide/appdev/hooks/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/guide/appdev/privacy/index.html
+++ b/archive/docs/fr/9.x/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/guide/appdev/security/index.html
+++ b/archive/docs/fr/9.x/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/guide/appdev/whitelist/index.html
+++ b/archive/docs/fr/9.x/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/guide/cli/index.html
+++ b/archive/docs/fr/9.x/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/guide/hybrid/plugins/index.html
+++ b/archive/docs/fr/9.x/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/guide/hybrid/webviews/index.html
+++ b/archive/docs/fr/9.x/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/guide/next/index.html
+++ b/archive/docs/fr/9.x/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/guide/overview/index.html
+++ b/archive/docs/fr/9.x/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/guide/platforms/amazonfireos/config.html
+++ b/archive/docs/fr/9.x/guide/platforms/amazonfireos/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/guide/platforms/amazonfireos/index.html
+++ b/archive/docs/fr/9.x/guide/platforms/amazonfireos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/fr/9.x/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/fr/9.x/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/guide/platforms/android/index.html
+++ b/archive/docs/fr/9.x/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/guide/platforms/android/plugin.html
+++ b/archive/docs/fr/9.x/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/guide/platforms/android/tools.html
+++ b/archive/docs/fr/9.x/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/guide/platforms/android/upgrading.html
+++ b/archive/docs/fr/9.x/guide/platforms/android/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/guide/platforms/android/webview.html
+++ b/archive/docs/fr/9.x/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/guide/platforms/blackberry/config.html
+++ b/archive/docs/fr/9.x/guide/platforms/blackberry/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/guide/platforms/blackberry10/config.html
+++ b/archive/docs/fr/9.x/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/guide/platforms/blackberry10/home.html
+++ b/archive/docs/fr/9.x/guide/platforms/blackberry10/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/guide/platforms/blackberry10/index.html
+++ b/archive/docs/fr/9.x/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/fr/9.x/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/fr/9.x/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/guide/platforms/blackberry10/upgrade.html
+++ b/archive/docs/fr/9.x/guide/platforms/blackberry10/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/guide/platforms/blackberry10/upgrading.html
+++ b/archive/docs/fr/9.x/guide/platforms/blackberry10/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/guide/platforms/firefoxos/index.html
+++ b/archive/docs/fr/9.x/guide/platforms/firefoxos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/guide/platforms/index.html
+++ b/archive/docs/fr/9.x/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/guide/platforms/ios/config.html
+++ b/archive/docs/fr/9.x/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/guide/platforms/ios/index.html
+++ b/archive/docs/fr/9.x/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/guide/platforms/ios/plugin.html
+++ b/archive/docs/fr/9.x/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/guide/platforms/ios/tools.html
+++ b/archive/docs/fr/9.x/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/guide/platforms/ios/upgrading.html
+++ b/archive/docs/fr/9.x/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/guide/platforms/ios/webview.html
+++ b/archive/docs/fr/9.x/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/guide/platforms/tizen/index.html
+++ b/archive/docs/fr/9.x/guide/platforms/tizen/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/guide/platforms/ubuntu/index.html
+++ b/archive/docs/fr/9.x/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/guide/platforms/win8/index.html
+++ b/archive/docs/fr/9.x/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/guide/platforms/win8/packaging.html
+++ b/archive/docs/fr/9.x/guide/platforms/win8/packaging.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/guide/platforms/win8/plugin.html
+++ b/archive/docs/fr/9.x/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/guide/platforms/win8/upgrading.html
+++ b/archive/docs/fr/9.x/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/guide/platforms/wp8/home.html
+++ b/archive/docs/fr/9.x/guide/platforms/wp8/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/guide/platforms/wp8/index.html
+++ b/archive/docs/fr/9.x/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/guide/platforms/wp8/plugin.html
+++ b/archive/docs/fr/9.x/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/fr/9.x/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/guide/platforms/wp8/webview.html
+++ b/archive/docs/fr/9.x/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/guide/support/index.html
+++ b/archive/docs/fr/9.x/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/index.html
+++ b/archive/docs/fr/9.x/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/fr/9.x/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/plugin_ref/plugman.html
+++ b/archive/docs/fr/9.x/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/fr/9.x/plugin_ref/spec.html
+++ b/archive/docs/fr/9.x/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/config_ref/images.html
+++ b/archive/docs/it/10.x/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/config_ref/index.html
+++ b/archive/docs/it/10.x/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/cordova/events/events.backbutton.html
+++ b/archive/docs/it/10.x/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/cordova/events/events.deviceready.html
+++ b/archive/docs/it/10.x/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/cordova/events/events.endcallbutton.html
+++ b/archive/docs/it/10.x/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/cordova/events/events.html
+++ b/archive/docs/it/10.x/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/cordova/events/events.menubutton.html
+++ b/archive/docs/it/10.x/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/cordova/events/events.pause.html
+++ b/archive/docs/it/10.x/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/cordova/events/events.resume.html
+++ b/archive/docs/it/10.x/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/cordova/events/events.searchbutton.html
+++ b/archive/docs/it/10.x/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/cordova/events/events.startcallbutton.html
+++ b/archive/docs/it/10.x/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/it/10.x/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/it/10.x/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/cordova/storage/database/database.html
+++ b/archive/docs/it/10.x/cordova/storage/database/database.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/it/10.x/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/cordova/storage/storage.html
+++ b/archive/docs/it/10.x/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/guide/appdev/hooks/index.html
+++ b/archive/docs/it/10.x/guide/appdev/hooks/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/guide/appdev/privacy/index.html
+++ b/archive/docs/it/10.x/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/guide/appdev/security/index.html
+++ b/archive/docs/it/10.x/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/guide/appdev/whitelist/index.html
+++ b/archive/docs/it/10.x/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/guide/cli/index.html
+++ b/archive/docs/it/10.x/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/guide/hybrid/plugins/index.html
+++ b/archive/docs/it/10.x/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/guide/hybrid/webviews/index.html
+++ b/archive/docs/it/10.x/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/guide/next/index.html
+++ b/archive/docs/it/10.x/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/guide/overview/index.html
+++ b/archive/docs/it/10.x/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/it/10.x/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/it/10.x/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/guide/platforms/android/config.html
+++ b/archive/docs/it/10.x/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/guide/platforms/android/index.html
+++ b/archive/docs/it/10.x/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/guide/platforms/android/plugin.html
+++ b/archive/docs/it/10.x/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/guide/platforms/android/webview.html
+++ b/archive/docs/it/10.x/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/guide/platforms/blackberry10/config.html
+++ b/archive/docs/it/10.x/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/guide/platforms/blackberry10/home.html
+++ b/archive/docs/it/10.x/guide/platforms/blackberry10/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/guide/platforms/blackberry10/index.html
+++ b/archive/docs/it/10.x/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/it/10.x/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/it/10.x/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/guide/platforms/blackberry10/upgrade.html
+++ b/archive/docs/it/10.x/guide/platforms/blackberry10/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/guide/platforms/ios/config.html
+++ b/archive/docs/it/10.x/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/guide/platforms/ios/index.html
+++ b/archive/docs/it/10.x/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/guide/platforms/ios/plugin.html
+++ b/archive/docs/it/10.x/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/guide/platforms/ios/upgrading.html
+++ b/archive/docs/it/10.x/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/guide/platforms/ios/webview.html
+++ b/archive/docs/it/10.x/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/guide/platforms/ubuntu/index.html
+++ b/archive/docs/it/10.x/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/guide/platforms/win8/index.html
+++ b/archive/docs/it/10.x/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/guide/platforms/win8/plugin.html
+++ b/archive/docs/it/10.x/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/guide/platforms/wp8/home.html
+++ b/archive/docs/it/10.x/guide/platforms/wp8/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/guide/platforms/wp8/index.html
+++ b/archive/docs/it/10.x/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/guide/platforms/wp8/parallels.html
+++ b/archive/docs/it/10.x/guide/platforms/wp8/parallels.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/guide/platforms/wp8/plugin.html
+++ b/archive/docs/it/10.x/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/it/10.x/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/guide/platforms/wp8/upgrading.html
+++ b/archive/docs/it/10.x/guide/platforms/wp8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/guide/platforms/wp8/webview.html
+++ b/archive/docs/it/10.x/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/guide/support/index.html
+++ b/archive/docs/it/10.x/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/index.html
+++ b/archive/docs/it/10.x/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/it/10.x/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/plugin_ref/plugman.html
+++ b/archive/docs/it/10.x/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/10.x/plugin_ref/spec.html
+++ b/archive/docs/it/10.x/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/config_ref/images.html
+++ b/archive/docs/it/3.1.0/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/config_ref/index.html
+++ b/archive/docs/it/3.1.0/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/accelerometer/acceleration/acceleration.html
+++ b/archive/docs/it/3.1.0/cordova/accelerometer/acceleration/acceleration.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/accelerometer/accelerometer.clearWatch.html
+++ b/archive/docs/it/3.1.0/cordova/accelerometer/accelerometer.clearWatch.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/accelerometer/accelerometer.getCurrentAcceleration.html
+++ b/archive/docs/it/3.1.0/cordova/accelerometer/accelerometer.getCurrentAcceleration.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/accelerometer/accelerometer.html
+++ b/archive/docs/it/3.1.0/cordova/accelerometer/accelerometer.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/accelerometer/accelerometer.watchAcceleration.html
+++ b/archive/docs/it/3.1.0/cordova/accelerometer/accelerometer.watchAcceleration.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/accelerometer/parameters/accelerometerError.html
+++ b/archive/docs/it/3.1.0/cordova/accelerometer/parameters/accelerometerError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/accelerometer/parameters/accelerometerOptions.html
+++ b/archive/docs/it/3.1.0/cordova/accelerometer/parameters/accelerometerOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/accelerometer/parameters/accelerometerSuccess.html
+++ b/archive/docs/it/3.1.0/cordova/accelerometer/parameters/accelerometerSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/camera/camera.getPicture.html
+++ b/archive/docs/it/3.1.0/cordova/camera/camera.getPicture.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/camera/camera.html
+++ b/archive/docs/it/3.1.0/cordova/camera/camera.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/compass/compass.clearWatch.html
+++ b/archive/docs/it/3.1.0/cordova/compass/compass.clearWatch.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/compass/compass.clearWatchFilter.html
+++ b/archive/docs/it/3.1.0/cordova/compass/compass.clearWatchFilter.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/compass/compass.getCurrentHeading.html
+++ b/archive/docs/it/3.1.0/cordova/compass/compass.getCurrentHeading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/compass/compass.html
+++ b/archive/docs/it/3.1.0/cordova/compass/compass.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/compass/compass.watchHeading.html
+++ b/archive/docs/it/3.1.0/cordova/compass/compass.watchHeading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/compass/compass.watchHeadingFilter.html
+++ b/archive/docs/it/3.1.0/cordova/compass/compass.watchHeadingFilter.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/compass/parameters/compassError.html
+++ b/archive/docs/it/3.1.0/cordova/compass/parameters/compassError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/compass/parameters/compassHeading.html
+++ b/archive/docs/it/3.1.0/cordova/compass/parameters/compassHeading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/compass/parameters/compassOptions.html
+++ b/archive/docs/it/3.1.0/cordova/compass/parameters/compassOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/compass/parameters/compassSuccess.html
+++ b/archive/docs/it/3.1.0/cordova/compass/parameters/compassSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/connection/connection.html
+++ b/archive/docs/it/3.1.0/cordova/connection/connection.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/connection/connection.type.html
+++ b/archive/docs/it/3.1.0/cordova/connection/connection.type.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/contacts/Contact/contact.html
+++ b/archive/docs/it/3.1.0/cordova/contacts/Contact/contact.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/contacts/ContactAddress/contactaddress.html
+++ b/archive/docs/it/3.1.0/cordova/contacts/ContactAddress/contactaddress.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/contacts/ContactError/contactError.html
+++ b/archive/docs/it/3.1.0/cordova/contacts/ContactError/contactError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/contacts/ContactField/contactfield.html
+++ b/archive/docs/it/3.1.0/cordova/contacts/ContactField/contactfield.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/contacts/ContactFindOptions/contactfindoptions.html
+++ b/archive/docs/it/3.1.0/cordova/contacts/ContactFindOptions/contactfindoptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/contacts/ContactName/contactname.html
+++ b/archive/docs/it/3.1.0/cordova/contacts/ContactName/contactname.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/contacts/ContactOrganization/contactorganization.html
+++ b/archive/docs/it/3.1.0/cordova/contacts/ContactOrganization/contactorganization.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/contacts/contacts.create.html
+++ b/archive/docs/it/3.1.0/cordova/contacts/contacts.create.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/contacts/contacts.html
+++ b/archive/docs/it/3.1.0/cordova/contacts/contacts.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/contacts/parameters/contactError.html
+++ b/archive/docs/it/3.1.0/cordova/contacts/parameters/contactError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/contacts/parameters/contactFields.html
+++ b/archive/docs/it/3.1.0/cordova/contacts/parameters/contactFields.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/contacts/parameters/contactFindOptions.html
+++ b/archive/docs/it/3.1.0/cordova/contacts/parameters/contactFindOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/contacts/parameters/contactSuccess.html
+++ b/archive/docs/it/3.1.0/cordova/contacts/parameters/contactSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/device/device.html
+++ b/archive/docs/it/3.1.0/cordova/device/device.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/device/device.model.html
+++ b/archive/docs/it/3.1.0/cordova/device/device.model.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/device/device.name.html
+++ b/archive/docs/it/3.1.0/cordova/device/device.name.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/events/events.backbutton.html
+++ b/archive/docs/it/3.1.0/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/events/events.batterycritical.html
+++ b/archive/docs/it/3.1.0/cordova/events/events.batterycritical.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/events/events.batterylow.html
+++ b/archive/docs/it/3.1.0/cordova/events/events.batterylow.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/events/events.batterystatus.html
+++ b/archive/docs/it/3.1.0/cordova/events/events.batterystatus.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/events/events.deviceready.html
+++ b/archive/docs/it/3.1.0/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/events/events.endcallbutton.html
+++ b/archive/docs/it/3.1.0/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/events/events.html
+++ b/archive/docs/it/3.1.0/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/events/events.menubutton.html
+++ b/archive/docs/it/3.1.0/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/events/events.offline.html
+++ b/archive/docs/it/3.1.0/cordova/events/events.offline.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/events/events.online.html
+++ b/archive/docs/it/3.1.0/cordova/events/events.online.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/events/events.pause.html
+++ b/archive/docs/it/3.1.0/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/events/events.resume.html
+++ b/archive/docs/it/3.1.0/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/events/events.searchbutton.html
+++ b/archive/docs/it/3.1.0/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/events/events.startcallbutton.html
+++ b/archive/docs/it/3.1.0/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/it/3.1.0/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/it/3.1.0/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/file/directoryentry/directoryentry.html
+++ b/archive/docs/it/3.1.0/cordova/file/directoryentry/directoryentry.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/file/directoryreader/directoryreader.html
+++ b/archive/docs/it/3.1.0/cordova/file/directoryreader/directoryreader.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/file/file.html
+++ b/archive/docs/it/3.1.0/cordova/file/file.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/file/fileentry/fileentry.html
+++ b/archive/docs/it/3.1.0/cordova/file/fileentry/fileentry.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/file/fileerror/fileerror.html
+++ b/archive/docs/it/3.1.0/cordova/file/fileerror/fileerror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/file/fileobj/fileobj.html
+++ b/archive/docs/it/3.1.0/cordova/file/fileobj/fileobj.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/file/filereader/filereader.html
+++ b/archive/docs/it/3.1.0/cordova/file/filereader/filereader.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/file/filesystem/filesystem.html
+++ b/archive/docs/it/3.1.0/cordova/file/filesystem/filesystem.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/file/filetransfer/filetransfer.html
+++ b/archive/docs/it/3.1.0/cordova/file/filetransfer/filetransfer.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/file/filetransfererror/filetransfererror.html
+++ b/archive/docs/it/3.1.0/cordova/file/filetransfererror/filetransfererror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/file/fileuploadoptions/fileuploadoptions.html
+++ b/archive/docs/it/3.1.0/cordova/file/fileuploadoptions/fileuploadoptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/file/fileuploadresult/fileuploadresult.html
+++ b/archive/docs/it/3.1.0/cordova/file/fileuploadresult/fileuploadresult.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/file/filewriter/filewriter.html
+++ b/archive/docs/it/3.1.0/cordova/file/filewriter/filewriter.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/file/flags/flags.html
+++ b/archive/docs/it/3.1.0/cordova/file/flags/flags.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/file/localfilesystem/localfilesystem.html
+++ b/archive/docs/it/3.1.0/cordova/file/localfilesystem/localfilesystem.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/file/metadata/metadata.html
+++ b/archive/docs/it/3.1.0/cordova/file/metadata/metadata.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/geolocation/PositionError/positionError.html
+++ b/archive/docs/it/3.1.0/cordova/geolocation/PositionError/positionError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/geolocation/geolocation.clearWatch.html
+++ b/archive/docs/it/3.1.0/cordova/geolocation/geolocation.clearWatch.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/geolocation/geolocation.getCurrentPosition.html
+++ b/archive/docs/it/3.1.0/cordova/geolocation/geolocation.getCurrentPosition.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/geolocation/geolocation.html
+++ b/archive/docs/it/3.1.0/cordova/geolocation/geolocation.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/geolocation/geolocation.watchPosition.html
+++ b/archive/docs/it/3.1.0/cordova/geolocation/geolocation.watchPosition.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/geolocation/parameters/geolocation.options.html
+++ b/archive/docs/it/3.1.0/cordova/geolocation/parameters/geolocation.options.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/geolocation/parameters/geolocationError.html
+++ b/archive/docs/it/3.1.0/cordova/geolocation/parameters/geolocationError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/geolocation/parameters/geolocationSuccess.html
+++ b/archive/docs/it/3.1.0/cordova/geolocation/parameters/geolocationSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/globalization/GlobalizationError/globalizationerror.html
+++ b/archive/docs/it/3.1.0/cordova/globalization/GlobalizationError/globalizationerror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/globalization/globalization.dateToString.html
+++ b/archive/docs/it/3.1.0/cordova/globalization/globalization.dateToString.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/globalization/globalization.getCurrencyPattern.html
+++ b/archive/docs/it/3.1.0/cordova/globalization/globalization.getCurrencyPattern.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/globalization/globalization.getDateNames.html
+++ b/archive/docs/it/3.1.0/cordova/globalization/globalization.getDateNames.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/globalization/globalization.getDatePattern.html
+++ b/archive/docs/it/3.1.0/cordova/globalization/globalization.getDatePattern.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/globalization/globalization.getFirstDayOfWeek.html
+++ b/archive/docs/it/3.1.0/cordova/globalization/globalization.getFirstDayOfWeek.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/globalization/globalization.getLocaleName.html
+++ b/archive/docs/it/3.1.0/cordova/globalization/globalization.getLocaleName.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/globalization/globalization.getNumberPattern.html
+++ b/archive/docs/it/3.1.0/cordova/globalization/globalization.getNumberPattern.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/globalization/globalization.getPreferredLanguage.html
+++ b/archive/docs/it/3.1.0/cordova/globalization/globalization.getPreferredLanguage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/globalization/globalization.html
+++ b/archive/docs/it/3.1.0/cordova/globalization/globalization.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/globalization/globalization.isDayLightSavingsTime.html
+++ b/archive/docs/it/3.1.0/cordova/globalization/globalization.isDayLightSavingsTime.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/globalization/globalization.numberToString.html
+++ b/archive/docs/it/3.1.0/cordova/globalization/globalization.numberToString.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/globalization/globalization.stringToDate.html
+++ b/archive/docs/it/3.1.0/cordova/globalization/globalization.stringToDate.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/globalization/globalization.stringToNumber.html
+++ b/archive/docs/it/3.1.0/cordova/globalization/globalization.stringToNumber.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/inappbrowser/inappbrowser.html
+++ b/archive/docs/it/3.1.0/cordova/inappbrowser/inappbrowser.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/media/capture/CaptureErrorCB.html
+++ b/archive/docs/it/3.1.0/cordova/media/capture/CaptureErrorCB.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/media/capture/ConfigurationData.html
+++ b/archive/docs/it/3.1.0/cordova/media/capture/ConfigurationData.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/media/capture/MediaFile.html
+++ b/archive/docs/it/3.1.0/cordova/media/capture/MediaFile.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/media/capture/MediaFileData.html
+++ b/archive/docs/it/3.1.0/cordova/media/capture/MediaFileData.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/media/capture/capture.html
+++ b/archive/docs/it/3.1.0/cordova/media/capture/capture.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/media/capture/captureAudio.html
+++ b/archive/docs/it/3.1.0/cordova/media/capture/captureAudio.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/media/capture/captureAudioOptions.html
+++ b/archive/docs/it/3.1.0/cordova/media/capture/captureAudioOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/media/capture/captureImage.html
+++ b/archive/docs/it/3.1.0/cordova/media/capture/captureImage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/media/capture/captureImageOptions.html
+++ b/archive/docs/it/3.1.0/cordova/media/capture/captureImageOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/media/capture/captureVideo.html
+++ b/archive/docs/it/3.1.0/cordova/media/capture/captureVideo.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/media/capture/captureVideoOptions.html
+++ b/archive/docs/it/3.1.0/cordova/media/capture/captureVideoOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/media/media.html
+++ b/archive/docs/it/3.1.0/cordova/media/media.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/notification/notification.html
+++ b/archive/docs/it/3.1.0/cordova/notification/notification.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/splashscreen/splashscreen.html
+++ b/archive/docs/it/3.1.0/cordova/splashscreen/splashscreen.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/splashscreen/splashscreen.show.html
+++ b/archive/docs/it/3.1.0/cordova/splashscreen/splashscreen.show.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/storage/database/database.html
+++ b/archive/docs/it/3.1.0/cordova/storage/database/database.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/it/3.1.0/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/storage/parameters/display_name.html
+++ b/archive/docs/it/3.1.0/cordova/storage/parameters/display_name.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/storage/parameters/name.html
+++ b/archive/docs/it/3.1.0/cordova/storage/parameters/name.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/storage/parameters/size.html
+++ b/archive/docs/it/3.1.0/cordova/storage/parameters/size.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/storage/parameters/version.html
+++ b/archive/docs/it/3.1.0/cordova/storage/parameters/version.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/storage/sqlerror/sqlerror.html
+++ b/archive/docs/it/3.1.0/cordova/storage/sqlerror/sqlerror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/storage/sqlresultset/sqlresultset.html
+++ b/archive/docs/it/3.1.0/cordova/storage/sqlresultset/sqlresultset.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/storage/sqlresultsetrowlist/sqlresultsetrowlist.html
+++ b/archive/docs/it/3.1.0/cordova/storage/sqlresultsetrowlist/sqlresultsetrowlist.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/storage/sqltransaction/sqltransaction.html
+++ b/archive/docs/it/3.1.0/cordova/storage/sqltransaction/sqltransaction.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/storage/storage.html
+++ b/archive/docs/it/3.1.0/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/cordova/storage/storage.opendatabase.html
+++ b/archive/docs/it/3.1.0/cordova/storage/storage.opendatabase.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/guide/appdev/privacy/index.html
+++ b/archive/docs/it/3.1.0/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/guide/appdev/whitelist/index.html
+++ b/archive/docs/it/3.1.0/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/guide/cli/index.html
+++ b/archive/docs/it/3.1.0/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/guide/hybrid/plugins/index.html
+++ b/archive/docs/it/3.1.0/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/guide/hybrid/webviews/index.html
+++ b/archive/docs/it/3.1.0/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/guide/overview/index.html
+++ b/archive/docs/it/3.1.0/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/guide/platforms/android/config.html
+++ b/archive/docs/it/3.1.0/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/guide/platforms/android/index.html
+++ b/archive/docs/it/3.1.0/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/guide/platforms/android/plugin.html
+++ b/archive/docs/it/3.1.0/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/guide/platforms/android/tools.html
+++ b/archive/docs/it/3.1.0/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/guide/platforms/android/upgrading.html
+++ b/archive/docs/it/3.1.0/guide/platforms/android/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/guide/platforms/android/webview.html
+++ b/archive/docs/it/3.1.0/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/guide/platforms/blackberry/index.html
+++ b/archive/docs/it/3.1.0/guide/platforms/blackberry/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/guide/platforms/blackberry/plugin.html
+++ b/archive/docs/it/3.1.0/guide/platforms/blackberry/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/guide/platforms/blackberry/tools.html
+++ b/archive/docs/it/3.1.0/guide/platforms/blackberry/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/guide/platforms/blackberry10/config.html
+++ b/archive/docs/it/3.1.0/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/guide/platforms/blackberry10/index.html
+++ b/archive/docs/it/3.1.0/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/it/3.1.0/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/guide/platforms/blackberry10/upgrading.html
+++ b/archive/docs/it/3.1.0/guide/platforms/blackberry10/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/guide/platforms/index.html
+++ b/archive/docs/it/3.1.0/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/guide/platforms/ios/config.html
+++ b/archive/docs/it/3.1.0/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/guide/platforms/ios/index.html
+++ b/archive/docs/it/3.1.0/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/guide/platforms/ios/plugin.html
+++ b/archive/docs/it/3.1.0/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/guide/platforms/ios/tools.html
+++ b/archive/docs/it/3.1.0/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/guide/platforms/ios/upgrading.html
+++ b/archive/docs/it/3.1.0/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/guide/platforms/ios/webview.html
+++ b/archive/docs/it/3.1.0/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/guide/platforms/tizen/index.html
+++ b/archive/docs/it/3.1.0/guide/platforms/tizen/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/guide/platforms/win8/index.html
+++ b/archive/docs/it/3.1.0/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/guide/platforms/win8/tools.html
+++ b/archive/docs/it/3.1.0/guide/platforms/win8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/guide/platforms/win8/upgrading.html
+++ b/archive/docs/it/3.1.0/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/guide/platforms/wp7/index.html
+++ b/archive/docs/it/3.1.0/guide/platforms/wp7/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/guide/platforms/wp8/index.html
+++ b/archive/docs/it/3.1.0/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/guide/platforms/wp8/plugin.html
+++ b/archive/docs/it/3.1.0/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/guide/platforms/wp8/tools.html
+++ b/archive/docs/it/3.1.0/guide/platforms/wp8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/guide/platforms/wp8/upgrading.html
+++ b/archive/docs/it/3.1.0/guide/platforms/wp8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/index.html
+++ b/archive/docs/it/3.1.0/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.1.0/plugin_ref/spec.html
+++ b/archive/docs/it/3.1.0/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/config_ref/images.html
+++ b/archive/docs/it/3.4.0/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/config_ref/index.html
+++ b/archive/docs/it/3.4.0/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/cordova/events/events.backbutton.html
+++ b/archive/docs/it/3.4.0/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/cordova/events/events.deviceready.html
+++ b/archive/docs/it/3.4.0/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/cordova/events/events.endcallbutton.html
+++ b/archive/docs/it/3.4.0/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/cordova/events/events.html
+++ b/archive/docs/it/3.4.0/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/cordova/events/events.menubutton.html
+++ b/archive/docs/it/3.4.0/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/cordova/events/events.pause.html
+++ b/archive/docs/it/3.4.0/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/cordova/events/events.resume.html
+++ b/archive/docs/it/3.4.0/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/cordova/events/events.searchbutton.html
+++ b/archive/docs/it/3.4.0/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/cordova/events/events.startcallbutton.html
+++ b/archive/docs/it/3.4.0/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/it/3.4.0/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/it/3.4.0/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/cordova/plugins/pluginapis.html
+++ b/archive/docs/it/3.4.0/cordova/plugins/pluginapis.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/cordova/storage/database/database.html
+++ b/archive/docs/it/3.4.0/cordova/storage/database/database.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/it/3.4.0/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/cordova/storage/storage.html
+++ b/archive/docs/it/3.4.0/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/guide/appdev/privacy/index.html
+++ b/archive/docs/it/3.4.0/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/guide/appdev/whitelist/index.html
+++ b/archive/docs/it/3.4.0/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/guide/cli/index.html
+++ b/archive/docs/it/3.4.0/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/guide/hybrid/plugins/index.html
+++ b/archive/docs/it/3.4.0/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/guide/hybrid/webviews/index.html
+++ b/archive/docs/it/3.4.0/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/guide/overview/index.html
+++ b/archive/docs/it/3.4.0/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/guide/platforms/amazonfireos/config.html
+++ b/archive/docs/it/3.4.0/guide/platforms/amazonfireos/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/guide/platforms/amazonfireos/index.html
+++ b/archive/docs/it/3.4.0/guide/platforms/amazonfireos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/it/3.4.0/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/it/3.4.0/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/guide/platforms/android/config.html
+++ b/archive/docs/it/3.4.0/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/guide/platforms/android/index.html
+++ b/archive/docs/it/3.4.0/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/guide/platforms/android/plugin.html
+++ b/archive/docs/it/3.4.0/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/guide/platforms/android/tools.html
+++ b/archive/docs/it/3.4.0/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/guide/platforms/android/upgrading.html
+++ b/archive/docs/it/3.4.0/guide/platforms/android/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/guide/platforms/android/webview.html
+++ b/archive/docs/it/3.4.0/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/guide/platforms/blackberry/config.html
+++ b/archive/docs/it/3.4.0/guide/platforms/blackberry/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/guide/platforms/blackberry/index.html
+++ b/archive/docs/it/3.4.0/guide/platforms/blackberry/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/guide/platforms/blackberry/plugin.html
+++ b/archive/docs/it/3.4.0/guide/platforms/blackberry/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/guide/platforms/blackberry/tools.html
+++ b/archive/docs/it/3.4.0/guide/platforms/blackberry/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/guide/platforms/blackberry/upgrading.html
+++ b/archive/docs/it/3.4.0/guide/platforms/blackberry/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/it/3.4.0/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/guide/platforms/index.html
+++ b/archive/docs/it/3.4.0/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/guide/platforms/ios/config.html
+++ b/archive/docs/it/3.4.0/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/guide/platforms/ios/index.html
+++ b/archive/docs/it/3.4.0/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/guide/platforms/ios/plugin.html
+++ b/archive/docs/it/3.4.0/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/guide/platforms/ios/tools.html
+++ b/archive/docs/it/3.4.0/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/guide/platforms/ios/upgrading.html
+++ b/archive/docs/it/3.4.0/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/guide/platforms/ios/webview.html
+++ b/archive/docs/it/3.4.0/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/guide/platforms/tizen/index.html
+++ b/archive/docs/it/3.4.0/guide/platforms/tizen/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/guide/platforms/ubuntu/index.html
+++ b/archive/docs/it/3.4.0/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/guide/platforms/win8/index.html
+++ b/archive/docs/it/3.4.0/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/guide/platforms/win8/tools.html
+++ b/archive/docs/it/3.4.0/guide/platforms/win8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/guide/platforms/win8/upgrading.html
+++ b/archive/docs/it/3.4.0/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/guide/platforms/wp7/index.html
+++ b/archive/docs/it/3.4.0/guide/platforms/wp7/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/guide/platforms/wp8/index.html
+++ b/archive/docs/it/3.4.0/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/guide/platforms/wp8/plugin.html
+++ b/archive/docs/it/3.4.0/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/guide/platforms/wp8/tools.html
+++ b/archive/docs/it/3.4.0/guide/platforms/wp8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/guide/platforms/wp8/upgrading.html
+++ b/archive/docs/it/3.4.0/guide/platforms/wp8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/guide/support/index.html
+++ b/archive/docs/it/3.4.0/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/index.html
+++ b/archive/docs/it/3.4.0/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.4.0/plugin_ref/plugman.html
+++ b/archive/docs/it/3.4.0/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/config_ref/images.html
+++ b/archive/docs/it/3.5.0/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/config_ref/index.html
+++ b/archive/docs/it/3.5.0/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/cordova/events/events.backbutton.html
+++ b/archive/docs/it/3.5.0/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/cordova/events/events.deviceready.html
+++ b/archive/docs/it/3.5.0/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/cordova/events/events.endcallbutton.html
+++ b/archive/docs/it/3.5.0/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/cordova/events/events.html
+++ b/archive/docs/it/3.5.0/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/cordova/events/events.menubutton.html
+++ b/archive/docs/it/3.5.0/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/cordova/events/events.pause.html
+++ b/archive/docs/it/3.5.0/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/cordova/events/events.resume.html
+++ b/archive/docs/it/3.5.0/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/cordova/events/events.searchbutton.html
+++ b/archive/docs/it/3.5.0/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/cordova/events/events.startcallbutton.html
+++ b/archive/docs/it/3.5.0/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/it/3.5.0/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/it/3.5.0/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/cordova/plugins/pluginapis.html
+++ b/archive/docs/it/3.5.0/cordova/plugins/pluginapis.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/cordova/storage/database/database.html
+++ b/archive/docs/it/3.5.0/cordova/storage/database/database.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/it/3.5.0/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/cordova/storage/storage.html
+++ b/archive/docs/it/3.5.0/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/guide/appdev/privacy/index.html
+++ b/archive/docs/it/3.5.0/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/guide/appdev/whitelist/index.html
+++ b/archive/docs/it/3.5.0/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/guide/cli/index.html
+++ b/archive/docs/it/3.5.0/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/guide/hybrid/plugins/index.html
+++ b/archive/docs/it/3.5.0/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/guide/hybrid/webviews/index.html
+++ b/archive/docs/it/3.5.0/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/guide/overview/index.html
+++ b/archive/docs/it/3.5.0/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/guide/platforms/amazonfireos/config.html
+++ b/archive/docs/it/3.5.0/guide/platforms/amazonfireos/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/guide/platforms/amazonfireos/index.html
+++ b/archive/docs/it/3.5.0/guide/platforms/amazonfireos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/it/3.5.0/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/it/3.5.0/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/guide/platforms/android/config.html
+++ b/archive/docs/it/3.5.0/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/guide/platforms/android/index.html
+++ b/archive/docs/it/3.5.0/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/guide/platforms/android/plugin.html
+++ b/archive/docs/it/3.5.0/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/guide/platforms/android/tools.html
+++ b/archive/docs/it/3.5.0/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/guide/platforms/android/upgrading.html
+++ b/archive/docs/it/3.5.0/guide/platforms/android/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/guide/platforms/android/webview.html
+++ b/archive/docs/it/3.5.0/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/guide/platforms/blackberry/config.html
+++ b/archive/docs/it/3.5.0/guide/platforms/blackberry/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/guide/platforms/blackberry/index.html
+++ b/archive/docs/it/3.5.0/guide/platforms/blackberry/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/guide/platforms/blackberry/plugin.html
+++ b/archive/docs/it/3.5.0/guide/platforms/blackberry/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/guide/platforms/blackberry/tools.html
+++ b/archive/docs/it/3.5.0/guide/platforms/blackberry/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/guide/platforms/blackberry/upgrading.html
+++ b/archive/docs/it/3.5.0/guide/platforms/blackberry/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/it/3.5.0/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/guide/platforms/index.html
+++ b/archive/docs/it/3.5.0/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/guide/platforms/ios/config.html
+++ b/archive/docs/it/3.5.0/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/guide/platforms/ios/index.html
+++ b/archive/docs/it/3.5.0/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/guide/platforms/ios/plugin.html
+++ b/archive/docs/it/3.5.0/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/guide/platforms/ios/tools.html
+++ b/archive/docs/it/3.5.0/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/guide/platforms/ios/upgrading.html
+++ b/archive/docs/it/3.5.0/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/guide/platforms/ios/webview.html
+++ b/archive/docs/it/3.5.0/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/guide/platforms/tizen/index.html
+++ b/archive/docs/it/3.5.0/guide/platforms/tizen/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/guide/platforms/ubuntu/index.html
+++ b/archive/docs/it/3.5.0/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/guide/platforms/win8/index.html
+++ b/archive/docs/it/3.5.0/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/guide/platforms/win8/tools.html
+++ b/archive/docs/it/3.5.0/guide/platforms/win8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/guide/platforms/win8/upgrading.html
+++ b/archive/docs/it/3.5.0/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/guide/platforms/wp7/index.html
+++ b/archive/docs/it/3.5.0/guide/platforms/wp7/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/guide/platforms/wp8/index.html
+++ b/archive/docs/it/3.5.0/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/guide/platforms/wp8/plugin.html
+++ b/archive/docs/it/3.5.0/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/guide/platforms/wp8/tools.html
+++ b/archive/docs/it/3.5.0/guide/platforms/wp8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/guide/platforms/wp8/upgrading.html
+++ b/archive/docs/it/3.5.0/guide/platforms/wp8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/guide/support/index.html
+++ b/archive/docs/it/3.5.0/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/index.html
+++ b/archive/docs/it/3.5.0/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/3.5.0/plugin_ref/plugman.html
+++ b/archive/docs/it/3.5.0/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/config_ref/images.html
+++ b/archive/docs/it/5.4.0/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/config_ref/index.html
+++ b/archive/docs/it/5.4.0/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/cordova/events/events.backbutton.html
+++ b/archive/docs/it/5.4.0/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/cordova/events/events.deviceready.html
+++ b/archive/docs/it/5.4.0/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/cordova/events/events.endcallbutton.html
+++ b/archive/docs/it/5.4.0/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/cordova/events/events.html
+++ b/archive/docs/it/5.4.0/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/cordova/events/events.menubutton.html
+++ b/archive/docs/it/5.4.0/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/cordova/events/events.pause.html
+++ b/archive/docs/it/5.4.0/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/cordova/events/events.resume.html
+++ b/archive/docs/it/5.4.0/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/cordova/events/events.searchbutton.html
+++ b/archive/docs/it/5.4.0/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/cordova/events/events.startcallbutton.html
+++ b/archive/docs/it/5.4.0/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/it/5.4.0/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/it/5.4.0/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/cordova/plugins/pluginapis.html
+++ b/archive/docs/it/5.4.0/cordova/plugins/pluginapis.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/cordova/storage/database/database.html
+++ b/archive/docs/it/5.4.0/cordova/storage/database/database.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/it/5.4.0/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/cordova/storage/storage.html
+++ b/archive/docs/it/5.4.0/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/guide/appdev/hooks/index.html
+++ b/archive/docs/it/5.4.0/guide/appdev/hooks/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/guide/appdev/privacy/index.html
+++ b/archive/docs/it/5.4.0/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/guide/appdev/security/index.html
+++ b/archive/docs/it/5.4.0/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/guide/appdev/whitelist/index.html
+++ b/archive/docs/it/5.4.0/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/guide/cli/index.html
+++ b/archive/docs/it/5.4.0/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/guide/hybrid/plugins/index.html
+++ b/archive/docs/it/5.4.0/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/guide/hybrid/webviews/index.html
+++ b/archive/docs/it/5.4.0/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/guide/next/index.html
+++ b/archive/docs/it/5.4.0/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/guide/overview/index.html
+++ b/archive/docs/it/5.4.0/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/guide/platforms/amazonfireos/config.html
+++ b/archive/docs/it/5.4.0/guide/platforms/amazonfireos/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/guide/platforms/amazonfireos/index.html
+++ b/archive/docs/it/5.4.0/guide/platforms/amazonfireos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/it/5.4.0/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/it/5.4.0/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/guide/platforms/android/config.html
+++ b/archive/docs/it/5.4.0/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/guide/platforms/android/index.html
+++ b/archive/docs/it/5.4.0/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/guide/platforms/android/plugin.html
+++ b/archive/docs/it/5.4.0/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/guide/platforms/android/tools.html
+++ b/archive/docs/it/5.4.0/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/guide/platforms/android/upgrading.html
+++ b/archive/docs/it/5.4.0/guide/platforms/android/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/guide/platforms/android/webview.html
+++ b/archive/docs/it/5.4.0/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/guide/platforms/blackberry10/config.html
+++ b/archive/docs/it/5.4.0/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/guide/platforms/blackberry10/index.html
+++ b/archive/docs/it/5.4.0/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/it/5.4.0/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/it/5.4.0/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/guide/platforms/blackberry10/upgrading.html
+++ b/archive/docs/it/5.4.0/guide/platforms/blackberry10/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/guide/platforms/firefoxos/index.html
+++ b/archive/docs/it/5.4.0/guide/platforms/firefoxos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/guide/platforms/index.html
+++ b/archive/docs/it/5.4.0/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/guide/platforms/ios/config.html
+++ b/archive/docs/it/5.4.0/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/guide/platforms/ios/index.html
+++ b/archive/docs/it/5.4.0/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/guide/platforms/ios/plugin.html
+++ b/archive/docs/it/5.4.0/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/guide/platforms/ios/tools.html
+++ b/archive/docs/it/5.4.0/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/guide/platforms/ios/upgrading.html
+++ b/archive/docs/it/5.4.0/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/guide/platforms/ios/webview.html
+++ b/archive/docs/it/5.4.0/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/guide/platforms/tizen/index.html
+++ b/archive/docs/it/5.4.0/guide/platforms/tizen/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/guide/platforms/ubuntu/index.html
+++ b/archive/docs/it/5.4.0/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/guide/platforms/win8/index.html
+++ b/archive/docs/it/5.4.0/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/guide/platforms/win8/packaging.html
+++ b/archive/docs/it/5.4.0/guide/platforms/win8/packaging.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/guide/platforms/win8/plugin.html
+++ b/archive/docs/it/5.4.0/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/guide/platforms/win8/upgrading.html
+++ b/archive/docs/it/5.4.0/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/guide/platforms/wp8/index.html
+++ b/archive/docs/it/5.4.0/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/guide/platforms/wp8/parallels.html
+++ b/archive/docs/it/5.4.0/guide/platforms/wp8/parallels.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/guide/platforms/wp8/plugin.html
+++ b/archive/docs/it/5.4.0/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/guide/platforms/wp8/upgrading.html
+++ b/archive/docs/it/5.4.0/guide/platforms/wp8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/guide/platforms/wp8/webview.html
+++ b/archive/docs/it/5.4.0/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/guide/support/index.html
+++ b/archive/docs/it/5.4.0/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/index.html
+++ b/archive/docs/it/5.4.0/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/it/5.4.0/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/plugin_ref/plugman.html
+++ b/archive/docs/it/5.4.0/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/5.4.0/plugin_ref/spec.html
+++ b/archive/docs/it/5.4.0/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/config_ref/images.html
+++ b/archive/docs/it/6.x/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/config_ref/index.html
+++ b/archive/docs/it/6.x/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/cordova/events/events.backbutton.html
+++ b/archive/docs/it/6.x/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/cordova/events/events.deviceready.html
+++ b/archive/docs/it/6.x/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/cordova/events/events.endcallbutton.html
+++ b/archive/docs/it/6.x/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/cordova/events/events.html
+++ b/archive/docs/it/6.x/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/cordova/events/events.menubutton.html
+++ b/archive/docs/it/6.x/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/cordova/events/events.pause.html
+++ b/archive/docs/it/6.x/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/cordova/events/events.resume.html
+++ b/archive/docs/it/6.x/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/cordova/events/events.searchbutton.html
+++ b/archive/docs/it/6.x/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/cordova/events/events.startcallbutton.html
+++ b/archive/docs/it/6.x/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/it/6.x/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/it/6.x/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/cordova/storage/database/database.html
+++ b/archive/docs/it/6.x/cordova/storage/database/database.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/it/6.x/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/cordova/storage/storage.html
+++ b/archive/docs/it/6.x/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/guide/appdev/hooks/index.html
+++ b/archive/docs/it/6.x/guide/appdev/hooks/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/guide/appdev/privacy/index.html
+++ b/archive/docs/it/6.x/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/guide/appdev/security/index.html
+++ b/archive/docs/it/6.x/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/guide/appdev/whitelist/index.html
+++ b/archive/docs/it/6.x/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/guide/cli/index.html
+++ b/archive/docs/it/6.x/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/guide/hybrid/plugins/index.html
+++ b/archive/docs/it/6.x/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/guide/hybrid/webviews/index.html
+++ b/archive/docs/it/6.x/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/guide/next/index.html
+++ b/archive/docs/it/6.x/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/guide/overview/index.html
+++ b/archive/docs/it/6.x/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/it/6.x/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/it/6.x/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/guide/platforms/android/config.html
+++ b/archive/docs/it/6.x/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/guide/platforms/android/index.html
+++ b/archive/docs/it/6.x/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/guide/platforms/android/plugin.html
+++ b/archive/docs/it/6.x/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/guide/platforms/android/webview.html
+++ b/archive/docs/it/6.x/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/guide/platforms/blackberry10/config.html
+++ b/archive/docs/it/6.x/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/guide/platforms/blackberry10/home.html
+++ b/archive/docs/it/6.x/guide/platforms/blackberry10/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/guide/platforms/blackberry10/index.html
+++ b/archive/docs/it/6.x/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/it/6.x/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/it/6.x/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/guide/platforms/blackberry10/upgrade.html
+++ b/archive/docs/it/6.x/guide/platforms/blackberry10/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/guide/platforms/ios/config.html
+++ b/archive/docs/it/6.x/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/guide/platforms/ios/index.html
+++ b/archive/docs/it/6.x/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/guide/platforms/ios/plugin.html
+++ b/archive/docs/it/6.x/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/guide/platforms/ios/upgrading.html
+++ b/archive/docs/it/6.x/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/guide/platforms/ios/webview.html
+++ b/archive/docs/it/6.x/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/guide/platforms/ubuntu/index.html
+++ b/archive/docs/it/6.x/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/guide/platforms/win8/index.html
+++ b/archive/docs/it/6.x/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/guide/platforms/win8/plugin.html
+++ b/archive/docs/it/6.x/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/guide/platforms/wp8/home.html
+++ b/archive/docs/it/6.x/guide/platforms/wp8/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/guide/platforms/wp8/index.html
+++ b/archive/docs/it/6.x/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/guide/platforms/wp8/parallels.html
+++ b/archive/docs/it/6.x/guide/platforms/wp8/parallels.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/guide/platforms/wp8/plugin.html
+++ b/archive/docs/it/6.x/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/it/6.x/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/guide/platforms/wp8/upgrading.html
+++ b/archive/docs/it/6.x/guide/platforms/wp8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/guide/platforms/wp8/webview.html
+++ b/archive/docs/it/6.x/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/guide/support/index.html
+++ b/archive/docs/it/6.x/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/index.html
+++ b/archive/docs/it/6.x/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/it/6.x/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/plugin_ref/plugman.html
+++ b/archive/docs/it/6.x/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/6.x/plugin_ref/spec.html
+++ b/archive/docs/it/6.x/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/config_ref/images.html
+++ b/archive/docs/it/7.x/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/config_ref/index.html
+++ b/archive/docs/it/7.x/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/cordova/events/events.backbutton.html
+++ b/archive/docs/it/7.x/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/cordova/events/events.deviceready.html
+++ b/archive/docs/it/7.x/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/cordova/events/events.endcallbutton.html
+++ b/archive/docs/it/7.x/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/cordova/events/events.html
+++ b/archive/docs/it/7.x/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/cordova/events/events.menubutton.html
+++ b/archive/docs/it/7.x/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/cordova/events/events.pause.html
+++ b/archive/docs/it/7.x/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/cordova/events/events.resume.html
+++ b/archive/docs/it/7.x/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/cordova/events/events.searchbutton.html
+++ b/archive/docs/it/7.x/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/cordova/events/events.startcallbutton.html
+++ b/archive/docs/it/7.x/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/it/7.x/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/it/7.x/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/cordova/storage/database/database.html
+++ b/archive/docs/it/7.x/cordova/storage/database/database.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/it/7.x/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/cordova/storage/storage.html
+++ b/archive/docs/it/7.x/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/guide/appdev/hooks/index.html
+++ b/archive/docs/it/7.x/guide/appdev/hooks/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/guide/appdev/privacy/index.html
+++ b/archive/docs/it/7.x/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/guide/appdev/security/index.html
+++ b/archive/docs/it/7.x/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/guide/appdev/whitelist/index.html
+++ b/archive/docs/it/7.x/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/guide/cli/index.html
+++ b/archive/docs/it/7.x/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/guide/hybrid/plugins/index.html
+++ b/archive/docs/it/7.x/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/guide/hybrid/webviews/index.html
+++ b/archive/docs/it/7.x/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/guide/next/index.html
+++ b/archive/docs/it/7.x/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/guide/overview/index.html
+++ b/archive/docs/it/7.x/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/it/7.x/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/it/7.x/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/guide/platforms/android/config.html
+++ b/archive/docs/it/7.x/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/guide/platforms/android/index.html
+++ b/archive/docs/it/7.x/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/guide/platforms/android/plugin.html
+++ b/archive/docs/it/7.x/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/guide/platforms/android/webview.html
+++ b/archive/docs/it/7.x/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/guide/platforms/blackberry10/config.html
+++ b/archive/docs/it/7.x/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/guide/platforms/blackberry10/home.html
+++ b/archive/docs/it/7.x/guide/platforms/blackberry10/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/guide/platforms/blackberry10/index.html
+++ b/archive/docs/it/7.x/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/it/7.x/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/it/7.x/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/guide/platforms/blackberry10/upgrade.html
+++ b/archive/docs/it/7.x/guide/platforms/blackberry10/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/guide/platforms/ios/config.html
+++ b/archive/docs/it/7.x/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/guide/platforms/ios/index.html
+++ b/archive/docs/it/7.x/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/guide/platforms/ios/plugin.html
+++ b/archive/docs/it/7.x/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/guide/platforms/ios/upgrading.html
+++ b/archive/docs/it/7.x/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/guide/platforms/ios/webview.html
+++ b/archive/docs/it/7.x/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/guide/platforms/ubuntu/index.html
+++ b/archive/docs/it/7.x/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/guide/platforms/win8/index.html
+++ b/archive/docs/it/7.x/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/guide/platforms/win8/plugin.html
+++ b/archive/docs/it/7.x/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/guide/platforms/wp8/home.html
+++ b/archive/docs/it/7.x/guide/platforms/wp8/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/guide/platforms/wp8/index.html
+++ b/archive/docs/it/7.x/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/guide/platforms/wp8/parallels.html
+++ b/archive/docs/it/7.x/guide/platforms/wp8/parallels.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/guide/platforms/wp8/plugin.html
+++ b/archive/docs/it/7.x/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/it/7.x/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/guide/platforms/wp8/upgrading.html
+++ b/archive/docs/it/7.x/guide/platforms/wp8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/guide/platforms/wp8/webview.html
+++ b/archive/docs/it/7.x/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/guide/support/index.html
+++ b/archive/docs/it/7.x/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/index.html
+++ b/archive/docs/it/7.x/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/it/7.x/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/plugin_ref/plugman.html
+++ b/archive/docs/it/7.x/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/7.x/plugin_ref/spec.html
+++ b/archive/docs/it/7.x/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/config_ref/images.html
+++ b/archive/docs/it/8.x/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/config_ref/index.html
+++ b/archive/docs/it/8.x/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/cordova/events/events.backbutton.html
+++ b/archive/docs/it/8.x/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/cordova/events/events.deviceready.html
+++ b/archive/docs/it/8.x/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/cordova/events/events.endcallbutton.html
+++ b/archive/docs/it/8.x/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/cordova/events/events.html
+++ b/archive/docs/it/8.x/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/cordova/events/events.menubutton.html
+++ b/archive/docs/it/8.x/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/cordova/events/events.pause.html
+++ b/archive/docs/it/8.x/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/cordova/events/events.resume.html
+++ b/archive/docs/it/8.x/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/cordova/events/events.searchbutton.html
+++ b/archive/docs/it/8.x/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/cordova/events/events.startcallbutton.html
+++ b/archive/docs/it/8.x/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/it/8.x/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/it/8.x/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/cordova/storage/database/database.html
+++ b/archive/docs/it/8.x/cordova/storage/database/database.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/it/8.x/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/cordova/storage/storage.html
+++ b/archive/docs/it/8.x/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/guide/appdev/hooks/index.html
+++ b/archive/docs/it/8.x/guide/appdev/hooks/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/guide/appdev/privacy/index.html
+++ b/archive/docs/it/8.x/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/guide/appdev/security/index.html
+++ b/archive/docs/it/8.x/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/guide/appdev/whitelist/index.html
+++ b/archive/docs/it/8.x/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/guide/cli/index.html
+++ b/archive/docs/it/8.x/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/guide/hybrid/plugins/index.html
+++ b/archive/docs/it/8.x/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/guide/hybrid/webviews/index.html
+++ b/archive/docs/it/8.x/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/guide/next/index.html
+++ b/archive/docs/it/8.x/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/guide/overview/index.html
+++ b/archive/docs/it/8.x/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/it/8.x/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/it/8.x/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/guide/platforms/android/config.html
+++ b/archive/docs/it/8.x/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/guide/platforms/android/index.html
+++ b/archive/docs/it/8.x/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/guide/platforms/android/plugin.html
+++ b/archive/docs/it/8.x/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/guide/platforms/android/webview.html
+++ b/archive/docs/it/8.x/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/guide/platforms/blackberry10/config.html
+++ b/archive/docs/it/8.x/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/guide/platforms/blackberry10/home.html
+++ b/archive/docs/it/8.x/guide/platforms/blackberry10/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/guide/platforms/blackberry10/index.html
+++ b/archive/docs/it/8.x/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/it/8.x/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/it/8.x/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/guide/platforms/blackberry10/upgrade.html
+++ b/archive/docs/it/8.x/guide/platforms/blackberry10/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/guide/platforms/ios/config.html
+++ b/archive/docs/it/8.x/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/guide/platforms/ios/index.html
+++ b/archive/docs/it/8.x/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/guide/platforms/ios/plugin.html
+++ b/archive/docs/it/8.x/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/guide/platforms/ios/upgrading.html
+++ b/archive/docs/it/8.x/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/guide/platforms/ios/webview.html
+++ b/archive/docs/it/8.x/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/guide/platforms/ubuntu/index.html
+++ b/archive/docs/it/8.x/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/guide/platforms/win8/index.html
+++ b/archive/docs/it/8.x/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/guide/platforms/win8/plugin.html
+++ b/archive/docs/it/8.x/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/guide/platforms/wp8/home.html
+++ b/archive/docs/it/8.x/guide/platforms/wp8/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/guide/platforms/wp8/index.html
+++ b/archive/docs/it/8.x/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/guide/platforms/wp8/parallels.html
+++ b/archive/docs/it/8.x/guide/platforms/wp8/parallels.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/guide/platforms/wp8/plugin.html
+++ b/archive/docs/it/8.x/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/it/8.x/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/guide/platforms/wp8/upgrading.html
+++ b/archive/docs/it/8.x/guide/platforms/wp8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/guide/platforms/wp8/webview.html
+++ b/archive/docs/it/8.x/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/guide/support/index.html
+++ b/archive/docs/it/8.x/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/index.html
+++ b/archive/docs/it/8.x/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/it/8.x/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/plugin_ref/plugman.html
+++ b/archive/docs/it/8.x/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/8.x/plugin_ref/spec.html
+++ b/archive/docs/it/8.x/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/config_ref/images.html
+++ b/archive/docs/it/9.x/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/config_ref/index.html
+++ b/archive/docs/it/9.x/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/cordova/events/events.backbutton.html
+++ b/archive/docs/it/9.x/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/cordova/events/events.deviceready.html
+++ b/archive/docs/it/9.x/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/cordova/events/events.endcallbutton.html
+++ b/archive/docs/it/9.x/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/cordova/events/events.html
+++ b/archive/docs/it/9.x/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/cordova/events/events.menubutton.html
+++ b/archive/docs/it/9.x/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/cordova/events/events.pause.html
+++ b/archive/docs/it/9.x/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/cordova/events/events.resume.html
+++ b/archive/docs/it/9.x/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/cordova/events/events.searchbutton.html
+++ b/archive/docs/it/9.x/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/cordova/events/events.startcallbutton.html
+++ b/archive/docs/it/9.x/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/it/9.x/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/it/9.x/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/cordova/storage/database/database.html
+++ b/archive/docs/it/9.x/cordova/storage/database/database.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/it/9.x/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/cordova/storage/storage.html
+++ b/archive/docs/it/9.x/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/guide/appdev/hooks/index.html
+++ b/archive/docs/it/9.x/guide/appdev/hooks/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/guide/appdev/privacy/index.html
+++ b/archive/docs/it/9.x/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/guide/appdev/security/index.html
+++ b/archive/docs/it/9.x/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/guide/appdev/whitelist/index.html
+++ b/archive/docs/it/9.x/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/guide/cli/index.html
+++ b/archive/docs/it/9.x/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/guide/hybrid/plugins/index.html
+++ b/archive/docs/it/9.x/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/guide/hybrid/webviews/index.html
+++ b/archive/docs/it/9.x/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/guide/next/index.html
+++ b/archive/docs/it/9.x/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/guide/overview/index.html
+++ b/archive/docs/it/9.x/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/it/9.x/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/it/9.x/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/guide/platforms/android/config.html
+++ b/archive/docs/it/9.x/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/guide/platforms/android/index.html
+++ b/archive/docs/it/9.x/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/guide/platforms/android/plugin.html
+++ b/archive/docs/it/9.x/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/guide/platforms/android/webview.html
+++ b/archive/docs/it/9.x/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/guide/platforms/blackberry10/config.html
+++ b/archive/docs/it/9.x/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/guide/platforms/blackberry10/home.html
+++ b/archive/docs/it/9.x/guide/platforms/blackberry10/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/guide/platforms/blackberry10/index.html
+++ b/archive/docs/it/9.x/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/it/9.x/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/it/9.x/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/guide/platforms/blackberry10/upgrade.html
+++ b/archive/docs/it/9.x/guide/platforms/blackberry10/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/guide/platforms/ios/config.html
+++ b/archive/docs/it/9.x/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/guide/platforms/ios/index.html
+++ b/archive/docs/it/9.x/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/guide/platforms/ios/plugin.html
+++ b/archive/docs/it/9.x/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/guide/platforms/ios/upgrading.html
+++ b/archive/docs/it/9.x/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/guide/platforms/ios/webview.html
+++ b/archive/docs/it/9.x/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/guide/platforms/ubuntu/index.html
+++ b/archive/docs/it/9.x/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/guide/platforms/win8/index.html
+++ b/archive/docs/it/9.x/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/guide/platforms/win8/plugin.html
+++ b/archive/docs/it/9.x/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/guide/platforms/wp8/home.html
+++ b/archive/docs/it/9.x/guide/platforms/wp8/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/guide/platforms/wp8/index.html
+++ b/archive/docs/it/9.x/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/guide/platforms/wp8/parallels.html
+++ b/archive/docs/it/9.x/guide/platforms/wp8/parallels.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/guide/platforms/wp8/plugin.html
+++ b/archive/docs/it/9.x/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/it/9.x/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/guide/platforms/wp8/upgrading.html
+++ b/archive/docs/it/9.x/guide/platforms/wp8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/guide/platforms/wp8/webview.html
+++ b/archive/docs/it/9.x/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/guide/support/index.html
+++ b/archive/docs/it/9.x/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/index.html
+++ b/archive/docs/it/9.x/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/it/9.x/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/plugin_ref/plugman.html
+++ b/archive/docs/it/9.x/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/it/9.x/plugin_ref/spec.html
+++ b/archive/docs/it/9.x/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/accelerometer/acceleration/acceleration.html
+++ b/archive/docs/ja/1.7.0/cordova/accelerometer/acceleration/acceleration.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/accelerometer/accelerometer.clearWatch.html
+++ b/archive/docs/ja/1.7.0/cordova/accelerometer/accelerometer.clearWatch.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/accelerometer/accelerometer.getCurrentAcceleration.html
+++ b/archive/docs/ja/1.7.0/cordova/accelerometer/accelerometer.getCurrentAcceleration.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/accelerometer/accelerometer.html
+++ b/archive/docs/ja/1.7.0/cordova/accelerometer/accelerometer.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/accelerometer/accelerometer.watchAcceleration.html
+++ b/archive/docs/ja/1.7.0/cordova/accelerometer/accelerometer.watchAcceleration.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/accelerometer/parameters/accelerometerError.html
+++ b/archive/docs/ja/1.7.0/cordova/accelerometer/parameters/accelerometerError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/accelerometer/parameters/accelerometerOptions.html
+++ b/archive/docs/ja/1.7.0/cordova/accelerometer/parameters/accelerometerOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/accelerometer/parameters/accelerometerSuccess.html
+++ b/archive/docs/ja/1.7.0/cordova/accelerometer/parameters/accelerometerSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/camera/camera.getPicture.html
+++ b/archive/docs/ja/1.7.0/cordova/camera/camera.getPicture.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/camera/camera.html
+++ b/archive/docs/ja/1.7.0/cordova/camera/camera.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/compass/compass.clearWatch.html
+++ b/archive/docs/ja/1.7.0/cordova/compass/compass.clearWatch.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/compass/compass.clearWatchFilter.html
+++ b/archive/docs/ja/1.7.0/cordova/compass/compass.clearWatchFilter.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/compass/compass.getCurrentHeading.html
+++ b/archive/docs/ja/1.7.0/cordova/compass/compass.getCurrentHeading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/compass/compass.html
+++ b/archive/docs/ja/1.7.0/cordova/compass/compass.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/compass/compass.watchHeading.html
+++ b/archive/docs/ja/1.7.0/cordova/compass/compass.watchHeading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/compass/compass.watchHeadingFilter.html
+++ b/archive/docs/ja/1.7.0/cordova/compass/compass.watchHeadingFilter.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/compass/parameters/compassError.html
+++ b/archive/docs/ja/1.7.0/cordova/compass/parameters/compassError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/compass/parameters/compassHeading.html
+++ b/archive/docs/ja/1.7.0/cordova/compass/parameters/compassHeading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/compass/parameters/compassOptions.html
+++ b/archive/docs/ja/1.7.0/cordova/compass/parameters/compassOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/compass/parameters/compassSuccess.html
+++ b/archive/docs/ja/1.7.0/cordova/compass/parameters/compassSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/connection/connection.html
+++ b/archive/docs/ja/1.7.0/cordova/connection/connection.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/connection/connection.type.html
+++ b/archive/docs/ja/1.7.0/cordova/connection/connection.type.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/contacts/Contact/contact.html
+++ b/archive/docs/ja/1.7.0/cordova/contacts/Contact/contact.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/contacts/ContactAddress/contactaddress.html
+++ b/archive/docs/ja/1.7.0/cordova/contacts/ContactAddress/contactaddress.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/contacts/ContactError/contactError.html
+++ b/archive/docs/ja/1.7.0/cordova/contacts/ContactError/contactError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/contacts/ContactField/contactfield.html
+++ b/archive/docs/ja/1.7.0/cordova/contacts/ContactField/contactfield.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/contacts/ContactFindOptions/contactfindoptions.html
+++ b/archive/docs/ja/1.7.0/cordova/contacts/ContactFindOptions/contactfindoptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/contacts/ContactName/contactname.html
+++ b/archive/docs/ja/1.7.0/cordova/contacts/ContactName/contactname.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/contacts/ContactOrganization/contactorganization.html
+++ b/archive/docs/ja/1.7.0/cordova/contacts/ContactOrganization/contactorganization.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/contacts/contacts.create.html
+++ b/archive/docs/ja/1.7.0/cordova/contacts/contacts.create.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/contacts/contacts.find.html
+++ b/archive/docs/ja/1.7.0/cordova/contacts/contacts.find.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/contacts/contacts.html
+++ b/archive/docs/ja/1.7.0/cordova/contacts/contacts.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/contacts/parameters/contactError.html
+++ b/archive/docs/ja/1.7.0/cordova/contacts/parameters/contactError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/contacts/parameters/contactFields.html
+++ b/archive/docs/ja/1.7.0/cordova/contacts/parameters/contactFields.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/contacts/parameters/contactFindOptions.html
+++ b/archive/docs/ja/1.7.0/cordova/contacts/parameters/contactFindOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/contacts/parameters/contactSuccess.html
+++ b/archive/docs/ja/1.7.0/cordova/contacts/parameters/contactSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/device/device.cordova.html
+++ b/archive/docs/ja/1.7.0/cordova/device/device.cordova.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/device/device.html
+++ b/archive/docs/ja/1.7.0/cordova/device/device.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/device/device.name.html
+++ b/archive/docs/ja/1.7.0/cordova/device/device.name.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/device/device.platform.html
+++ b/archive/docs/ja/1.7.0/cordova/device/device.platform.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/device/device.uuid.html
+++ b/archive/docs/ja/1.7.0/cordova/device/device.uuid.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/device/device.version.html
+++ b/archive/docs/ja/1.7.0/cordova/device/device.version.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/events/events.backbutton.html
+++ b/archive/docs/ja/1.7.0/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/events/events.batterycritical.html
+++ b/archive/docs/ja/1.7.0/cordova/events/events.batterycritical.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/events/events.batterylow.html
+++ b/archive/docs/ja/1.7.0/cordova/events/events.batterylow.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/events/events.batterystatus.html
+++ b/archive/docs/ja/1.7.0/cordova/events/events.batterystatus.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/events/events.deviceready.html
+++ b/archive/docs/ja/1.7.0/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/events/events.endcallbutton.html
+++ b/archive/docs/ja/1.7.0/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/events/events.html
+++ b/archive/docs/ja/1.7.0/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/events/events.menubutton.html
+++ b/archive/docs/ja/1.7.0/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/events/events.offline.html
+++ b/archive/docs/ja/1.7.0/cordova/events/events.offline.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/events/events.online.html
+++ b/archive/docs/ja/1.7.0/cordova/events/events.online.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/events/events.pause.html
+++ b/archive/docs/ja/1.7.0/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/events/events.resume.html
+++ b/archive/docs/ja/1.7.0/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/events/events.searchbutton.html
+++ b/archive/docs/ja/1.7.0/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/events/events.startcallbutton.html
+++ b/archive/docs/ja/1.7.0/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/ja/1.7.0/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/ja/1.7.0/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/file/directoryentry/directoryentry.html
+++ b/archive/docs/ja/1.7.0/cordova/file/directoryentry/directoryentry.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/file/directoryreader/directoryreader.html
+++ b/archive/docs/ja/1.7.0/cordova/file/directoryreader/directoryreader.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/file/file.html
+++ b/archive/docs/ja/1.7.0/cordova/file/file.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/file/fileentry/fileentry.html
+++ b/archive/docs/ja/1.7.0/cordova/file/fileentry/fileentry.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/file/fileerror/fileerror.html
+++ b/archive/docs/ja/1.7.0/cordova/file/fileerror/fileerror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/file/fileobj/fileobj.html
+++ b/archive/docs/ja/1.7.0/cordova/file/fileobj/fileobj.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/file/filereader/filereader.html
+++ b/archive/docs/ja/1.7.0/cordova/file/filereader/filereader.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/file/filesystem/filesystem.html
+++ b/archive/docs/ja/1.7.0/cordova/file/filesystem/filesystem.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/file/filetransfer/filetransfer.html
+++ b/archive/docs/ja/1.7.0/cordova/file/filetransfer/filetransfer.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/file/filetransfererror/filetransfererror.html
+++ b/archive/docs/ja/1.7.0/cordova/file/filetransfererror/filetransfererror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/file/fileuploadoptions/fileuploadoptions.html
+++ b/archive/docs/ja/1.7.0/cordova/file/fileuploadoptions/fileuploadoptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/file/fileuploadresult/fileuploadresult.html
+++ b/archive/docs/ja/1.7.0/cordova/file/fileuploadresult/fileuploadresult.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/file/filewriter/filewriter.html
+++ b/archive/docs/ja/1.7.0/cordova/file/filewriter/filewriter.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/file/flags/flags.html
+++ b/archive/docs/ja/1.7.0/cordova/file/flags/flags.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/file/localfilesystem/localfilesystem.html
+++ b/archive/docs/ja/1.7.0/cordova/file/localfilesystem/localfilesystem.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/file/metadata/metadata.html
+++ b/archive/docs/ja/1.7.0/cordova/file/metadata/metadata.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/geolocation/Coordinates/coordinates.html
+++ b/archive/docs/ja/1.7.0/cordova/geolocation/Coordinates/coordinates.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/geolocation/Position/position.html
+++ b/archive/docs/ja/1.7.0/cordova/geolocation/Position/position.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/geolocation/PositionError/positionError.html
+++ b/archive/docs/ja/1.7.0/cordova/geolocation/PositionError/positionError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/geolocation/geolocation.clearWatch.html
+++ b/archive/docs/ja/1.7.0/cordova/geolocation/geolocation.clearWatch.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/geolocation/geolocation.getCurrentPosition.html
+++ b/archive/docs/ja/1.7.0/cordova/geolocation/geolocation.getCurrentPosition.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/geolocation/geolocation.html
+++ b/archive/docs/ja/1.7.0/cordova/geolocation/geolocation.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/geolocation/geolocation.watchPosition.html
+++ b/archive/docs/ja/1.7.0/cordova/geolocation/geolocation.watchPosition.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/geolocation/parameters/geolocation.options.html
+++ b/archive/docs/ja/1.7.0/cordova/geolocation/parameters/geolocation.options.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/geolocation/parameters/geolocationError.html
+++ b/archive/docs/ja/1.7.0/cordova/geolocation/parameters/geolocationError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/geolocation/parameters/geolocationSuccess.html
+++ b/archive/docs/ja/1.7.0/cordova/geolocation/parameters/geolocationSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/media/capture/CaptureCB.html
+++ b/archive/docs/ja/1.7.0/cordova/media/capture/CaptureCB.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/media/capture/CaptureError.html
+++ b/archive/docs/ja/1.7.0/cordova/media/capture/CaptureError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/media/capture/CaptureErrorCB.html
+++ b/archive/docs/ja/1.7.0/cordova/media/capture/CaptureErrorCB.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/media/capture/ConfigurationData.html
+++ b/archive/docs/ja/1.7.0/cordova/media/capture/ConfigurationData.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/media/capture/MediaFile.html
+++ b/archive/docs/ja/1.7.0/cordova/media/capture/MediaFile.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/media/capture/MediaFileData.html
+++ b/archive/docs/ja/1.7.0/cordova/media/capture/MediaFileData.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/media/capture/capture.html
+++ b/archive/docs/ja/1.7.0/cordova/media/capture/capture.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/media/capture/captureAudio.html
+++ b/archive/docs/ja/1.7.0/cordova/media/capture/captureAudio.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/media/capture/captureAudioOptions.html
+++ b/archive/docs/ja/1.7.0/cordova/media/capture/captureAudioOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/media/capture/captureImage.html
+++ b/archive/docs/ja/1.7.0/cordova/media/capture/captureImage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/media/capture/captureImageOptions.html
+++ b/archive/docs/ja/1.7.0/cordova/media/capture/captureImageOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/media/capture/captureVideo.html
+++ b/archive/docs/ja/1.7.0/cordova/media/capture/captureVideo.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/media/capture/captureVideoOptions.html
+++ b/archive/docs/ja/1.7.0/cordova/media/capture/captureVideoOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/media/media.getCurrentPosition.html
+++ b/archive/docs/ja/1.7.0/cordova/media/media.getCurrentPosition.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/media/media.getDuration.html
+++ b/archive/docs/ja/1.7.0/cordova/media/media.getDuration.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/media/media.html
+++ b/archive/docs/ja/1.7.0/cordova/media/media.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/media/media.pause.html
+++ b/archive/docs/ja/1.7.0/cordova/media/media.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/media/media.play.html
+++ b/archive/docs/ja/1.7.0/cordova/media/media.play.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/media/media.release.html
+++ b/archive/docs/ja/1.7.0/cordova/media/media.release.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/media/media.seekTo.html
+++ b/archive/docs/ja/1.7.0/cordova/media/media.seekTo.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/media/media.startRecord.html
+++ b/archive/docs/ja/1.7.0/cordova/media/media.startRecord.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/media/media.stop.html
+++ b/archive/docs/ja/1.7.0/cordova/media/media.stop.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/media/media.stopRecord.html
+++ b/archive/docs/ja/1.7.0/cordova/media/media.stopRecord.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/notification/notification.alert.html
+++ b/archive/docs/ja/1.7.0/cordova/notification/notification.alert.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/notification/notification.beep.html
+++ b/archive/docs/ja/1.7.0/cordova/notification/notification.beep.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/notification/notification.confirm.html
+++ b/archive/docs/ja/1.7.0/cordova/notification/notification.confirm.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/notification/notification.html
+++ b/archive/docs/ja/1.7.0/cordova/notification/notification.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/notification/notification.vibrate.html
+++ b/archive/docs/ja/1.7.0/cordova/notification/notification.vibrate.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/storage/database/database.html
+++ b/archive/docs/ja/1.7.0/cordova/storage/database/database.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/ja/1.7.0/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/storage/parameters/display_name.html
+++ b/archive/docs/ja/1.7.0/cordova/storage/parameters/display_name.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/storage/parameters/name.html
+++ b/archive/docs/ja/1.7.0/cordova/storage/parameters/name.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/storage/parameters/size.html
+++ b/archive/docs/ja/1.7.0/cordova/storage/parameters/size.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/storage/parameters/version.html
+++ b/archive/docs/ja/1.7.0/cordova/storage/parameters/version.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/storage/sqlerror/sqlerror.html
+++ b/archive/docs/ja/1.7.0/cordova/storage/sqlerror/sqlerror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/storage/sqlresultset/sqlresultset.html
+++ b/archive/docs/ja/1.7.0/cordova/storage/sqlresultset/sqlresultset.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/storage/sqlresultsetlist/sqlresultsetlist.html
+++ b/archive/docs/ja/1.7.0/cordova/storage/sqlresultsetlist/sqlresultsetlist.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/storage/sqltransaction/sqltransaction.html
+++ b/archive/docs/ja/1.7.0/cordova/storage/sqltransaction/sqltransaction.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/storage/storage.html
+++ b/archive/docs/ja/1.7.0/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/cordova/storage/storage.opendatabase.html
+++ b/archive/docs/ja/1.7.0/cordova/storage/storage.opendatabase.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/guide/getting-started/android/index.html
+++ b/archive/docs/ja/1.7.0/guide/getting-started/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/guide/getting-started/bada/index.html
+++ b/archive/docs/ja/1.7.0/guide/getting-started/bada/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/guide/getting-started/blackberry/index.html
+++ b/archive/docs/ja/1.7.0/guide/getting-started/blackberry/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/guide/getting-started/index.html
+++ b/archive/docs/ja/1.7.0/guide/getting-started/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/guide/getting-started/ios/index.html
+++ b/archive/docs/ja/1.7.0/guide/getting-started/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/guide/getting-started/symbian/index.html
+++ b/archive/docs/ja/1.7.0/guide/getting-started/symbian/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/guide/getting-started/webos/index.html
+++ b/archive/docs/ja/1.7.0/guide/getting-started/webos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/guide/getting-started/windows-phone/index.html
+++ b/archive/docs/ja/1.7.0/guide/getting-started/windows-phone/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.7.0/index.html
+++ b/archive/docs/ja/1.7.0/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/accelerometer/acceleration/acceleration.html
+++ b/archive/docs/ja/1.8.1/cordova/accelerometer/acceleration/acceleration.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/accelerometer/accelerometer.clearWatch.html
+++ b/archive/docs/ja/1.8.1/cordova/accelerometer/accelerometer.clearWatch.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/accelerometer/accelerometer.getCurrentAcceleration.html
+++ b/archive/docs/ja/1.8.1/cordova/accelerometer/accelerometer.getCurrentAcceleration.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/accelerometer/accelerometer.html
+++ b/archive/docs/ja/1.8.1/cordova/accelerometer/accelerometer.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/accelerometer/accelerometer.watchAcceleration.html
+++ b/archive/docs/ja/1.8.1/cordova/accelerometer/accelerometer.watchAcceleration.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/accelerometer/parameters/accelerometerError.html
+++ b/archive/docs/ja/1.8.1/cordova/accelerometer/parameters/accelerometerError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/accelerometer/parameters/accelerometerOptions.html
+++ b/archive/docs/ja/1.8.1/cordova/accelerometer/parameters/accelerometerOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/accelerometer/parameters/accelerometerSuccess.html
+++ b/archive/docs/ja/1.8.1/cordova/accelerometer/parameters/accelerometerSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/camera/camera.getPicture.html
+++ b/archive/docs/ja/1.8.1/cordova/camera/camera.getPicture.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/camera/camera.html
+++ b/archive/docs/ja/1.8.1/cordova/camera/camera.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/compass/compass.clearWatch.html
+++ b/archive/docs/ja/1.8.1/cordova/compass/compass.clearWatch.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/compass/compass.clearWatchFilter.html
+++ b/archive/docs/ja/1.8.1/cordova/compass/compass.clearWatchFilter.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/compass/compass.getCurrentHeading.html
+++ b/archive/docs/ja/1.8.1/cordova/compass/compass.getCurrentHeading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/compass/compass.html
+++ b/archive/docs/ja/1.8.1/cordova/compass/compass.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/compass/compass.watchHeading.html
+++ b/archive/docs/ja/1.8.1/cordova/compass/compass.watchHeading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/compass/compass.watchHeadingFilter.html
+++ b/archive/docs/ja/1.8.1/cordova/compass/compass.watchHeadingFilter.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/compass/parameters/compassError.html
+++ b/archive/docs/ja/1.8.1/cordova/compass/parameters/compassError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/compass/parameters/compassHeading.html
+++ b/archive/docs/ja/1.8.1/cordova/compass/parameters/compassHeading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/compass/parameters/compassOptions.html
+++ b/archive/docs/ja/1.8.1/cordova/compass/parameters/compassOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/compass/parameters/compassSuccess.html
+++ b/archive/docs/ja/1.8.1/cordova/compass/parameters/compassSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/connection/connection.html
+++ b/archive/docs/ja/1.8.1/cordova/connection/connection.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/connection/connection.type.html
+++ b/archive/docs/ja/1.8.1/cordova/connection/connection.type.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/contacts/Contact/contact.html
+++ b/archive/docs/ja/1.8.1/cordova/contacts/Contact/contact.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/contacts/ContactAddress/contactaddress.html
+++ b/archive/docs/ja/1.8.1/cordova/contacts/ContactAddress/contactaddress.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/contacts/ContactError/contactError.html
+++ b/archive/docs/ja/1.8.1/cordova/contacts/ContactError/contactError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/contacts/ContactField/contactfield.html
+++ b/archive/docs/ja/1.8.1/cordova/contacts/ContactField/contactfield.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/contacts/ContactFindOptions/contactfindoptions.html
+++ b/archive/docs/ja/1.8.1/cordova/contacts/ContactFindOptions/contactfindoptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/contacts/ContactName/contactname.html
+++ b/archive/docs/ja/1.8.1/cordova/contacts/ContactName/contactname.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/contacts/ContactOrganization/contactorganization.html
+++ b/archive/docs/ja/1.8.1/cordova/contacts/ContactOrganization/contactorganization.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/contacts/contacts.create.html
+++ b/archive/docs/ja/1.8.1/cordova/contacts/contacts.create.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/contacts/contacts.find.html
+++ b/archive/docs/ja/1.8.1/cordova/contacts/contacts.find.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/contacts/contacts.html
+++ b/archive/docs/ja/1.8.1/cordova/contacts/contacts.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/contacts/parameters/contactError.html
+++ b/archive/docs/ja/1.8.1/cordova/contacts/parameters/contactError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/contacts/parameters/contactFields.html
+++ b/archive/docs/ja/1.8.1/cordova/contacts/parameters/contactFields.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/contacts/parameters/contactFindOptions.html
+++ b/archive/docs/ja/1.8.1/cordova/contacts/parameters/contactFindOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/contacts/parameters/contactSuccess.html
+++ b/archive/docs/ja/1.8.1/cordova/contacts/parameters/contactSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/device/device.cordova.html
+++ b/archive/docs/ja/1.8.1/cordova/device/device.cordova.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/device/device.html
+++ b/archive/docs/ja/1.8.1/cordova/device/device.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/device/device.name.html
+++ b/archive/docs/ja/1.8.1/cordova/device/device.name.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/device/device.platform.html
+++ b/archive/docs/ja/1.8.1/cordova/device/device.platform.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/device/device.uuid.html
+++ b/archive/docs/ja/1.8.1/cordova/device/device.uuid.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/device/device.version.html
+++ b/archive/docs/ja/1.8.1/cordova/device/device.version.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/events/events.backbutton.html
+++ b/archive/docs/ja/1.8.1/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/events/events.batterycritical.html
+++ b/archive/docs/ja/1.8.1/cordova/events/events.batterycritical.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/events/events.batterylow.html
+++ b/archive/docs/ja/1.8.1/cordova/events/events.batterylow.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/events/events.batterystatus.html
+++ b/archive/docs/ja/1.8.1/cordova/events/events.batterystatus.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/events/events.deviceready.html
+++ b/archive/docs/ja/1.8.1/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/events/events.endcallbutton.html
+++ b/archive/docs/ja/1.8.1/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/events/events.html
+++ b/archive/docs/ja/1.8.1/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/events/events.menubutton.html
+++ b/archive/docs/ja/1.8.1/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/events/events.offline.html
+++ b/archive/docs/ja/1.8.1/cordova/events/events.offline.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/events/events.online.html
+++ b/archive/docs/ja/1.8.1/cordova/events/events.online.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/events/events.pause.html
+++ b/archive/docs/ja/1.8.1/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/events/events.resume.html
+++ b/archive/docs/ja/1.8.1/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/events/events.searchbutton.html
+++ b/archive/docs/ja/1.8.1/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/events/events.startcallbutton.html
+++ b/archive/docs/ja/1.8.1/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/ja/1.8.1/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/ja/1.8.1/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/file/directoryentry/directoryentry.html
+++ b/archive/docs/ja/1.8.1/cordova/file/directoryentry/directoryentry.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/file/directoryreader/directoryreader.html
+++ b/archive/docs/ja/1.8.1/cordova/file/directoryreader/directoryreader.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/file/file.html
+++ b/archive/docs/ja/1.8.1/cordova/file/file.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/file/fileentry/fileentry.html
+++ b/archive/docs/ja/1.8.1/cordova/file/fileentry/fileentry.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/file/fileerror/fileerror.html
+++ b/archive/docs/ja/1.8.1/cordova/file/fileerror/fileerror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/file/fileobj/fileobj.html
+++ b/archive/docs/ja/1.8.1/cordova/file/fileobj/fileobj.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/file/filereader/filereader.html
+++ b/archive/docs/ja/1.8.1/cordova/file/filereader/filereader.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/file/filesystem/filesystem.html
+++ b/archive/docs/ja/1.8.1/cordova/file/filesystem/filesystem.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/file/filetransfer/filetransfer.html
+++ b/archive/docs/ja/1.8.1/cordova/file/filetransfer/filetransfer.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/file/filetransfererror/filetransfererror.html
+++ b/archive/docs/ja/1.8.1/cordova/file/filetransfererror/filetransfererror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/file/fileuploadoptions/fileuploadoptions.html
+++ b/archive/docs/ja/1.8.1/cordova/file/fileuploadoptions/fileuploadoptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/file/fileuploadresult/fileuploadresult.html
+++ b/archive/docs/ja/1.8.1/cordova/file/fileuploadresult/fileuploadresult.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/file/filewriter/filewriter.html
+++ b/archive/docs/ja/1.8.1/cordova/file/filewriter/filewriter.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/file/flags/flags.html
+++ b/archive/docs/ja/1.8.1/cordova/file/flags/flags.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/file/localfilesystem/localfilesystem.html
+++ b/archive/docs/ja/1.8.1/cordova/file/localfilesystem/localfilesystem.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/file/metadata/metadata.html
+++ b/archive/docs/ja/1.8.1/cordova/file/metadata/metadata.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/geolocation/Coordinates/coordinates.html
+++ b/archive/docs/ja/1.8.1/cordova/geolocation/Coordinates/coordinates.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/geolocation/Position/position.html
+++ b/archive/docs/ja/1.8.1/cordova/geolocation/Position/position.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/geolocation/PositionError/positionError.html
+++ b/archive/docs/ja/1.8.1/cordova/geolocation/PositionError/positionError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/geolocation/geolocation.clearWatch.html
+++ b/archive/docs/ja/1.8.1/cordova/geolocation/geolocation.clearWatch.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/geolocation/geolocation.getCurrentPosition.html
+++ b/archive/docs/ja/1.8.1/cordova/geolocation/geolocation.getCurrentPosition.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/geolocation/geolocation.html
+++ b/archive/docs/ja/1.8.1/cordova/geolocation/geolocation.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/geolocation/geolocation.watchPosition.html
+++ b/archive/docs/ja/1.8.1/cordova/geolocation/geolocation.watchPosition.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/geolocation/parameters/geolocation.options.html
+++ b/archive/docs/ja/1.8.1/cordova/geolocation/parameters/geolocation.options.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/geolocation/parameters/geolocationError.html
+++ b/archive/docs/ja/1.8.1/cordova/geolocation/parameters/geolocationError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/geolocation/parameters/geolocationSuccess.html
+++ b/archive/docs/ja/1.8.1/cordova/geolocation/parameters/geolocationSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/media/capture/CaptureCB.html
+++ b/archive/docs/ja/1.8.1/cordova/media/capture/CaptureCB.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/media/capture/CaptureError.html
+++ b/archive/docs/ja/1.8.1/cordova/media/capture/CaptureError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/media/capture/CaptureErrorCB.html
+++ b/archive/docs/ja/1.8.1/cordova/media/capture/CaptureErrorCB.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/media/capture/ConfigurationData.html
+++ b/archive/docs/ja/1.8.1/cordova/media/capture/ConfigurationData.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/media/capture/MediaFile.html
+++ b/archive/docs/ja/1.8.1/cordova/media/capture/MediaFile.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/media/capture/MediaFileData.html
+++ b/archive/docs/ja/1.8.1/cordova/media/capture/MediaFileData.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/media/capture/capture.html
+++ b/archive/docs/ja/1.8.1/cordova/media/capture/capture.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/media/capture/captureAudio.html
+++ b/archive/docs/ja/1.8.1/cordova/media/capture/captureAudio.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/media/capture/captureAudioOptions.html
+++ b/archive/docs/ja/1.8.1/cordova/media/capture/captureAudioOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/media/capture/captureImage.html
+++ b/archive/docs/ja/1.8.1/cordova/media/capture/captureImage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/media/capture/captureImageOptions.html
+++ b/archive/docs/ja/1.8.1/cordova/media/capture/captureImageOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/media/capture/captureVideo.html
+++ b/archive/docs/ja/1.8.1/cordova/media/capture/captureVideo.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/media/capture/captureVideoOptions.html
+++ b/archive/docs/ja/1.8.1/cordova/media/capture/captureVideoOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/media/media.getCurrentPosition.html
+++ b/archive/docs/ja/1.8.1/cordova/media/media.getCurrentPosition.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/media/media.getDuration.html
+++ b/archive/docs/ja/1.8.1/cordova/media/media.getDuration.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/media/media.html
+++ b/archive/docs/ja/1.8.1/cordova/media/media.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/media/media.pause.html
+++ b/archive/docs/ja/1.8.1/cordova/media/media.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/media/media.play.html
+++ b/archive/docs/ja/1.8.1/cordova/media/media.play.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/media/media.release.html
+++ b/archive/docs/ja/1.8.1/cordova/media/media.release.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/media/media.seekTo.html
+++ b/archive/docs/ja/1.8.1/cordova/media/media.seekTo.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/media/media.startRecord.html
+++ b/archive/docs/ja/1.8.1/cordova/media/media.startRecord.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/media/media.stop.html
+++ b/archive/docs/ja/1.8.1/cordova/media/media.stop.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/media/media.stopRecord.html
+++ b/archive/docs/ja/1.8.1/cordova/media/media.stopRecord.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/notification/notification.alert.html
+++ b/archive/docs/ja/1.8.1/cordova/notification/notification.alert.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/notification/notification.beep.html
+++ b/archive/docs/ja/1.8.1/cordova/notification/notification.beep.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/notification/notification.confirm.html
+++ b/archive/docs/ja/1.8.1/cordova/notification/notification.confirm.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/notification/notification.html
+++ b/archive/docs/ja/1.8.1/cordova/notification/notification.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/notification/notification.vibrate.html
+++ b/archive/docs/ja/1.8.1/cordova/notification/notification.vibrate.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/storage/database/database.html
+++ b/archive/docs/ja/1.8.1/cordova/storage/database/database.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/ja/1.8.1/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/storage/parameters/display_name.html
+++ b/archive/docs/ja/1.8.1/cordova/storage/parameters/display_name.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/storage/parameters/name.html
+++ b/archive/docs/ja/1.8.1/cordova/storage/parameters/name.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/storage/parameters/size.html
+++ b/archive/docs/ja/1.8.1/cordova/storage/parameters/size.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/storage/parameters/version.html
+++ b/archive/docs/ja/1.8.1/cordova/storage/parameters/version.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/storage/sqlerror/sqlerror.html
+++ b/archive/docs/ja/1.8.1/cordova/storage/sqlerror/sqlerror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/storage/sqlresultset/sqlresultset.html
+++ b/archive/docs/ja/1.8.1/cordova/storage/sqlresultset/sqlresultset.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/storage/sqlresultsetlist/sqlresultsetlist.html
+++ b/archive/docs/ja/1.8.1/cordova/storage/sqlresultsetlist/sqlresultsetlist.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/storage/sqltransaction/sqltransaction.html
+++ b/archive/docs/ja/1.8.1/cordova/storage/sqltransaction/sqltransaction.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/storage/storage.html
+++ b/archive/docs/ja/1.8.1/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/cordova/storage/storage.opendatabase.html
+++ b/archive/docs/ja/1.8.1/cordova/storage/storage.opendatabase.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/guide/getting-started/android/index.html
+++ b/archive/docs/ja/1.8.1/guide/getting-started/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/guide/getting-started/bada/index.html
+++ b/archive/docs/ja/1.8.1/guide/getting-started/bada/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/guide/getting-started/blackberry/index.html
+++ b/archive/docs/ja/1.8.1/guide/getting-started/blackberry/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/guide/getting-started/index.html
+++ b/archive/docs/ja/1.8.1/guide/getting-started/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/guide/getting-started/ios/index.html
+++ b/archive/docs/ja/1.8.1/guide/getting-started/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/guide/getting-started/symbian/index.html
+++ b/archive/docs/ja/1.8.1/guide/getting-started/symbian/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/guide/getting-started/webos/index.html
+++ b/archive/docs/ja/1.8.1/guide/getting-started/webos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/guide/getting-started/windows-phone/index.html
+++ b/archive/docs/ja/1.8.1/guide/getting-started/windows-phone/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/guide/upgrading/android/index.html
+++ b/archive/docs/ja/1.8.1/guide/upgrading/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/guide/upgrading/bada/index.html
+++ b/archive/docs/ja/1.8.1/guide/upgrading/bada/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/guide/upgrading/blackberry/index.html
+++ b/archive/docs/ja/1.8.1/guide/upgrading/blackberry/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/guide/upgrading/index.html
+++ b/archive/docs/ja/1.8.1/guide/upgrading/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/guide/upgrading/ios/index.html
+++ b/archive/docs/ja/1.8.1/guide/upgrading/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/guide/upgrading/symbian/index.html
+++ b/archive/docs/ja/1.8.1/guide/upgrading/symbian/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/guide/upgrading/webos/index.html
+++ b/archive/docs/ja/1.8.1/guide/upgrading/webos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/guide/upgrading/windows-phone/index.html
+++ b/archive/docs/ja/1.8.1/guide/upgrading/windows-phone/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/guide/whitelist/index.html
+++ b/archive/docs/ja/1.8.1/guide/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.8.1/index.html
+++ b/archive/docs/ja/1.8.1/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/accelerometer/acceleration/acceleration.html
+++ b/archive/docs/ja/1.9.0/cordova/accelerometer/acceleration/acceleration.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/accelerometer/accelerometer.clearWatch.html
+++ b/archive/docs/ja/1.9.0/cordova/accelerometer/accelerometer.clearWatch.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/accelerometer/accelerometer.getCurrentAcceleration.html
+++ b/archive/docs/ja/1.9.0/cordova/accelerometer/accelerometer.getCurrentAcceleration.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/accelerometer/accelerometer.html
+++ b/archive/docs/ja/1.9.0/cordova/accelerometer/accelerometer.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/accelerometer/accelerometer.watchAcceleration.html
+++ b/archive/docs/ja/1.9.0/cordova/accelerometer/accelerometer.watchAcceleration.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/accelerometer/parameters/accelerometerError.html
+++ b/archive/docs/ja/1.9.0/cordova/accelerometer/parameters/accelerometerError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/accelerometer/parameters/accelerometerOptions.html
+++ b/archive/docs/ja/1.9.0/cordova/accelerometer/parameters/accelerometerOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/accelerometer/parameters/accelerometerSuccess.html
+++ b/archive/docs/ja/1.9.0/cordova/accelerometer/parameters/accelerometerSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/camera/camera.cleanup.html
+++ b/archive/docs/ja/1.9.0/cordova/camera/camera.cleanup.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/camera/camera.getPicture.html
+++ b/archive/docs/ja/1.9.0/cordova/camera/camera.getPicture.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/camera/camera.html
+++ b/archive/docs/ja/1.9.0/cordova/camera/camera.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/compass/compass.clearWatch.html
+++ b/archive/docs/ja/1.9.0/cordova/compass/compass.clearWatch.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/compass/compass.clearWatchFilter.html
+++ b/archive/docs/ja/1.9.0/cordova/compass/compass.clearWatchFilter.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/compass/compass.getCurrentHeading.html
+++ b/archive/docs/ja/1.9.0/cordova/compass/compass.getCurrentHeading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/compass/compass.html
+++ b/archive/docs/ja/1.9.0/cordova/compass/compass.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/compass/compass.watchHeading.html
+++ b/archive/docs/ja/1.9.0/cordova/compass/compass.watchHeading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/compass/compass.watchHeadingFilter.html
+++ b/archive/docs/ja/1.9.0/cordova/compass/compass.watchHeadingFilter.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/compass/parameters/compassError.html
+++ b/archive/docs/ja/1.9.0/cordova/compass/parameters/compassError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/compass/parameters/compassHeading.html
+++ b/archive/docs/ja/1.9.0/cordova/compass/parameters/compassHeading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/compass/parameters/compassOptions.html
+++ b/archive/docs/ja/1.9.0/cordova/compass/parameters/compassOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/compass/parameters/compassSuccess.html
+++ b/archive/docs/ja/1.9.0/cordova/compass/parameters/compassSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/connection/connection.html
+++ b/archive/docs/ja/1.9.0/cordova/connection/connection.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/connection/connection.type.html
+++ b/archive/docs/ja/1.9.0/cordova/connection/connection.type.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/contacts/Contact/contact.html
+++ b/archive/docs/ja/1.9.0/cordova/contacts/Contact/contact.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/contacts/ContactAddress/contactaddress.html
+++ b/archive/docs/ja/1.9.0/cordova/contacts/ContactAddress/contactaddress.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/contacts/ContactError/contactError.html
+++ b/archive/docs/ja/1.9.0/cordova/contacts/ContactError/contactError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/contacts/ContactField/contactfield.html
+++ b/archive/docs/ja/1.9.0/cordova/contacts/ContactField/contactfield.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/contacts/ContactFindOptions/contactfindoptions.html
+++ b/archive/docs/ja/1.9.0/cordova/contacts/ContactFindOptions/contactfindoptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/contacts/ContactName/contactname.html
+++ b/archive/docs/ja/1.9.0/cordova/contacts/ContactName/contactname.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/contacts/ContactOrganization/contactorganization.html
+++ b/archive/docs/ja/1.9.0/cordova/contacts/ContactOrganization/contactorganization.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/contacts/contacts.create.html
+++ b/archive/docs/ja/1.9.0/cordova/contacts/contacts.create.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/contacts/contacts.find.html
+++ b/archive/docs/ja/1.9.0/cordova/contacts/contacts.find.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/contacts/contacts.html
+++ b/archive/docs/ja/1.9.0/cordova/contacts/contacts.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/contacts/parameters/contactError.html
+++ b/archive/docs/ja/1.9.0/cordova/contacts/parameters/contactError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/contacts/parameters/contactFields.html
+++ b/archive/docs/ja/1.9.0/cordova/contacts/parameters/contactFields.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/contacts/parameters/contactFindOptions.html
+++ b/archive/docs/ja/1.9.0/cordova/contacts/parameters/contactFindOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/contacts/parameters/contactSuccess.html
+++ b/archive/docs/ja/1.9.0/cordova/contacts/parameters/contactSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/device/device.cordova.html
+++ b/archive/docs/ja/1.9.0/cordova/device/device.cordova.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/device/device.html
+++ b/archive/docs/ja/1.9.0/cordova/device/device.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/device/device.name.html
+++ b/archive/docs/ja/1.9.0/cordova/device/device.name.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/device/device.platform.html
+++ b/archive/docs/ja/1.9.0/cordova/device/device.platform.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/device/device.uuid.html
+++ b/archive/docs/ja/1.9.0/cordova/device/device.uuid.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/device/device.version.html
+++ b/archive/docs/ja/1.9.0/cordova/device/device.version.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/events/events.backbutton.html
+++ b/archive/docs/ja/1.9.0/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/events/events.batterycritical.html
+++ b/archive/docs/ja/1.9.0/cordova/events/events.batterycritical.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/events/events.batterylow.html
+++ b/archive/docs/ja/1.9.0/cordova/events/events.batterylow.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/events/events.batterystatus.html
+++ b/archive/docs/ja/1.9.0/cordova/events/events.batterystatus.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/events/events.deviceready.html
+++ b/archive/docs/ja/1.9.0/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/events/events.endcallbutton.html
+++ b/archive/docs/ja/1.9.0/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/events/events.html
+++ b/archive/docs/ja/1.9.0/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/events/events.menubutton.html
+++ b/archive/docs/ja/1.9.0/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/events/events.offline.html
+++ b/archive/docs/ja/1.9.0/cordova/events/events.offline.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/events/events.online.html
+++ b/archive/docs/ja/1.9.0/cordova/events/events.online.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/events/events.pause.html
+++ b/archive/docs/ja/1.9.0/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/events/events.resume.html
+++ b/archive/docs/ja/1.9.0/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/events/events.searchbutton.html
+++ b/archive/docs/ja/1.9.0/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/events/events.startcallbutton.html
+++ b/archive/docs/ja/1.9.0/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/ja/1.9.0/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/ja/1.9.0/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/file/directoryentry/directoryentry.html
+++ b/archive/docs/ja/1.9.0/cordova/file/directoryentry/directoryentry.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/file/directoryreader/directoryreader.html
+++ b/archive/docs/ja/1.9.0/cordova/file/directoryreader/directoryreader.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/file/file.html
+++ b/archive/docs/ja/1.9.0/cordova/file/file.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/file/fileentry/fileentry.html
+++ b/archive/docs/ja/1.9.0/cordova/file/fileentry/fileentry.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/file/fileerror/fileerror.html
+++ b/archive/docs/ja/1.9.0/cordova/file/fileerror/fileerror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/file/fileobj/fileobj.html
+++ b/archive/docs/ja/1.9.0/cordova/file/fileobj/fileobj.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/file/filereader/filereader.html
+++ b/archive/docs/ja/1.9.0/cordova/file/filereader/filereader.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/file/filesystem/filesystem.html
+++ b/archive/docs/ja/1.9.0/cordova/file/filesystem/filesystem.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/file/filetransfer/filetransfer.html
+++ b/archive/docs/ja/1.9.0/cordova/file/filetransfer/filetransfer.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/file/filetransfererror/filetransfererror.html
+++ b/archive/docs/ja/1.9.0/cordova/file/filetransfererror/filetransfererror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/file/fileuploadoptions/fileuploadoptions.html
+++ b/archive/docs/ja/1.9.0/cordova/file/fileuploadoptions/fileuploadoptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/file/fileuploadresult/fileuploadresult.html
+++ b/archive/docs/ja/1.9.0/cordova/file/fileuploadresult/fileuploadresult.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/file/filewriter/filewriter.html
+++ b/archive/docs/ja/1.9.0/cordova/file/filewriter/filewriter.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/file/flags/flags.html
+++ b/archive/docs/ja/1.9.0/cordova/file/flags/flags.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/file/localfilesystem/localfilesystem.html
+++ b/archive/docs/ja/1.9.0/cordova/file/localfilesystem/localfilesystem.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/file/metadata/metadata.html
+++ b/archive/docs/ja/1.9.0/cordova/file/metadata/metadata.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/geolocation/Coordinates/coordinates.html
+++ b/archive/docs/ja/1.9.0/cordova/geolocation/Coordinates/coordinates.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/geolocation/Position/position.html
+++ b/archive/docs/ja/1.9.0/cordova/geolocation/Position/position.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/geolocation/PositionError/positionError.html
+++ b/archive/docs/ja/1.9.0/cordova/geolocation/PositionError/positionError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/geolocation/geolocation.clearWatch.html
+++ b/archive/docs/ja/1.9.0/cordova/geolocation/geolocation.clearWatch.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/geolocation/geolocation.getCurrentPosition.html
+++ b/archive/docs/ja/1.9.0/cordova/geolocation/geolocation.getCurrentPosition.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/geolocation/geolocation.html
+++ b/archive/docs/ja/1.9.0/cordova/geolocation/geolocation.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/geolocation/geolocation.watchPosition.html
+++ b/archive/docs/ja/1.9.0/cordova/geolocation/geolocation.watchPosition.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/geolocation/parameters/geolocation.options.html
+++ b/archive/docs/ja/1.9.0/cordova/geolocation/parameters/geolocation.options.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/geolocation/parameters/geolocationError.html
+++ b/archive/docs/ja/1.9.0/cordova/geolocation/parameters/geolocationError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/geolocation/parameters/geolocationSuccess.html
+++ b/archive/docs/ja/1.9.0/cordova/geolocation/parameters/geolocationSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/media/capture/CaptureCB.html
+++ b/archive/docs/ja/1.9.0/cordova/media/capture/CaptureCB.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/media/capture/CaptureError.html
+++ b/archive/docs/ja/1.9.0/cordova/media/capture/CaptureError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/media/capture/CaptureErrorCB.html
+++ b/archive/docs/ja/1.9.0/cordova/media/capture/CaptureErrorCB.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/media/capture/ConfigurationData.html
+++ b/archive/docs/ja/1.9.0/cordova/media/capture/ConfigurationData.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/media/capture/MediaFile.html
+++ b/archive/docs/ja/1.9.0/cordova/media/capture/MediaFile.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/media/capture/MediaFileData.html
+++ b/archive/docs/ja/1.9.0/cordova/media/capture/MediaFileData.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/media/capture/capture.html
+++ b/archive/docs/ja/1.9.0/cordova/media/capture/capture.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/media/capture/captureAudio.html
+++ b/archive/docs/ja/1.9.0/cordova/media/capture/captureAudio.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/media/capture/captureAudioOptions.html
+++ b/archive/docs/ja/1.9.0/cordova/media/capture/captureAudioOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/media/capture/captureImage.html
+++ b/archive/docs/ja/1.9.0/cordova/media/capture/captureImage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/media/capture/captureImageOptions.html
+++ b/archive/docs/ja/1.9.0/cordova/media/capture/captureImageOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/media/capture/captureVideo.html
+++ b/archive/docs/ja/1.9.0/cordova/media/capture/captureVideo.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/media/capture/captureVideoOptions.html
+++ b/archive/docs/ja/1.9.0/cordova/media/capture/captureVideoOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/media/media.getCurrentPosition.html
+++ b/archive/docs/ja/1.9.0/cordova/media/media.getCurrentPosition.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/media/media.getDuration.html
+++ b/archive/docs/ja/1.9.0/cordova/media/media.getDuration.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/media/media.html
+++ b/archive/docs/ja/1.9.0/cordova/media/media.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/media/media.pause.html
+++ b/archive/docs/ja/1.9.0/cordova/media/media.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/media/media.play.html
+++ b/archive/docs/ja/1.9.0/cordova/media/media.play.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/media/media.release.html
+++ b/archive/docs/ja/1.9.0/cordova/media/media.release.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/media/media.seekTo.html
+++ b/archive/docs/ja/1.9.0/cordova/media/media.seekTo.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/media/media.startRecord.html
+++ b/archive/docs/ja/1.9.0/cordova/media/media.startRecord.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/media/media.stop.html
+++ b/archive/docs/ja/1.9.0/cordova/media/media.stop.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/media/media.stopRecord.html
+++ b/archive/docs/ja/1.9.0/cordova/media/media.stopRecord.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/notification/notification.alert.html
+++ b/archive/docs/ja/1.9.0/cordova/notification/notification.alert.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/notification/notification.beep.html
+++ b/archive/docs/ja/1.9.0/cordova/notification/notification.beep.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/notification/notification.confirm.html
+++ b/archive/docs/ja/1.9.0/cordova/notification/notification.confirm.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/notification/notification.html
+++ b/archive/docs/ja/1.9.0/cordova/notification/notification.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/notification/notification.vibrate.html
+++ b/archive/docs/ja/1.9.0/cordova/notification/notification.vibrate.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/storage/database/database.html
+++ b/archive/docs/ja/1.9.0/cordova/storage/database/database.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/ja/1.9.0/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/storage/parameters/display_name.html
+++ b/archive/docs/ja/1.9.0/cordova/storage/parameters/display_name.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/storage/parameters/name.html
+++ b/archive/docs/ja/1.9.0/cordova/storage/parameters/name.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/storage/parameters/size.html
+++ b/archive/docs/ja/1.9.0/cordova/storage/parameters/size.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/storage/parameters/version.html
+++ b/archive/docs/ja/1.9.0/cordova/storage/parameters/version.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/storage/sqlerror/sqlerror.html
+++ b/archive/docs/ja/1.9.0/cordova/storage/sqlerror/sqlerror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/storage/sqlresultset/sqlresultset.html
+++ b/archive/docs/ja/1.9.0/cordova/storage/sqlresultset/sqlresultset.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/storage/sqlresultsetlist/sqlresultsetlist.html
+++ b/archive/docs/ja/1.9.0/cordova/storage/sqlresultsetlist/sqlresultsetlist.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/storage/sqltransaction/sqltransaction.html
+++ b/archive/docs/ja/1.9.0/cordova/storage/sqltransaction/sqltransaction.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/storage/storage.html
+++ b/archive/docs/ja/1.9.0/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/cordova/storage/storage.opendatabase.html
+++ b/archive/docs/ja/1.9.0/cordova/storage/storage.opendatabase.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/guide/command-line/index.html
+++ b/archive/docs/ja/1.9.0/guide/command-line/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/guide/cordova-webview/android.html
+++ b/archive/docs/ja/1.9.0/guide/cordova-webview/android.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/guide/cordova-webview/index.html
+++ b/archive/docs/ja/1.9.0/guide/cordova-webview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/guide/cordova-webview/ios.html
+++ b/archive/docs/ja/1.9.0/guide/cordova-webview/ios.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/guide/getting-started/android/index.html
+++ b/archive/docs/ja/1.9.0/guide/getting-started/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/guide/getting-started/bada/index.html
+++ b/archive/docs/ja/1.9.0/guide/getting-started/bada/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/guide/getting-started/blackberry/index.html
+++ b/archive/docs/ja/1.9.0/guide/getting-started/blackberry/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/guide/getting-started/index.html
+++ b/archive/docs/ja/1.9.0/guide/getting-started/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/guide/getting-started/ios/index.html
+++ b/archive/docs/ja/1.9.0/guide/getting-started/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/guide/getting-started/symbian/index.html
+++ b/archive/docs/ja/1.9.0/guide/getting-started/symbian/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/guide/getting-started/webos/index.html
+++ b/archive/docs/ja/1.9.0/guide/getting-started/webos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/guide/getting-started/windows-phone/index.html
+++ b/archive/docs/ja/1.9.0/guide/getting-started/windows-phone/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/guide/upgrading/android/index.html
+++ b/archive/docs/ja/1.9.0/guide/upgrading/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/guide/upgrading/bada/index.html
+++ b/archive/docs/ja/1.9.0/guide/upgrading/bada/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/guide/upgrading/blackberry/index.html
+++ b/archive/docs/ja/1.9.0/guide/upgrading/blackberry/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/guide/upgrading/index.html
+++ b/archive/docs/ja/1.9.0/guide/upgrading/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/guide/upgrading/ios/index.html
+++ b/archive/docs/ja/1.9.0/guide/upgrading/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/guide/upgrading/symbian/index.html
+++ b/archive/docs/ja/1.9.0/guide/upgrading/symbian/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/guide/upgrading/webos/index.html
+++ b/archive/docs/ja/1.9.0/guide/upgrading/webos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/guide/upgrading/windows-phone/index.html
+++ b/archive/docs/ja/1.9.0/guide/upgrading/windows-phone/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/guide/whitelist/index.html
+++ b/archive/docs/ja/1.9.0/guide/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/1.9.0/index.html
+++ b/archive/docs/ja/1.9.0/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/10.x/config_ref/images.html
+++ b/archive/docs/ja/10.x/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/10.x/config_ref/index.html
+++ b/archive/docs/ja/10.x/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/10.x/cordova/events/events.backbutton.html
+++ b/archive/docs/ja/10.x/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/10.x/cordova/events/events.deviceready.html
+++ b/archive/docs/ja/10.x/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/10.x/cordova/events/events.endcallbutton.html
+++ b/archive/docs/ja/10.x/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/10.x/cordova/events/events.html
+++ b/archive/docs/ja/10.x/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/10.x/cordova/events/events.menubutton.html
+++ b/archive/docs/ja/10.x/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/10.x/cordova/events/events.pause.html
+++ b/archive/docs/ja/10.x/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/10.x/cordova/events/events.resume.html
+++ b/archive/docs/ja/10.x/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/10.x/cordova/events/events.searchbutton.html
+++ b/archive/docs/ja/10.x/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/10.x/cordova/events/events.startcallbutton.html
+++ b/archive/docs/ja/10.x/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/10.x/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/ja/10.x/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/10.x/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/ja/10.x/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/10.x/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/ja/10.x/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/10.x/cordova/storage/storage.html
+++ b/archive/docs/ja/10.x/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/10.x/guide/appdev/hooks/index.html
+++ b/archive/docs/ja/10.x/guide/appdev/hooks/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/10.x/guide/appdev/privacy/index.html
+++ b/archive/docs/ja/10.x/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/10.x/guide/appdev/security/index.html
+++ b/archive/docs/ja/10.x/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/10.x/guide/appdev/whitelist/index.html
+++ b/archive/docs/ja/10.x/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/10.x/guide/cli/index.html
+++ b/archive/docs/ja/10.x/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/10.x/guide/hybrid/plugins/index.html
+++ b/archive/docs/ja/10.x/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/10.x/guide/hybrid/webviews/index.html
+++ b/archive/docs/ja/10.x/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/10.x/guide/next/index.html
+++ b/archive/docs/ja/10.x/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/10.x/guide/overview/index.html
+++ b/archive/docs/ja/10.x/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/10.x/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/ja/10.x/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/10.x/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/ja/10.x/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/10.x/guide/platforms/android/config.html
+++ b/archive/docs/ja/10.x/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/10.x/guide/platforms/android/index.html
+++ b/archive/docs/ja/10.x/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/10.x/guide/platforms/android/plugin.html
+++ b/archive/docs/ja/10.x/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/10.x/guide/platforms/android/webview.html
+++ b/archive/docs/ja/10.x/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/10.x/guide/platforms/blackberry10/config.html
+++ b/archive/docs/ja/10.x/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/10.x/guide/platforms/blackberry10/home.html
+++ b/archive/docs/ja/10.x/guide/platforms/blackberry10/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/10.x/guide/platforms/blackberry10/index.html
+++ b/archive/docs/ja/10.x/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/10.x/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/ja/10.x/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/10.x/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/ja/10.x/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/10.x/guide/platforms/blackberry10/upgrade.html
+++ b/archive/docs/ja/10.x/guide/platforms/blackberry10/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/10.x/guide/platforms/ios/config.html
+++ b/archive/docs/ja/10.x/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/10.x/guide/platforms/ios/index.html
+++ b/archive/docs/ja/10.x/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/10.x/guide/platforms/ios/plugin.html
+++ b/archive/docs/ja/10.x/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/10.x/guide/platforms/ios/upgrading.html
+++ b/archive/docs/ja/10.x/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/10.x/guide/platforms/ios/webview.html
+++ b/archive/docs/ja/10.x/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/10.x/guide/platforms/ubuntu/index.html
+++ b/archive/docs/ja/10.x/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/10.x/guide/platforms/win8/index.html
+++ b/archive/docs/ja/10.x/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/10.x/guide/platforms/win8/plugin.html
+++ b/archive/docs/ja/10.x/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/10.x/guide/platforms/win8/win10-support.html
+++ b/archive/docs/ja/10.x/guide/platforms/win8/win10-support.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/10.x/guide/platforms/wp8/home.html
+++ b/archive/docs/ja/10.x/guide/platforms/wp8/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/10.x/guide/platforms/wp8/index.html
+++ b/archive/docs/ja/10.x/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/10.x/guide/platforms/wp8/plugin.html
+++ b/archive/docs/ja/10.x/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/10.x/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/ja/10.x/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/10.x/guide/platforms/wp8/webview.html
+++ b/archive/docs/ja/10.x/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/10.x/guide/support/index.html
+++ b/archive/docs/ja/10.x/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/10.x/index.html
+++ b/archive/docs/ja/10.x/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/10.x/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/ja/10.x/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/10.x/plugin_ref/plugman.html
+++ b/archive/docs/ja/10.x/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/10.x/plugin_ref/spec.html
+++ b/archive/docs/ja/10.x/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/accelerometer/acceleration/acceleration.html
+++ b/archive/docs/ja/2.0.0/cordova/accelerometer/acceleration/acceleration.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/accelerometer/accelerometer.clearWatch.html
+++ b/archive/docs/ja/2.0.0/cordova/accelerometer/accelerometer.clearWatch.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/accelerometer/accelerometer.getCurrentAcceleration.html
+++ b/archive/docs/ja/2.0.0/cordova/accelerometer/accelerometer.getCurrentAcceleration.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/accelerometer/accelerometer.html
+++ b/archive/docs/ja/2.0.0/cordova/accelerometer/accelerometer.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/accelerometer/accelerometer.watchAcceleration.html
+++ b/archive/docs/ja/2.0.0/cordova/accelerometer/accelerometer.watchAcceleration.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/accelerometer/parameters/accelerometerError.html
+++ b/archive/docs/ja/2.0.0/cordova/accelerometer/parameters/accelerometerError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/accelerometer/parameters/accelerometerOptions.html
+++ b/archive/docs/ja/2.0.0/cordova/accelerometer/parameters/accelerometerOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/accelerometer/parameters/accelerometerSuccess.html
+++ b/archive/docs/ja/2.0.0/cordova/accelerometer/parameters/accelerometerSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/camera/camera.cleanup.html
+++ b/archive/docs/ja/2.0.0/cordova/camera/camera.cleanup.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/camera/camera.getPicture.html
+++ b/archive/docs/ja/2.0.0/cordova/camera/camera.getPicture.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/camera/camera.html
+++ b/archive/docs/ja/2.0.0/cordova/camera/camera.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/compass/compass.clearWatch.html
+++ b/archive/docs/ja/2.0.0/cordova/compass/compass.clearWatch.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/compass/compass.clearWatchFilter.html
+++ b/archive/docs/ja/2.0.0/cordova/compass/compass.clearWatchFilter.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/compass/compass.getCurrentHeading.html
+++ b/archive/docs/ja/2.0.0/cordova/compass/compass.getCurrentHeading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/compass/compass.html
+++ b/archive/docs/ja/2.0.0/cordova/compass/compass.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/compass/compass.watchHeading.html
+++ b/archive/docs/ja/2.0.0/cordova/compass/compass.watchHeading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/compass/compass.watchHeadingFilter.html
+++ b/archive/docs/ja/2.0.0/cordova/compass/compass.watchHeadingFilter.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/compass/parameters/compassError.html
+++ b/archive/docs/ja/2.0.0/cordova/compass/parameters/compassError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/compass/parameters/compassHeading.html
+++ b/archive/docs/ja/2.0.0/cordova/compass/parameters/compassHeading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/compass/parameters/compassOptions.html
+++ b/archive/docs/ja/2.0.0/cordova/compass/parameters/compassOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/compass/parameters/compassSuccess.html
+++ b/archive/docs/ja/2.0.0/cordova/compass/parameters/compassSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/connection/connection.html
+++ b/archive/docs/ja/2.0.0/cordova/connection/connection.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/connection/connection.type.html
+++ b/archive/docs/ja/2.0.0/cordova/connection/connection.type.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/contacts/Contact/contact.html
+++ b/archive/docs/ja/2.0.0/cordova/contacts/Contact/contact.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/contacts/ContactAddress/contactaddress.html
+++ b/archive/docs/ja/2.0.0/cordova/contacts/ContactAddress/contactaddress.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/contacts/ContactError/contactError.html
+++ b/archive/docs/ja/2.0.0/cordova/contacts/ContactError/contactError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/contacts/ContactField/contactfield.html
+++ b/archive/docs/ja/2.0.0/cordova/contacts/ContactField/contactfield.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/contacts/ContactFindOptions/contactfindoptions.html
+++ b/archive/docs/ja/2.0.0/cordova/contacts/ContactFindOptions/contactfindoptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/contacts/ContactName/contactname.html
+++ b/archive/docs/ja/2.0.0/cordova/contacts/ContactName/contactname.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/contacts/ContactOrganization/contactorganization.html
+++ b/archive/docs/ja/2.0.0/cordova/contacts/ContactOrganization/contactorganization.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/contacts/contacts.create.html
+++ b/archive/docs/ja/2.0.0/cordova/contacts/contacts.create.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/contacts/contacts.find.html
+++ b/archive/docs/ja/2.0.0/cordova/contacts/contacts.find.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/contacts/contacts.html
+++ b/archive/docs/ja/2.0.0/cordova/contacts/contacts.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/contacts/parameters/contactError.html
+++ b/archive/docs/ja/2.0.0/cordova/contacts/parameters/contactError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/contacts/parameters/contactFields.html
+++ b/archive/docs/ja/2.0.0/cordova/contacts/parameters/contactFields.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/contacts/parameters/contactFindOptions.html
+++ b/archive/docs/ja/2.0.0/cordova/contacts/parameters/contactFindOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/contacts/parameters/contactSuccess.html
+++ b/archive/docs/ja/2.0.0/cordova/contacts/parameters/contactSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/device/device.cordova.html
+++ b/archive/docs/ja/2.0.0/cordova/device/device.cordova.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/device/device.html
+++ b/archive/docs/ja/2.0.0/cordova/device/device.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/device/device.name.html
+++ b/archive/docs/ja/2.0.0/cordova/device/device.name.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/device/device.platform.html
+++ b/archive/docs/ja/2.0.0/cordova/device/device.platform.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/device/device.uuid.html
+++ b/archive/docs/ja/2.0.0/cordova/device/device.uuid.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/device/device.version.html
+++ b/archive/docs/ja/2.0.0/cordova/device/device.version.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/events/events.backbutton.html
+++ b/archive/docs/ja/2.0.0/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/events/events.batterycritical.html
+++ b/archive/docs/ja/2.0.0/cordova/events/events.batterycritical.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/events/events.batterylow.html
+++ b/archive/docs/ja/2.0.0/cordova/events/events.batterylow.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/events/events.batterystatus.html
+++ b/archive/docs/ja/2.0.0/cordova/events/events.batterystatus.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/events/events.deviceready.html
+++ b/archive/docs/ja/2.0.0/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/events/events.endcallbutton.html
+++ b/archive/docs/ja/2.0.0/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/events/events.html
+++ b/archive/docs/ja/2.0.0/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/events/events.menubutton.html
+++ b/archive/docs/ja/2.0.0/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/events/events.offline.html
+++ b/archive/docs/ja/2.0.0/cordova/events/events.offline.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/events/events.online.html
+++ b/archive/docs/ja/2.0.0/cordova/events/events.online.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/events/events.pause.html
+++ b/archive/docs/ja/2.0.0/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/events/events.resume.html
+++ b/archive/docs/ja/2.0.0/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/events/events.searchbutton.html
+++ b/archive/docs/ja/2.0.0/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/events/events.startcallbutton.html
+++ b/archive/docs/ja/2.0.0/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/ja/2.0.0/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/ja/2.0.0/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/file/directoryentry/directoryentry.html
+++ b/archive/docs/ja/2.0.0/cordova/file/directoryentry/directoryentry.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/file/directoryreader/directoryreader.html
+++ b/archive/docs/ja/2.0.0/cordova/file/directoryreader/directoryreader.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/file/file.html
+++ b/archive/docs/ja/2.0.0/cordova/file/file.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/file/fileentry/fileentry.html
+++ b/archive/docs/ja/2.0.0/cordova/file/fileentry/fileentry.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/file/fileerror/fileerror.html
+++ b/archive/docs/ja/2.0.0/cordova/file/fileerror/fileerror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/file/fileobj/fileobj.html
+++ b/archive/docs/ja/2.0.0/cordova/file/fileobj/fileobj.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/file/filereader/filereader.html
+++ b/archive/docs/ja/2.0.0/cordova/file/filereader/filereader.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/file/filesystem/filesystem.html
+++ b/archive/docs/ja/2.0.0/cordova/file/filesystem/filesystem.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/file/filetransfer/filetransfer.html
+++ b/archive/docs/ja/2.0.0/cordova/file/filetransfer/filetransfer.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/file/filetransfererror/filetransfererror.html
+++ b/archive/docs/ja/2.0.0/cordova/file/filetransfererror/filetransfererror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/file/fileuploadoptions/fileuploadoptions.html
+++ b/archive/docs/ja/2.0.0/cordova/file/fileuploadoptions/fileuploadoptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/file/fileuploadresult/fileuploadresult.html
+++ b/archive/docs/ja/2.0.0/cordova/file/fileuploadresult/fileuploadresult.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/file/filewriter/filewriter.html
+++ b/archive/docs/ja/2.0.0/cordova/file/filewriter/filewriter.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/file/flags/flags.html
+++ b/archive/docs/ja/2.0.0/cordova/file/flags/flags.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/file/localfilesystem/localfilesystem.html
+++ b/archive/docs/ja/2.0.0/cordova/file/localfilesystem/localfilesystem.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/file/metadata/metadata.html
+++ b/archive/docs/ja/2.0.0/cordova/file/metadata/metadata.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/geolocation/Coordinates/coordinates.html
+++ b/archive/docs/ja/2.0.0/cordova/geolocation/Coordinates/coordinates.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/geolocation/Position/position.html
+++ b/archive/docs/ja/2.0.0/cordova/geolocation/Position/position.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/geolocation/PositionError/positionError.html
+++ b/archive/docs/ja/2.0.0/cordova/geolocation/PositionError/positionError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/geolocation/geolocation.clearWatch.html
+++ b/archive/docs/ja/2.0.0/cordova/geolocation/geolocation.clearWatch.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/geolocation/geolocation.getCurrentPosition.html
+++ b/archive/docs/ja/2.0.0/cordova/geolocation/geolocation.getCurrentPosition.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/geolocation/geolocation.html
+++ b/archive/docs/ja/2.0.0/cordova/geolocation/geolocation.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/geolocation/geolocation.watchPosition.html
+++ b/archive/docs/ja/2.0.0/cordova/geolocation/geolocation.watchPosition.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/geolocation/parameters/geolocation.options.html
+++ b/archive/docs/ja/2.0.0/cordova/geolocation/parameters/geolocation.options.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/geolocation/parameters/geolocationError.html
+++ b/archive/docs/ja/2.0.0/cordova/geolocation/parameters/geolocationError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/geolocation/parameters/geolocationSuccess.html
+++ b/archive/docs/ja/2.0.0/cordova/geolocation/parameters/geolocationSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/media/capture/CaptureCB.html
+++ b/archive/docs/ja/2.0.0/cordova/media/capture/CaptureCB.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/media/capture/CaptureError.html
+++ b/archive/docs/ja/2.0.0/cordova/media/capture/CaptureError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/media/capture/CaptureErrorCB.html
+++ b/archive/docs/ja/2.0.0/cordova/media/capture/CaptureErrorCB.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/media/capture/ConfigurationData.html
+++ b/archive/docs/ja/2.0.0/cordova/media/capture/ConfigurationData.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/media/capture/MediaFile.html
+++ b/archive/docs/ja/2.0.0/cordova/media/capture/MediaFile.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/media/capture/MediaFileData.html
+++ b/archive/docs/ja/2.0.0/cordova/media/capture/MediaFileData.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/media/capture/capture.html
+++ b/archive/docs/ja/2.0.0/cordova/media/capture/capture.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/media/capture/captureAudio.html
+++ b/archive/docs/ja/2.0.0/cordova/media/capture/captureAudio.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/media/capture/captureAudioOptions.html
+++ b/archive/docs/ja/2.0.0/cordova/media/capture/captureAudioOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/media/capture/captureImage.html
+++ b/archive/docs/ja/2.0.0/cordova/media/capture/captureImage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/media/capture/captureImageOptions.html
+++ b/archive/docs/ja/2.0.0/cordova/media/capture/captureImageOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/media/capture/captureVideo.html
+++ b/archive/docs/ja/2.0.0/cordova/media/capture/captureVideo.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/media/capture/captureVideoOptions.html
+++ b/archive/docs/ja/2.0.0/cordova/media/capture/captureVideoOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/media/media.getCurrentPosition.html
+++ b/archive/docs/ja/2.0.0/cordova/media/media.getCurrentPosition.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/media/media.getDuration.html
+++ b/archive/docs/ja/2.0.0/cordova/media/media.getDuration.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/media/media.html
+++ b/archive/docs/ja/2.0.0/cordova/media/media.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/media/media.pause.html
+++ b/archive/docs/ja/2.0.0/cordova/media/media.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/media/media.play.html
+++ b/archive/docs/ja/2.0.0/cordova/media/media.play.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/media/media.release.html
+++ b/archive/docs/ja/2.0.0/cordova/media/media.release.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/media/media.seekTo.html
+++ b/archive/docs/ja/2.0.0/cordova/media/media.seekTo.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/media/media.startRecord.html
+++ b/archive/docs/ja/2.0.0/cordova/media/media.startRecord.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/media/media.stop.html
+++ b/archive/docs/ja/2.0.0/cordova/media/media.stop.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/media/media.stopRecord.html
+++ b/archive/docs/ja/2.0.0/cordova/media/media.stopRecord.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/notification/notification.alert.html
+++ b/archive/docs/ja/2.0.0/cordova/notification/notification.alert.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/notification/notification.beep.html
+++ b/archive/docs/ja/2.0.0/cordova/notification/notification.beep.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/notification/notification.confirm.html
+++ b/archive/docs/ja/2.0.0/cordova/notification/notification.confirm.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/notification/notification.html
+++ b/archive/docs/ja/2.0.0/cordova/notification/notification.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/notification/notification.vibrate.html
+++ b/archive/docs/ja/2.0.0/cordova/notification/notification.vibrate.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/storage/database/database.html
+++ b/archive/docs/ja/2.0.0/cordova/storage/database/database.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/ja/2.0.0/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/storage/parameters/display_name.html
+++ b/archive/docs/ja/2.0.0/cordova/storage/parameters/display_name.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/storage/parameters/name.html
+++ b/archive/docs/ja/2.0.0/cordova/storage/parameters/name.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/storage/parameters/size.html
+++ b/archive/docs/ja/2.0.0/cordova/storage/parameters/size.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/storage/parameters/version.html
+++ b/archive/docs/ja/2.0.0/cordova/storage/parameters/version.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/storage/sqlerror/sqlerror.html
+++ b/archive/docs/ja/2.0.0/cordova/storage/sqlerror/sqlerror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/storage/sqlresultset/sqlresultset.html
+++ b/archive/docs/ja/2.0.0/cordova/storage/sqlresultset/sqlresultset.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/storage/sqlresultsetlist/sqlresultsetlist.html
+++ b/archive/docs/ja/2.0.0/cordova/storage/sqlresultsetlist/sqlresultsetlist.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/storage/sqltransaction/sqltransaction.html
+++ b/archive/docs/ja/2.0.0/cordova/storage/sqltransaction/sqltransaction.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/storage/storage.html
+++ b/archive/docs/ja/2.0.0/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/cordova/storage/storage.opendatabase.html
+++ b/archive/docs/ja/2.0.0/cordova/storage/storage.opendatabase.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/guide/command-line/index.html
+++ b/archive/docs/ja/2.0.0/guide/command-line/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/guide/cordova-webview/android.html
+++ b/archive/docs/ja/2.0.0/guide/cordova-webview/android.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/guide/cordova-webview/index.html
+++ b/archive/docs/ja/2.0.0/guide/cordova-webview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/guide/cordova-webview/ios.html
+++ b/archive/docs/ja/2.0.0/guide/cordova-webview/ios.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/guide/getting-started/android/index.html
+++ b/archive/docs/ja/2.0.0/guide/getting-started/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/guide/getting-started/bada/index.html
+++ b/archive/docs/ja/2.0.0/guide/getting-started/bada/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/guide/getting-started/blackberry/index.html
+++ b/archive/docs/ja/2.0.0/guide/getting-started/blackberry/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/guide/getting-started/index.html
+++ b/archive/docs/ja/2.0.0/guide/getting-started/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/guide/getting-started/ios/index.html
+++ b/archive/docs/ja/2.0.0/guide/getting-started/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/guide/getting-started/symbian/index.html
+++ b/archive/docs/ja/2.0.0/guide/getting-started/symbian/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/guide/getting-started/webos/index.html
+++ b/archive/docs/ja/2.0.0/guide/getting-started/webos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/guide/getting-started/windows-phone/index.html
+++ b/archive/docs/ja/2.0.0/guide/getting-started/windows-phone/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/guide/plugin-development/android/index.html
+++ b/archive/docs/ja/2.0.0/guide/plugin-development/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/guide/plugin-development/bada/index.html
+++ b/archive/docs/ja/2.0.0/guide/plugin-development/bada/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/guide/plugin-development/blackberry/index.html
+++ b/archive/docs/ja/2.0.0/guide/plugin-development/blackberry/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/guide/plugin-development/index.html
+++ b/archive/docs/ja/2.0.0/guide/plugin-development/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/guide/plugin-development/ios/index.html
+++ b/archive/docs/ja/2.0.0/guide/plugin-development/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/guide/plugin-development/webos/index.html
+++ b/archive/docs/ja/2.0.0/guide/plugin-development/webos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/guide/plugin-development/windows-phone/index.html
+++ b/archive/docs/ja/2.0.0/guide/plugin-development/windows-phone/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/guide/upgrading/android/index.html
+++ b/archive/docs/ja/2.0.0/guide/upgrading/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/guide/upgrading/bada/index.html
+++ b/archive/docs/ja/2.0.0/guide/upgrading/bada/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/guide/upgrading/blackberry/index.html
+++ b/archive/docs/ja/2.0.0/guide/upgrading/blackberry/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/guide/upgrading/index.html
+++ b/archive/docs/ja/2.0.0/guide/upgrading/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/guide/upgrading/ios/index.html
+++ b/archive/docs/ja/2.0.0/guide/upgrading/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/guide/upgrading/symbian/index.html
+++ b/archive/docs/ja/2.0.0/guide/upgrading/symbian/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/guide/upgrading/webos/index.html
+++ b/archive/docs/ja/2.0.0/guide/upgrading/webos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/guide/upgrading/windows-phone/index.html
+++ b/archive/docs/ja/2.0.0/guide/upgrading/windows-phone/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/guide/whitelist/index.html
+++ b/archive/docs/ja/2.0.0/guide/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.0.0/index.html
+++ b/archive/docs/ja/2.0.0/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/accelerometer/acceleration/acceleration.html
+++ b/archive/docs/ja/2.1.0/cordova/accelerometer/acceleration/acceleration.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/accelerometer/accelerometer.clearWatch.html
+++ b/archive/docs/ja/2.1.0/cordova/accelerometer/accelerometer.clearWatch.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/accelerometer/accelerometer.getCurrentAcceleration.html
+++ b/archive/docs/ja/2.1.0/cordova/accelerometer/accelerometer.getCurrentAcceleration.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/accelerometer/accelerometer.html
+++ b/archive/docs/ja/2.1.0/cordova/accelerometer/accelerometer.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/accelerometer/accelerometer.watchAcceleration.html
+++ b/archive/docs/ja/2.1.0/cordova/accelerometer/accelerometer.watchAcceleration.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/accelerometer/parameters/accelerometerError.html
+++ b/archive/docs/ja/2.1.0/cordova/accelerometer/parameters/accelerometerError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/accelerometer/parameters/accelerometerOptions.html
+++ b/archive/docs/ja/2.1.0/cordova/accelerometer/parameters/accelerometerOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/accelerometer/parameters/accelerometerSuccess.html
+++ b/archive/docs/ja/2.1.0/cordova/accelerometer/parameters/accelerometerSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/camera/camera.cleanup.html
+++ b/archive/docs/ja/2.1.0/cordova/camera/camera.cleanup.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/camera/camera.getPicture.html
+++ b/archive/docs/ja/2.1.0/cordova/camera/camera.getPicture.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/camera/camera.html
+++ b/archive/docs/ja/2.1.0/cordova/camera/camera.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/compass/compass.clearWatch.html
+++ b/archive/docs/ja/2.1.0/cordova/compass/compass.clearWatch.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/compass/compass.clearWatchFilter.html
+++ b/archive/docs/ja/2.1.0/cordova/compass/compass.clearWatchFilter.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/compass/compass.getCurrentHeading.html
+++ b/archive/docs/ja/2.1.0/cordova/compass/compass.getCurrentHeading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/compass/compass.html
+++ b/archive/docs/ja/2.1.0/cordova/compass/compass.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/compass/compass.watchHeading.html
+++ b/archive/docs/ja/2.1.0/cordova/compass/compass.watchHeading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/compass/compass.watchHeadingFilter.html
+++ b/archive/docs/ja/2.1.0/cordova/compass/compass.watchHeadingFilter.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/compass/parameters/compassError.html
+++ b/archive/docs/ja/2.1.0/cordova/compass/parameters/compassError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/compass/parameters/compassHeading.html
+++ b/archive/docs/ja/2.1.0/cordova/compass/parameters/compassHeading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/compass/parameters/compassOptions.html
+++ b/archive/docs/ja/2.1.0/cordova/compass/parameters/compassOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/compass/parameters/compassSuccess.html
+++ b/archive/docs/ja/2.1.0/cordova/compass/parameters/compassSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/connection/connection.html
+++ b/archive/docs/ja/2.1.0/cordova/connection/connection.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/connection/connection.type.html
+++ b/archive/docs/ja/2.1.0/cordova/connection/connection.type.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/contacts/Contact/contact.html
+++ b/archive/docs/ja/2.1.0/cordova/contacts/Contact/contact.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/contacts/ContactAddress/contactaddress.html
+++ b/archive/docs/ja/2.1.0/cordova/contacts/ContactAddress/contactaddress.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/contacts/ContactError/contactError.html
+++ b/archive/docs/ja/2.1.0/cordova/contacts/ContactError/contactError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/contacts/ContactField/contactfield.html
+++ b/archive/docs/ja/2.1.0/cordova/contacts/ContactField/contactfield.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/contacts/ContactFindOptions/contactfindoptions.html
+++ b/archive/docs/ja/2.1.0/cordova/contacts/ContactFindOptions/contactfindoptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/contacts/ContactName/contactname.html
+++ b/archive/docs/ja/2.1.0/cordova/contacts/ContactName/contactname.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/contacts/ContactOrganization/contactorganization.html
+++ b/archive/docs/ja/2.1.0/cordova/contacts/ContactOrganization/contactorganization.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/contacts/contacts.create.html
+++ b/archive/docs/ja/2.1.0/cordova/contacts/contacts.create.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/contacts/contacts.find.html
+++ b/archive/docs/ja/2.1.0/cordova/contacts/contacts.find.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/contacts/contacts.html
+++ b/archive/docs/ja/2.1.0/cordova/contacts/contacts.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/contacts/parameters/contactError.html
+++ b/archive/docs/ja/2.1.0/cordova/contacts/parameters/contactError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/contacts/parameters/contactFields.html
+++ b/archive/docs/ja/2.1.0/cordova/contacts/parameters/contactFields.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/contacts/parameters/contactFindOptions.html
+++ b/archive/docs/ja/2.1.0/cordova/contacts/parameters/contactFindOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/contacts/parameters/contactSuccess.html
+++ b/archive/docs/ja/2.1.0/cordova/contacts/parameters/contactSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/device/device.cordova.html
+++ b/archive/docs/ja/2.1.0/cordova/device/device.cordova.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/device/device.html
+++ b/archive/docs/ja/2.1.0/cordova/device/device.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/device/device.name.html
+++ b/archive/docs/ja/2.1.0/cordova/device/device.name.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/device/device.platform.html
+++ b/archive/docs/ja/2.1.0/cordova/device/device.platform.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/device/device.uuid.html
+++ b/archive/docs/ja/2.1.0/cordova/device/device.uuid.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/device/device.version.html
+++ b/archive/docs/ja/2.1.0/cordova/device/device.version.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/events/events.backbutton.html
+++ b/archive/docs/ja/2.1.0/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/events/events.batterycritical.html
+++ b/archive/docs/ja/2.1.0/cordova/events/events.batterycritical.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/events/events.batterylow.html
+++ b/archive/docs/ja/2.1.0/cordova/events/events.batterylow.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/events/events.batterystatus.html
+++ b/archive/docs/ja/2.1.0/cordova/events/events.batterystatus.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/events/events.deviceready.html
+++ b/archive/docs/ja/2.1.0/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/events/events.endcallbutton.html
+++ b/archive/docs/ja/2.1.0/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/events/events.html
+++ b/archive/docs/ja/2.1.0/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/events/events.menubutton.html
+++ b/archive/docs/ja/2.1.0/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/events/events.offline.html
+++ b/archive/docs/ja/2.1.0/cordova/events/events.offline.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/events/events.online.html
+++ b/archive/docs/ja/2.1.0/cordova/events/events.online.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/events/events.pause.html
+++ b/archive/docs/ja/2.1.0/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/events/events.resume.html
+++ b/archive/docs/ja/2.1.0/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/events/events.searchbutton.html
+++ b/archive/docs/ja/2.1.0/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/events/events.startcallbutton.html
+++ b/archive/docs/ja/2.1.0/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/ja/2.1.0/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/ja/2.1.0/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/file/directoryentry/directoryentry.html
+++ b/archive/docs/ja/2.1.0/cordova/file/directoryentry/directoryentry.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/file/directoryreader/directoryreader.html
+++ b/archive/docs/ja/2.1.0/cordova/file/directoryreader/directoryreader.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/file/file.html
+++ b/archive/docs/ja/2.1.0/cordova/file/file.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/file/fileentry/fileentry.html
+++ b/archive/docs/ja/2.1.0/cordova/file/fileentry/fileentry.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/file/fileerror/fileerror.html
+++ b/archive/docs/ja/2.1.0/cordova/file/fileerror/fileerror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/file/fileobj/fileobj.html
+++ b/archive/docs/ja/2.1.0/cordova/file/fileobj/fileobj.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/file/filereader/filereader.html
+++ b/archive/docs/ja/2.1.0/cordova/file/filereader/filereader.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/file/filesystem/filesystem.html
+++ b/archive/docs/ja/2.1.0/cordova/file/filesystem/filesystem.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/file/filetransfer/filetransfer.html
+++ b/archive/docs/ja/2.1.0/cordova/file/filetransfer/filetransfer.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/file/filetransfererror/filetransfererror.html
+++ b/archive/docs/ja/2.1.0/cordova/file/filetransfererror/filetransfererror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/file/fileuploadoptions/fileuploadoptions.html
+++ b/archive/docs/ja/2.1.0/cordova/file/fileuploadoptions/fileuploadoptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/file/fileuploadresult/fileuploadresult.html
+++ b/archive/docs/ja/2.1.0/cordova/file/fileuploadresult/fileuploadresult.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/file/filewriter/filewriter.html
+++ b/archive/docs/ja/2.1.0/cordova/file/filewriter/filewriter.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/file/flags/flags.html
+++ b/archive/docs/ja/2.1.0/cordova/file/flags/flags.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/file/localfilesystem/localfilesystem.html
+++ b/archive/docs/ja/2.1.0/cordova/file/localfilesystem/localfilesystem.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/file/metadata/metadata.html
+++ b/archive/docs/ja/2.1.0/cordova/file/metadata/metadata.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/geolocation/Coordinates/coordinates.html
+++ b/archive/docs/ja/2.1.0/cordova/geolocation/Coordinates/coordinates.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/geolocation/Position/position.html
+++ b/archive/docs/ja/2.1.0/cordova/geolocation/Position/position.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/geolocation/PositionError/positionError.html
+++ b/archive/docs/ja/2.1.0/cordova/geolocation/PositionError/positionError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/geolocation/geolocation.clearWatch.html
+++ b/archive/docs/ja/2.1.0/cordova/geolocation/geolocation.clearWatch.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/geolocation/geolocation.getCurrentPosition.html
+++ b/archive/docs/ja/2.1.0/cordova/geolocation/geolocation.getCurrentPosition.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/geolocation/geolocation.html
+++ b/archive/docs/ja/2.1.0/cordova/geolocation/geolocation.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/geolocation/geolocation.watchPosition.html
+++ b/archive/docs/ja/2.1.0/cordova/geolocation/geolocation.watchPosition.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/geolocation/parameters/geolocation.options.html
+++ b/archive/docs/ja/2.1.0/cordova/geolocation/parameters/geolocation.options.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/geolocation/parameters/geolocationError.html
+++ b/archive/docs/ja/2.1.0/cordova/geolocation/parameters/geolocationError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/geolocation/parameters/geolocationSuccess.html
+++ b/archive/docs/ja/2.1.0/cordova/geolocation/parameters/geolocationSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/media/capture/CaptureCB.html
+++ b/archive/docs/ja/2.1.0/cordova/media/capture/CaptureCB.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/media/capture/CaptureError.html
+++ b/archive/docs/ja/2.1.0/cordova/media/capture/CaptureError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/media/capture/CaptureErrorCB.html
+++ b/archive/docs/ja/2.1.0/cordova/media/capture/CaptureErrorCB.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/media/capture/ConfigurationData.html
+++ b/archive/docs/ja/2.1.0/cordova/media/capture/ConfigurationData.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/media/capture/MediaFile.html
+++ b/archive/docs/ja/2.1.0/cordova/media/capture/MediaFile.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/media/capture/MediaFileData.html
+++ b/archive/docs/ja/2.1.0/cordova/media/capture/MediaFileData.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/media/capture/capture.html
+++ b/archive/docs/ja/2.1.0/cordova/media/capture/capture.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/media/capture/captureAudio.html
+++ b/archive/docs/ja/2.1.0/cordova/media/capture/captureAudio.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/media/capture/captureAudioOptions.html
+++ b/archive/docs/ja/2.1.0/cordova/media/capture/captureAudioOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/media/capture/captureImage.html
+++ b/archive/docs/ja/2.1.0/cordova/media/capture/captureImage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/media/capture/captureImageOptions.html
+++ b/archive/docs/ja/2.1.0/cordova/media/capture/captureImageOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/media/capture/captureVideo.html
+++ b/archive/docs/ja/2.1.0/cordova/media/capture/captureVideo.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/media/capture/captureVideoOptions.html
+++ b/archive/docs/ja/2.1.0/cordova/media/capture/captureVideoOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/media/media.getCurrentPosition.html
+++ b/archive/docs/ja/2.1.0/cordova/media/media.getCurrentPosition.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/media/media.getDuration.html
+++ b/archive/docs/ja/2.1.0/cordova/media/media.getDuration.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/media/media.html
+++ b/archive/docs/ja/2.1.0/cordova/media/media.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/media/media.pause.html
+++ b/archive/docs/ja/2.1.0/cordova/media/media.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/media/media.play.html
+++ b/archive/docs/ja/2.1.0/cordova/media/media.play.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/media/media.release.html
+++ b/archive/docs/ja/2.1.0/cordova/media/media.release.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/media/media.seekTo.html
+++ b/archive/docs/ja/2.1.0/cordova/media/media.seekTo.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/media/media.startRecord.html
+++ b/archive/docs/ja/2.1.0/cordova/media/media.startRecord.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/media/media.stop.html
+++ b/archive/docs/ja/2.1.0/cordova/media/media.stop.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/media/media.stopRecord.html
+++ b/archive/docs/ja/2.1.0/cordova/media/media.stopRecord.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/notification/notification.alert.html
+++ b/archive/docs/ja/2.1.0/cordova/notification/notification.alert.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/notification/notification.beep.html
+++ b/archive/docs/ja/2.1.0/cordova/notification/notification.beep.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/notification/notification.confirm.html
+++ b/archive/docs/ja/2.1.0/cordova/notification/notification.confirm.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/notification/notification.html
+++ b/archive/docs/ja/2.1.0/cordova/notification/notification.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/notification/notification.vibrate.html
+++ b/archive/docs/ja/2.1.0/cordova/notification/notification.vibrate.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/storage/database/database.html
+++ b/archive/docs/ja/2.1.0/cordova/storage/database/database.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/ja/2.1.0/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/storage/parameters/display_name.html
+++ b/archive/docs/ja/2.1.0/cordova/storage/parameters/display_name.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/storage/parameters/name.html
+++ b/archive/docs/ja/2.1.0/cordova/storage/parameters/name.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/storage/parameters/size.html
+++ b/archive/docs/ja/2.1.0/cordova/storage/parameters/size.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/storage/parameters/version.html
+++ b/archive/docs/ja/2.1.0/cordova/storage/parameters/version.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/storage/sqlerror/sqlerror.html
+++ b/archive/docs/ja/2.1.0/cordova/storage/sqlerror/sqlerror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/storage/sqlresultset/sqlresultset.html
+++ b/archive/docs/ja/2.1.0/cordova/storage/sqlresultset/sqlresultset.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/storage/sqlresultsetlist/sqlresultsetlist.html
+++ b/archive/docs/ja/2.1.0/cordova/storage/sqlresultsetlist/sqlresultsetlist.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/storage/sqltransaction/sqltransaction.html
+++ b/archive/docs/ja/2.1.0/cordova/storage/sqltransaction/sqltransaction.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/storage/storage.html
+++ b/archive/docs/ja/2.1.0/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/cordova/storage/storage.opendatabase.html
+++ b/archive/docs/ja/2.1.0/cordova/storage/storage.opendatabase.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/guide/command-line/index.html
+++ b/archive/docs/ja/2.1.0/guide/command-line/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/guide/cordova-webview/android.html
+++ b/archive/docs/ja/2.1.0/guide/cordova-webview/android.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/guide/cordova-webview/index.html
+++ b/archive/docs/ja/2.1.0/guide/cordova-webview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/guide/cordova-webview/ios.html
+++ b/archive/docs/ja/2.1.0/guide/cordova-webview/ios.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/guide/getting-started/android/index.html
+++ b/archive/docs/ja/2.1.0/guide/getting-started/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/guide/getting-started/bada/index.html
+++ b/archive/docs/ja/2.1.0/guide/getting-started/bada/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/guide/getting-started/blackberry/index.html
+++ b/archive/docs/ja/2.1.0/guide/getting-started/blackberry/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/guide/getting-started/index.html
+++ b/archive/docs/ja/2.1.0/guide/getting-started/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/guide/getting-started/ios/index.html
+++ b/archive/docs/ja/2.1.0/guide/getting-started/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/guide/getting-started/symbian/index.html
+++ b/archive/docs/ja/2.1.0/guide/getting-started/symbian/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/guide/getting-started/tizen/index.html
+++ b/archive/docs/ja/2.1.0/guide/getting-started/tizen/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/guide/getting-started/webos/index.html
+++ b/archive/docs/ja/2.1.0/guide/getting-started/webos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/guide/getting-started/windows-phone/index.html
+++ b/archive/docs/ja/2.1.0/guide/getting-started/windows-phone/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/guide/plugin-development/android/index.html
+++ b/archive/docs/ja/2.1.0/guide/plugin-development/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/guide/plugin-development/bada/index.html
+++ b/archive/docs/ja/2.1.0/guide/plugin-development/bada/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/guide/plugin-development/blackberry/index.html
+++ b/archive/docs/ja/2.1.0/guide/plugin-development/blackberry/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/guide/plugin-development/index.html
+++ b/archive/docs/ja/2.1.0/guide/plugin-development/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/guide/plugin-development/ios/index.html
+++ b/archive/docs/ja/2.1.0/guide/plugin-development/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/guide/plugin-development/tizen/index.html
+++ b/archive/docs/ja/2.1.0/guide/plugin-development/tizen/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/guide/plugin-development/webos/index.html
+++ b/archive/docs/ja/2.1.0/guide/plugin-development/webos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/guide/plugin-development/windows-phone/index.html
+++ b/archive/docs/ja/2.1.0/guide/plugin-development/windows-phone/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/guide/upgrading/android/index.html
+++ b/archive/docs/ja/2.1.0/guide/upgrading/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/guide/upgrading/bada/index.html
+++ b/archive/docs/ja/2.1.0/guide/upgrading/bada/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/guide/upgrading/blackberry/index.html
+++ b/archive/docs/ja/2.1.0/guide/upgrading/blackberry/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/guide/upgrading/index.html
+++ b/archive/docs/ja/2.1.0/guide/upgrading/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/guide/upgrading/ios/index.html
+++ b/archive/docs/ja/2.1.0/guide/upgrading/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/guide/upgrading/symbian/index.html
+++ b/archive/docs/ja/2.1.0/guide/upgrading/symbian/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/guide/upgrading/tizen/index.html
+++ b/archive/docs/ja/2.1.0/guide/upgrading/tizen/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/guide/upgrading/webos/index.html
+++ b/archive/docs/ja/2.1.0/guide/upgrading/webos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/guide/upgrading/windows-phone/index.html
+++ b/archive/docs/ja/2.1.0/guide/upgrading/windows-phone/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/guide/whitelist/index.html
+++ b/archive/docs/ja/2.1.0/guide/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.1.0/index.html
+++ b/archive/docs/ja/2.1.0/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/accelerometer/acceleration/acceleration.html
+++ b/archive/docs/ja/2.2.0/cordova/accelerometer/acceleration/acceleration.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/accelerometer/accelerometer.clearWatch.html
+++ b/archive/docs/ja/2.2.0/cordova/accelerometer/accelerometer.clearWatch.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/accelerometer/accelerometer.getCurrentAcceleration.html
+++ b/archive/docs/ja/2.2.0/cordova/accelerometer/accelerometer.getCurrentAcceleration.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/accelerometer/accelerometer.html
+++ b/archive/docs/ja/2.2.0/cordova/accelerometer/accelerometer.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/accelerometer/accelerometer.watchAcceleration.html
+++ b/archive/docs/ja/2.2.0/cordova/accelerometer/accelerometer.watchAcceleration.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/accelerometer/parameters/accelerometerError.html
+++ b/archive/docs/ja/2.2.0/cordova/accelerometer/parameters/accelerometerError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/accelerometer/parameters/accelerometerOptions.html
+++ b/archive/docs/ja/2.2.0/cordova/accelerometer/parameters/accelerometerOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/accelerometer/parameters/accelerometerSuccess.html
+++ b/archive/docs/ja/2.2.0/cordova/accelerometer/parameters/accelerometerSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/camera/camera.cleanup.html
+++ b/archive/docs/ja/2.2.0/cordova/camera/camera.cleanup.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/camera/camera.getPicture.html
+++ b/archive/docs/ja/2.2.0/cordova/camera/camera.getPicture.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/camera/camera.html
+++ b/archive/docs/ja/2.2.0/cordova/camera/camera.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/compass/compass.clearWatch.html
+++ b/archive/docs/ja/2.2.0/cordova/compass/compass.clearWatch.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/compass/compass.clearWatchFilter.html
+++ b/archive/docs/ja/2.2.0/cordova/compass/compass.clearWatchFilter.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/compass/compass.getCurrentHeading.html
+++ b/archive/docs/ja/2.2.0/cordova/compass/compass.getCurrentHeading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/compass/compass.html
+++ b/archive/docs/ja/2.2.0/cordova/compass/compass.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/compass/compass.watchHeading.html
+++ b/archive/docs/ja/2.2.0/cordova/compass/compass.watchHeading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/compass/compass.watchHeadingFilter.html
+++ b/archive/docs/ja/2.2.0/cordova/compass/compass.watchHeadingFilter.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/compass/parameters/compassError.html
+++ b/archive/docs/ja/2.2.0/cordova/compass/parameters/compassError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/compass/parameters/compassHeading.html
+++ b/archive/docs/ja/2.2.0/cordova/compass/parameters/compassHeading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/compass/parameters/compassOptions.html
+++ b/archive/docs/ja/2.2.0/cordova/compass/parameters/compassOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/compass/parameters/compassSuccess.html
+++ b/archive/docs/ja/2.2.0/cordova/compass/parameters/compassSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/connection/connection.html
+++ b/archive/docs/ja/2.2.0/cordova/connection/connection.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/connection/connection.type.html
+++ b/archive/docs/ja/2.2.0/cordova/connection/connection.type.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/contacts/Contact/contact.html
+++ b/archive/docs/ja/2.2.0/cordova/contacts/Contact/contact.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/contacts/ContactAddress/contactaddress.html
+++ b/archive/docs/ja/2.2.0/cordova/contacts/ContactAddress/contactaddress.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/contacts/ContactError/contactError.html
+++ b/archive/docs/ja/2.2.0/cordova/contacts/ContactError/contactError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/contacts/ContactField/contactfield.html
+++ b/archive/docs/ja/2.2.0/cordova/contacts/ContactField/contactfield.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/contacts/ContactFindOptions/contactfindoptions.html
+++ b/archive/docs/ja/2.2.0/cordova/contacts/ContactFindOptions/contactfindoptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/contacts/ContactName/contactname.html
+++ b/archive/docs/ja/2.2.0/cordova/contacts/ContactName/contactname.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/contacts/ContactOrganization/contactorganization.html
+++ b/archive/docs/ja/2.2.0/cordova/contacts/ContactOrganization/contactorganization.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/contacts/contacts.create.html
+++ b/archive/docs/ja/2.2.0/cordova/contacts/contacts.create.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/contacts/contacts.find.html
+++ b/archive/docs/ja/2.2.0/cordova/contacts/contacts.find.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/contacts/contacts.html
+++ b/archive/docs/ja/2.2.0/cordova/contacts/contacts.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/contacts/parameters/contactError.html
+++ b/archive/docs/ja/2.2.0/cordova/contacts/parameters/contactError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/contacts/parameters/contactFields.html
+++ b/archive/docs/ja/2.2.0/cordova/contacts/parameters/contactFields.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/contacts/parameters/contactFindOptions.html
+++ b/archive/docs/ja/2.2.0/cordova/contacts/parameters/contactFindOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/contacts/parameters/contactSuccess.html
+++ b/archive/docs/ja/2.2.0/cordova/contacts/parameters/contactSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/device/device.cordova.html
+++ b/archive/docs/ja/2.2.0/cordova/device/device.cordova.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/device/device.html
+++ b/archive/docs/ja/2.2.0/cordova/device/device.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/device/device.name.html
+++ b/archive/docs/ja/2.2.0/cordova/device/device.name.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/device/device.platform.html
+++ b/archive/docs/ja/2.2.0/cordova/device/device.platform.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/device/device.uuid.html
+++ b/archive/docs/ja/2.2.0/cordova/device/device.uuid.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/device/device.version.html
+++ b/archive/docs/ja/2.2.0/cordova/device/device.version.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/events/events.backbutton.html
+++ b/archive/docs/ja/2.2.0/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/events/events.batterycritical.html
+++ b/archive/docs/ja/2.2.0/cordova/events/events.batterycritical.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/events/events.batterylow.html
+++ b/archive/docs/ja/2.2.0/cordova/events/events.batterylow.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/events/events.batterystatus.html
+++ b/archive/docs/ja/2.2.0/cordova/events/events.batterystatus.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/events/events.deviceready.html
+++ b/archive/docs/ja/2.2.0/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/events/events.endcallbutton.html
+++ b/archive/docs/ja/2.2.0/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/events/events.html
+++ b/archive/docs/ja/2.2.0/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/events/events.menubutton.html
+++ b/archive/docs/ja/2.2.0/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/events/events.offline.html
+++ b/archive/docs/ja/2.2.0/cordova/events/events.offline.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/events/events.online.html
+++ b/archive/docs/ja/2.2.0/cordova/events/events.online.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/events/events.pause.html
+++ b/archive/docs/ja/2.2.0/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/events/events.resume.html
+++ b/archive/docs/ja/2.2.0/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/events/events.searchbutton.html
+++ b/archive/docs/ja/2.2.0/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/events/events.startcallbutton.html
+++ b/archive/docs/ja/2.2.0/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/ja/2.2.0/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/ja/2.2.0/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/file/directoryentry/directoryentry.html
+++ b/archive/docs/ja/2.2.0/cordova/file/directoryentry/directoryentry.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/file/directoryreader/directoryreader.html
+++ b/archive/docs/ja/2.2.0/cordova/file/directoryreader/directoryreader.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/file/file.html
+++ b/archive/docs/ja/2.2.0/cordova/file/file.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/file/fileentry/fileentry.html
+++ b/archive/docs/ja/2.2.0/cordova/file/fileentry/fileentry.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/file/fileerror/fileerror.html
+++ b/archive/docs/ja/2.2.0/cordova/file/fileerror/fileerror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/file/fileobj/fileobj.html
+++ b/archive/docs/ja/2.2.0/cordova/file/fileobj/fileobj.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/file/filereader/filereader.html
+++ b/archive/docs/ja/2.2.0/cordova/file/filereader/filereader.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/file/filesystem/filesystem.html
+++ b/archive/docs/ja/2.2.0/cordova/file/filesystem/filesystem.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/file/filetransfer/filetransfer.html
+++ b/archive/docs/ja/2.2.0/cordova/file/filetransfer/filetransfer.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/file/filetransfererror/filetransfererror.html
+++ b/archive/docs/ja/2.2.0/cordova/file/filetransfererror/filetransfererror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/file/fileuploadoptions/fileuploadoptions.html
+++ b/archive/docs/ja/2.2.0/cordova/file/fileuploadoptions/fileuploadoptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/file/fileuploadresult/fileuploadresult.html
+++ b/archive/docs/ja/2.2.0/cordova/file/fileuploadresult/fileuploadresult.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/file/filewriter/filewriter.html
+++ b/archive/docs/ja/2.2.0/cordova/file/filewriter/filewriter.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/file/flags/flags.html
+++ b/archive/docs/ja/2.2.0/cordova/file/flags/flags.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/file/localfilesystem/localfilesystem.html
+++ b/archive/docs/ja/2.2.0/cordova/file/localfilesystem/localfilesystem.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/file/metadata/metadata.html
+++ b/archive/docs/ja/2.2.0/cordova/file/metadata/metadata.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/geolocation/Coordinates/coordinates.html
+++ b/archive/docs/ja/2.2.0/cordova/geolocation/Coordinates/coordinates.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/geolocation/Position/position.html
+++ b/archive/docs/ja/2.2.0/cordova/geolocation/Position/position.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/geolocation/PositionError/positionError.html
+++ b/archive/docs/ja/2.2.0/cordova/geolocation/PositionError/positionError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/geolocation/geolocation.clearWatch.html
+++ b/archive/docs/ja/2.2.0/cordova/geolocation/geolocation.clearWatch.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/geolocation/geolocation.getCurrentPosition.html
+++ b/archive/docs/ja/2.2.0/cordova/geolocation/geolocation.getCurrentPosition.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/geolocation/geolocation.html
+++ b/archive/docs/ja/2.2.0/cordova/geolocation/geolocation.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/geolocation/geolocation.watchPosition.html
+++ b/archive/docs/ja/2.2.0/cordova/geolocation/geolocation.watchPosition.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/geolocation/parameters/geolocation.options.html
+++ b/archive/docs/ja/2.2.0/cordova/geolocation/parameters/geolocation.options.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/geolocation/parameters/geolocationError.html
+++ b/archive/docs/ja/2.2.0/cordova/geolocation/parameters/geolocationError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/geolocation/parameters/geolocationSuccess.html
+++ b/archive/docs/ja/2.2.0/cordova/geolocation/parameters/geolocationSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/globalization/GlobalizationError/globalizationerror.html
+++ b/archive/docs/ja/2.2.0/cordova/globalization/GlobalizationError/globalizationerror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/globalization/globalization.dateToString.html
+++ b/archive/docs/ja/2.2.0/cordova/globalization/globalization.dateToString.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/globalization/globalization.getCurrencyPattern.html
+++ b/archive/docs/ja/2.2.0/cordova/globalization/globalization.getCurrencyPattern.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/globalization/globalization.getDateNames.html
+++ b/archive/docs/ja/2.2.0/cordova/globalization/globalization.getDateNames.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/globalization/globalization.getDatePattern.html
+++ b/archive/docs/ja/2.2.0/cordova/globalization/globalization.getDatePattern.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/globalization/globalization.getFirstDayOfWeek.html
+++ b/archive/docs/ja/2.2.0/cordova/globalization/globalization.getFirstDayOfWeek.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/globalization/globalization.getLocaleName.html
+++ b/archive/docs/ja/2.2.0/cordova/globalization/globalization.getLocaleName.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/globalization/globalization.getNumberPattern.html
+++ b/archive/docs/ja/2.2.0/cordova/globalization/globalization.getNumberPattern.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/globalization/globalization.getPreferredLanguage.html
+++ b/archive/docs/ja/2.2.0/cordova/globalization/globalization.getPreferredLanguage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/globalization/globalization.html
+++ b/archive/docs/ja/2.2.0/cordova/globalization/globalization.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/globalization/globalization.isDayLightSavingsTime.html
+++ b/archive/docs/ja/2.2.0/cordova/globalization/globalization.isDayLightSavingsTime.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/globalization/globalization.numberToString.html
+++ b/archive/docs/ja/2.2.0/cordova/globalization/globalization.numberToString.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/globalization/globalization.stringToDate.html
+++ b/archive/docs/ja/2.2.0/cordova/globalization/globalization.stringToDate.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/globalization/globalization.stringToNumber.html
+++ b/archive/docs/ja/2.2.0/cordova/globalization/globalization.stringToNumber.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/media/capture/CaptureCB.html
+++ b/archive/docs/ja/2.2.0/cordova/media/capture/CaptureCB.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/media/capture/CaptureError.html
+++ b/archive/docs/ja/2.2.0/cordova/media/capture/CaptureError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/media/capture/CaptureErrorCB.html
+++ b/archive/docs/ja/2.2.0/cordova/media/capture/CaptureErrorCB.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/media/capture/ConfigurationData.html
+++ b/archive/docs/ja/2.2.0/cordova/media/capture/ConfigurationData.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/media/capture/MediaFile.html
+++ b/archive/docs/ja/2.2.0/cordova/media/capture/MediaFile.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/media/capture/MediaFileData.html
+++ b/archive/docs/ja/2.2.0/cordova/media/capture/MediaFileData.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/media/capture/capture.html
+++ b/archive/docs/ja/2.2.0/cordova/media/capture/capture.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/media/capture/captureAudio.html
+++ b/archive/docs/ja/2.2.0/cordova/media/capture/captureAudio.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/media/capture/captureAudioOptions.html
+++ b/archive/docs/ja/2.2.0/cordova/media/capture/captureAudioOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/media/capture/captureImage.html
+++ b/archive/docs/ja/2.2.0/cordova/media/capture/captureImage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/media/capture/captureImageOptions.html
+++ b/archive/docs/ja/2.2.0/cordova/media/capture/captureImageOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/media/capture/captureVideo.html
+++ b/archive/docs/ja/2.2.0/cordova/media/capture/captureVideo.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/media/capture/captureVideoOptions.html
+++ b/archive/docs/ja/2.2.0/cordova/media/capture/captureVideoOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/media/media.getCurrentPosition.html
+++ b/archive/docs/ja/2.2.0/cordova/media/media.getCurrentPosition.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/media/media.getDuration.html
+++ b/archive/docs/ja/2.2.0/cordova/media/media.getDuration.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/media/media.html
+++ b/archive/docs/ja/2.2.0/cordova/media/media.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/media/media.pause.html
+++ b/archive/docs/ja/2.2.0/cordova/media/media.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/media/media.play.html
+++ b/archive/docs/ja/2.2.0/cordova/media/media.play.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/media/media.release.html
+++ b/archive/docs/ja/2.2.0/cordova/media/media.release.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/media/media.seekTo.html
+++ b/archive/docs/ja/2.2.0/cordova/media/media.seekTo.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/media/media.startRecord.html
+++ b/archive/docs/ja/2.2.0/cordova/media/media.startRecord.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/media/media.stop.html
+++ b/archive/docs/ja/2.2.0/cordova/media/media.stop.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/media/media.stopRecord.html
+++ b/archive/docs/ja/2.2.0/cordova/media/media.stopRecord.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/notification/notification.alert.html
+++ b/archive/docs/ja/2.2.0/cordova/notification/notification.alert.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/notification/notification.beep.html
+++ b/archive/docs/ja/2.2.0/cordova/notification/notification.beep.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/notification/notification.confirm.html
+++ b/archive/docs/ja/2.2.0/cordova/notification/notification.confirm.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/notification/notification.html
+++ b/archive/docs/ja/2.2.0/cordova/notification/notification.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/notification/notification.vibrate.html
+++ b/archive/docs/ja/2.2.0/cordova/notification/notification.vibrate.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/splashscreen/splashscreen.hide.html
+++ b/archive/docs/ja/2.2.0/cordova/splashscreen/splashscreen.hide.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/splashscreen/splashscreen.html
+++ b/archive/docs/ja/2.2.0/cordova/splashscreen/splashscreen.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/splashscreen/splashscreen.show.html
+++ b/archive/docs/ja/2.2.0/cordova/splashscreen/splashscreen.show.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/storage/database/database.html
+++ b/archive/docs/ja/2.2.0/cordova/storage/database/database.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/ja/2.2.0/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/storage/parameters/display_name.html
+++ b/archive/docs/ja/2.2.0/cordova/storage/parameters/display_name.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/storage/parameters/name.html
+++ b/archive/docs/ja/2.2.0/cordova/storage/parameters/name.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/storage/parameters/size.html
+++ b/archive/docs/ja/2.2.0/cordova/storage/parameters/size.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/storage/parameters/version.html
+++ b/archive/docs/ja/2.2.0/cordova/storage/parameters/version.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/storage/sqlerror/sqlerror.html
+++ b/archive/docs/ja/2.2.0/cordova/storage/sqlerror/sqlerror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/storage/sqlresultset/sqlresultset.html
+++ b/archive/docs/ja/2.2.0/cordova/storage/sqlresultset/sqlresultset.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/storage/sqlresultsetlist/sqlresultsetlist.html
+++ b/archive/docs/ja/2.2.0/cordova/storage/sqlresultsetlist/sqlresultsetlist.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/storage/sqltransaction/sqltransaction.html
+++ b/archive/docs/ja/2.2.0/cordova/storage/sqltransaction/sqltransaction.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/storage/storage.html
+++ b/archive/docs/ja/2.2.0/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/cordova/storage/storage.opendatabase.html
+++ b/archive/docs/ja/2.2.0/cordova/storage/storage.opendatabase.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/guide/command-line/index.html
+++ b/archive/docs/ja/2.2.0/guide/command-line/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/guide/cordova-webview/android.html
+++ b/archive/docs/ja/2.2.0/guide/cordova-webview/android.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/guide/cordova-webview/index.html
+++ b/archive/docs/ja/2.2.0/guide/cordova-webview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/guide/cordova-webview/ios.html
+++ b/archive/docs/ja/2.2.0/guide/cordova-webview/ios.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/guide/getting-started/android/index.html
+++ b/archive/docs/ja/2.2.0/guide/getting-started/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/guide/getting-started/bada/index.html
+++ b/archive/docs/ja/2.2.0/guide/getting-started/bada/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/guide/getting-started/blackberry/index.html
+++ b/archive/docs/ja/2.2.0/guide/getting-started/blackberry/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/guide/getting-started/index.html
+++ b/archive/docs/ja/2.2.0/guide/getting-started/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/guide/getting-started/ios/index.html
+++ b/archive/docs/ja/2.2.0/guide/getting-started/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/guide/getting-started/symbian/index.html
+++ b/archive/docs/ja/2.2.0/guide/getting-started/symbian/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/guide/getting-started/tizen/index.html
+++ b/archive/docs/ja/2.2.0/guide/getting-started/tizen/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/guide/getting-started/webos/index.html
+++ b/archive/docs/ja/2.2.0/guide/getting-started/webos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/guide/getting-started/windows-8/index.html
+++ b/archive/docs/ja/2.2.0/guide/getting-started/windows-8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/guide/getting-started/windows-phone/index.html
+++ b/archive/docs/ja/2.2.0/guide/getting-started/windows-phone/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/guide/plugin-development/android/index.html
+++ b/archive/docs/ja/2.2.0/guide/plugin-development/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/guide/plugin-development/bada/index.html
+++ b/archive/docs/ja/2.2.0/guide/plugin-development/bada/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/guide/plugin-development/blackberry/index.html
+++ b/archive/docs/ja/2.2.0/guide/plugin-development/blackberry/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/guide/plugin-development/index.html
+++ b/archive/docs/ja/2.2.0/guide/plugin-development/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/guide/plugin-development/ios/index.html
+++ b/archive/docs/ja/2.2.0/guide/plugin-development/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/guide/plugin-development/tizen/index.html
+++ b/archive/docs/ja/2.2.0/guide/plugin-development/tizen/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/guide/plugin-development/webos/index.html
+++ b/archive/docs/ja/2.2.0/guide/plugin-development/webos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/guide/plugin-development/windows-phone/index.html
+++ b/archive/docs/ja/2.2.0/guide/plugin-development/windows-phone/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/guide/project-settings/index.html
+++ b/archive/docs/ja/2.2.0/guide/project-settings/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/guide/project-settings/ios/index.html
+++ b/archive/docs/ja/2.2.0/guide/project-settings/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/guide/upgrading/android/index.html
+++ b/archive/docs/ja/2.2.0/guide/upgrading/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/guide/upgrading/bada/index.html
+++ b/archive/docs/ja/2.2.0/guide/upgrading/bada/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/guide/upgrading/blackberry/index.html
+++ b/archive/docs/ja/2.2.0/guide/upgrading/blackberry/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/guide/upgrading/index.html
+++ b/archive/docs/ja/2.2.0/guide/upgrading/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/guide/upgrading/ios/index.html
+++ b/archive/docs/ja/2.2.0/guide/upgrading/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/guide/upgrading/symbian/index.html
+++ b/archive/docs/ja/2.2.0/guide/upgrading/symbian/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/guide/upgrading/tizen/index.html
+++ b/archive/docs/ja/2.2.0/guide/upgrading/tizen/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/guide/upgrading/webos/index.html
+++ b/archive/docs/ja/2.2.0/guide/upgrading/webos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/guide/upgrading/windows-phone/index.html
+++ b/archive/docs/ja/2.2.0/guide/upgrading/windows-phone/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/guide/whitelist/index.html
+++ b/archive/docs/ja/2.2.0/guide/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/2.2.0/index.html
+++ b/archive/docs/ja/2.2.0/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/config_ref/images.html
+++ b/archive/docs/ja/3.1.0/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/config_ref/index.html
+++ b/archive/docs/ja/3.1.0/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/accelerometer/acceleration/acceleration.html
+++ b/archive/docs/ja/3.1.0/cordova/accelerometer/acceleration/acceleration.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/accelerometer/accelerometer.clearWatch.html
+++ b/archive/docs/ja/3.1.0/cordova/accelerometer/accelerometer.clearWatch.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/accelerometer/accelerometer.getCurrentAcceleration.html
+++ b/archive/docs/ja/3.1.0/cordova/accelerometer/accelerometer.getCurrentAcceleration.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/accelerometer/accelerometer.html
+++ b/archive/docs/ja/3.1.0/cordova/accelerometer/accelerometer.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/accelerometer/accelerometer.watchAcceleration.html
+++ b/archive/docs/ja/3.1.0/cordova/accelerometer/accelerometer.watchAcceleration.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/accelerometer/parameters/accelerometerError.html
+++ b/archive/docs/ja/3.1.0/cordova/accelerometer/parameters/accelerometerError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/accelerometer/parameters/accelerometerOptions.html
+++ b/archive/docs/ja/3.1.0/cordova/accelerometer/parameters/accelerometerOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/accelerometer/parameters/accelerometerSuccess.html
+++ b/archive/docs/ja/3.1.0/cordova/accelerometer/parameters/accelerometerSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/camera/camera.cleanup.html
+++ b/archive/docs/ja/3.1.0/cordova/camera/camera.cleanup.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/camera/camera.getPicture.html
+++ b/archive/docs/ja/3.1.0/cordova/camera/camera.getPicture.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/camera/camera.html
+++ b/archive/docs/ja/3.1.0/cordova/camera/camera.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/compass/compass.clearWatch.html
+++ b/archive/docs/ja/3.1.0/cordova/compass/compass.clearWatch.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/compass/compass.clearWatchFilter.html
+++ b/archive/docs/ja/3.1.0/cordova/compass/compass.clearWatchFilter.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/compass/compass.getCurrentHeading.html
+++ b/archive/docs/ja/3.1.0/cordova/compass/compass.getCurrentHeading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/compass/compass.html
+++ b/archive/docs/ja/3.1.0/cordova/compass/compass.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/compass/compass.watchHeading.html
+++ b/archive/docs/ja/3.1.0/cordova/compass/compass.watchHeading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/compass/compass.watchHeadingFilter.html
+++ b/archive/docs/ja/3.1.0/cordova/compass/compass.watchHeadingFilter.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/compass/parameters/compassError.html
+++ b/archive/docs/ja/3.1.0/cordova/compass/parameters/compassError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/compass/parameters/compassHeading.html
+++ b/archive/docs/ja/3.1.0/cordova/compass/parameters/compassHeading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/compass/parameters/compassOptions.html
+++ b/archive/docs/ja/3.1.0/cordova/compass/parameters/compassOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/compass/parameters/compassSuccess.html
+++ b/archive/docs/ja/3.1.0/cordova/compass/parameters/compassSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/connection/connection.html
+++ b/archive/docs/ja/3.1.0/cordova/connection/connection.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/connection/connection.type.html
+++ b/archive/docs/ja/3.1.0/cordova/connection/connection.type.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/contacts/Contact/contact.html
+++ b/archive/docs/ja/3.1.0/cordova/contacts/Contact/contact.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/contacts/ContactAddress/contactaddress.html
+++ b/archive/docs/ja/3.1.0/cordova/contacts/ContactAddress/contactaddress.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/contacts/ContactError/contactError.html
+++ b/archive/docs/ja/3.1.0/cordova/contacts/ContactError/contactError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/contacts/ContactField/contactfield.html
+++ b/archive/docs/ja/3.1.0/cordova/contacts/ContactField/contactfield.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/contacts/ContactFindOptions/contactfindoptions.html
+++ b/archive/docs/ja/3.1.0/cordova/contacts/ContactFindOptions/contactfindoptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/contacts/ContactName/contactname.html
+++ b/archive/docs/ja/3.1.0/cordova/contacts/ContactName/contactname.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/contacts/ContactOrganization/contactorganization.html
+++ b/archive/docs/ja/3.1.0/cordova/contacts/ContactOrganization/contactorganization.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/contacts/contacts.create.html
+++ b/archive/docs/ja/3.1.0/cordova/contacts/contacts.create.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/contacts/contacts.find.html
+++ b/archive/docs/ja/3.1.0/cordova/contacts/contacts.find.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/contacts/contacts.html
+++ b/archive/docs/ja/3.1.0/cordova/contacts/contacts.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/contacts/parameters/contactError.html
+++ b/archive/docs/ja/3.1.0/cordova/contacts/parameters/contactError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/contacts/parameters/contactFields.html
+++ b/archive/docs/ja/3.1.0/cordova/contacts/parameters/contactFields.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/contacts/parameters/contactFindOptions.html
+++ b/archive/docs/ja/3.1.0/cordova/contacts/parameters/contactFindOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/contacts/parameters/contactSuccess.html
+++ b/archive/docs/ja/3.1.0/cordova/contacts/parameters/contactSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/device/device.cordova.html
+++ b/archive/docs/ja/3.1.0/cordova/device/device.cordova.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/device/device.html
+++ b/archive/docs/ja/3.1.0/cordova/device/device.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/device/device.model.html
+++ b/archive/docs/ja/3.1.0/cordova/device/device.model.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/device/device.name.html
+++ b/archive/docs/ja/3.1.0/cordova/device/device.name.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/device/device.platform.html
+++ b/archive/docs/ja/3.1.0/cordova/device/device.platform.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/device/device.uuid.html
+++ b/archive/docs/ja/3.1.0/cordova/device/device.uuid.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/device/device.version.html
+++ b/archive/docs/ja/3.1.0/cordova/device/device.version.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/events/events.backbutton.html
+++ b/archive/docs/ja/3.1.0/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/events/events.batterycritical.html
+++ b/archive/docs/ja/3.1.0/cordova/events/events.batterycritical.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/events/events.batterylow.html
+++ b/archive/docs/ja/3.1.0/cordova/events/events.batterylow.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/events/events.batterystatus.html
+++ b/archive/docs/ja/3.1.0/cordova/events/events.batterystatus.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/events/events.deviceready.html
+++ b/archive/docs/ja/3.1.0/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/events/events.endcallbutton.html
+++ b/archive/docs/ja/3.1.0/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/events/events.html
+++ b/archive/docs/ja/3.1.0/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/events/events.menubutton.html
+++ b/archive/docs/ja/3.1.0/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/events/events.offline.html
+++ b/archive/docs/ja/3.1.0/cordova/events/events.offline.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/events/events.online.html
+++ b/archive/docs/ja/3.1.0/cordova/events/events.online.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/events/events.pause.html
+++ b/archive/docs/ja/3.1.0/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/events/events.resume.html
+++ b/archive/docs/ja/3.1.0/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/events/events.searchbutton.html
+++ b/archive/docs/ja/3.1.0/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/events/events.startcallbutton.html
+++ b/archive/docs/ja/3.1.0/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/ja/3.1.0/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/ja/3.1.0/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/file/directoryentry/directoryentry.html
+++ b/archive/docs/ja/3.1.0/cordova/file/directoryentry/directoryentry.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/file/directoryreader/directoryreader.html
+++ b/archive/docs/ja/3.1.0/cordova/file/directoryreader/directoryreader.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/file/file.html
+++ b/archive/docs/ja/3.1.0/cordova/file/file.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/file/fileentry/fileentry.html
+++ b/archive/docs/ja/3.1.0/cordova/file/fileentry/fileentry.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/file/fileerror/fileerror.html
+++ b/archive/docs/ja/3.1.0/cordova/file/fileerror/fileerror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/file/fileobj/fileobj.html
+++ b/archive/docs/ja/3.1.0/cordova/file/fileobj/fileobj.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/file/filereader/filereader.html
+++ b/archive/docs/ja/3.1.0/cordova/file/filereader/filereader.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/file/filetransfer/filetransfer.html
+++ b/archive/docs/ja/3.1.0/cordova/file/filetransfer/filetransfer.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/file/filetransfererror/filetransfererror.html
+++ b/archive/docs/ja/3.1.0/cordova/file/filetransfererror/filetransfererror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/file/fileuploadoptions/fileuploadoptions.html
+++ b/archive/docs/ja/3.1.0/cordova/file/fileuploadoptions/fileuploadoptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/file/fileuploadresult/fileuploadresult.html
+++ b/archive/docs/ja/3.1.0/cordova/file/fileuploadresult/fileuploadresult.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/file/filewriter/filewriter.html
+++ b/archive/docs/ja/3.1.0/cordova/file/filewriter/filewriter.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/file/flags/flags.html
+++ b/archive/docs/ja/3.1.0/cordova/file/flags/flags.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/file/localfilesystem/localfilesystem.html
+++ b/archive/docs/ja/3.1.0/cordova/file/localfilesystem/localfilesystem.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/file/metadata/metadata.html
+++ b/archive/docs/ja/3.1.0/cordova/file/metadata/metadata.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/geolocation/PositionError/positionError.html
+++ b/archive/docs/ja/3.1.0/cordova/geolocation/PositionError/positionError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/geolocation/geolocation.clearWatch.html
+++ b/archive/docs/ja/3.1.0/cordova/geolocation/geolocation.clearWatch.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/geolocation/geolocation.getCurrentPosition.html
+++ b/archive/docs/ja/3.1.0/cordova/geolocation/geolocation.getCurrentPosition.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/geolocation/geolocation.html
+++ b/archive/docs/ja/3.1.0/cordova/geolocation/geolocation.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/geolocation/geolocation.watchPosition.html
+++ b/archive/docs/ja/3.1.0/cordova/geolocation/geolocation.watchPosition.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/geolocation/parameters/geolocation.options.html
+++ b/archive/docs/ja/3.1.0/cordova/geolocation/parameters/geolocation.options.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/geolocation/parameters/geolocationError.html
+++ b/archive/docs/ja/3.1.0/cordova/geolocation/parameters/geolocationError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/geolocation/parameters/geolocationSuccess.html
+++ b/archive/docs/ja/3.1.0/cordova/geolocation/parameters/geolocationSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/globalization/GlobalizationError/globalizationerror.html
+++ b/archive/docs/ja/3.1.0/cordova/globalization/GlobalizationError/globalizationerror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/globalization/globalization.dateToString.html
+++ b/archive/docs/ja/3.1.0/cordova/globalization/globalization.dateToString.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/globalization/globalization.getCurrencyPattern.html
+++ b/archive/docs/ja/3.1.0/cordova/globalization/globalization.getCurrencyPattern.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/globalization/globalization.getDateNames.html
+++ b/archive/docs/ja/3.1.0/cordova/globalization/globalization.getDateNames.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/globalization/globalization.getDatePattern.html
+++ b/archive/docs/ja/3.1.0/cordova/globalization/globalization.getDatePattern.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/globalization/globalization.getFirstDayOfWeek.html
+++ b/archive/docs/ja/3.1.0/cordova/globalization/globalization.getFirstDayOfWeek.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/globalization/globalization.getLocaleName.html
+++ b/archive/docs/ja/3.1.0/cordova/globalization/globalization.getLocaleName.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/globalization/globalization.getNumberPattern.html
+++ b/archive/docs/ja/3.1.0/cordova/globalization/globalization.getNumberPattern.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/globalization/globalization.getPreferredLanguage.html
+++ b/archive/docs/ja/3.1.0/cordova/globalization/globalization.getPreferredLanguage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/globalization/globalization.html
+++ b/archive/docs/ja/3.1.0/cordova/globalization/globalization.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/globalization/globalization.isDayLightSavingsTime.html
+++ b/archive/docs/ja/3.1.0/cordova/globalization/globalization.isDayLightSavingsTime.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/globalization/globalization.numberToString.html
+++ b/archive/docs/ja/3.1.0/cordova/globalization/globalization.numberToString.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/globalization/globalization.stringToDate.html
+++ b/archive/docs/ja/3.1.0/cordova/globalization/globalization.stringToDate.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/globalization/globalization.stringToNumber.html
+++ b/archive/docs/ja/3.1.0/cordova/globalization/globalization.stringToNumber.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/inappbrowser/inappbrowser.html
+++ b/archive/docs/ja/3.1.0/cordova/inappbrowser/inappbrowser.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/media/capture/CaptureErrorCB.html
+++ b/archive/docs/ja/3.1.0/cordova/media/capture/CaptureErrorCB.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/media/capture/ConfigurationData.html
+++ b/archive/docs/ja/3.1.0/cordova/media/capture/ConfigurationData.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/media/capture/MediaFile.getFormatData.html
+++ b/archive/docs/ja/3.1.0/cordova/media/capture/MediaFile.getFormatData.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/media/capture/MediaFile.html
+++ b/archive/docs/ja/3.1.0/cordova/media/capture/MediaFile.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/media/capture/MediaFileData.html
+++ b/archive/docs/ja/3.1.0/cordova/media/capture/MediaFileData.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/media/capture/capture.html
+++ b/archive/docs/ja/3.1.0/cordova/media/capture/capture.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/media/capture/captureAudio.html
+++ b/archive/docs/ja/3.1.0/cordova/media/capture/captureAudio.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/media/capture/captureAudioOptions.html
+++ b/archive/docs/ja/3.1.0/cordova/media/capture/captureAudioOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/media/capture/captureImage.html
+++ b/archive/docs/ja/3.1.0/cordova/media/capture/captureImage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/media/capture/captureImageOptions.html
+++ b/archive/docs/ja/3.1.0/cordova/media/capture/captureImageOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/media/capture/captureVideo.html
+++ b/archive/docs/ja/3.1.0/cordova/media/capture/captureVideo.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/media/capture/captureVideoOptions.html
+++ b/archive/docs/ja/3.1.0/cordova/media/capture/captureVideoOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/media/media.html
+++ b/archive/docs/ja/3.1.0/cordova/media/media.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/notification/notification.html
+++ b/archive/docs/ja/3.1.0/cordova/notification/notification.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/splashscreen/splashscreen.hide.html
+++ b/archive/docs/ja/3.1.0/cordova/splashscreen/splashscreen.hide.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/splashscreen/splashscreen.html
+++ b/archive/docs/ja/3.1.0/cordova/splashscreen/splashscreen.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/splashscreen/splashscreen.show.html
+++ b/archive/docs/ja/3.1.0/cordova/splashscreen/splashscreen.show.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/storage/database/database.html
+++ b/archive/docs/ja/3.1.0/cordova/storage/database/database.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/ja/3.1.0/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/storage/parameters/display_name.html
+++ b/archive/docs/ja/3.1.0/cordova/storage/parameters/display_name.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/storage/parameters/name.html
+++ b/archive/docs/ja/3.1.0/cordova/storage/parameters/name.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/storage/parameters/size.html
+++ b/archive/docs/ja/3.1.0/cordova/storage/parameters/size.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/storage/parameters/version.html
+++ b/archive/docs/ja/3.1.0/cordova/storage/parameters/version.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/storage/sqlresultset/sqlresultset.html
+++ b/archive/docs/ja/3.1.0/cordova/storage/sqlresultset/sqlresultset.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/storage/sqlresultsetrowlist/sqlresultsetrowlist.html
+++ b/archive/docs/ja/3.1.0/cordova/storage/sqlresultsetrowlist/sqlresultsetrowlist.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/storage/sqltransaction/sqltransaction.html
+++ b/archive/docs/ja/3.1.0/cordova/storage/sqltransaction/sqltransaction.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/storage/storage.html
+++ b/archive/docs/ja/3.1.0/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/cordova/storage/storage.opendatabase.html
+++ b/archive/docs/ja/3.1.0/cordova/storage/storage.opendatabase.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/guide/appdev/privacy/index.html
+++ b/archive/docs/ja/3.1.0/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/guide/appdev/whitelist/index.html
+++ b/archive/docs/ja/3.1.0/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/guide/cli/index.html
+++ b/archive/docs/ja/3.1.0/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/guide/hybrid/plugins/index.html
+++ b/archive/docs/ja/3.1.0/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/guide/hybrid/webviews/index.html
+++ b/archive/docs/ja/3.1.0/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/guide/overview/index.html
+++ b/archive/docs/ja/3.1.0/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/guide/platforms/android/config.html
+++ b/archive/docs/ja/3.1.0/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/guide/platforms/android/index.html
+++ b/archive/docs/ja/3.1.0/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/guide/platforms/android/plugin.html
+++ b/archive/docs/ja/3.1.0/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/guide/platforms/android/tools.html
+++ b/archive/docs/ja/3.1.0/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/guide/platforms/android/upgrading.html
+++ b/archive/docs/ja/3.1.0/guide/platforms/android/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/guide/platforms/android/webview.html
+++ b/archive/docs/ja/3.1.0/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/guide/platforms/blackberry/plugin.html
+++ b/archive/docs/ja/3.1.0/guide/platforms/blackberry/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/guide/platforms/blackberry/tools.html
+++ b/archive/docs/ja/3.1.0/guide/platforms/blackberry/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/guide/platforms/blackberry10/config.html
+++ b/archive/docs/ja/3.1.0/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/guide/platforms/blackberry10/index.html
+++ b/archive/docs/ja/3.1.0/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/ja/3.1.0/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/ja/3.1.0/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/guide/platforms/blackberry10/upgrading.html
+++ b/archive/docs/ja/3.1.0/guide/platforms/blackberry10/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/guide/platforms/index.html
+++ b/archive/docs/ja/3.1.0/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/guide/platforms/ios/config.html
+++ b/archive/docs/ja/3.1.0/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/guide/platforms/ios/index.html
+++ b/archive/docs/ja/3.1.0/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/guide/platforms/ios/plugin.html
+++ b/archive/docs/ja/3.1.0/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/guide/platforms/ios/tools.html
+++ b/archive/docs/ja/3.1.0/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/guide/platforms/ios/upgrading.html
+++ b/archive/docs/ja/3.1.0/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/guide/platforms/ios/webview.html
+++ b/archive/docs/ja/3.1.0/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/guide/platforms/win8/index.html
+++ b/archive/docs/ja/3.1.0/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/guide/platforms/win8/tools.html
+++ b/archive/docs/ja/3.1.0/guide/platforms/win8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/guide/platforms/win8/upgrading.html
+++ b/archive/docs/ja/3.1.0/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/guide/platforms/wp7/index.html
+++ b/archive/docs/ja/3.1.0/guide/platforms/wp7/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/guide/platforms/wp8/plugin.html
+++ b/archive/docs/ja/3.1.0/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/guide/platforms/wp8/tools.html
+++ b/archive/docs/ja/3.1.0/guide/platforms/wp8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/guide/platforms/wp8/upgrading.html
+++ b/archive/docs/ja/3.1.0/guide/platforms/wp8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/index.html
+++ b/archive/docs/ja/3.1.0/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.1.0/plugin_ref/spec.html
+++ b/archive/docs/ja/3.1.0/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.4.0/config_ref/images.html
+++ b/archive/docs/ja/3.4.0/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.4.0/config_ref/index.html
+++ b/archive/docs/ja/3.4.0/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.4.0/cordova/events/events.backbutton.html
+++ b/archive/docs/ja/3.4.0/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.4.0/cordova/events/events.deviceready.html
+++ b/archive/docs/ja/3.4.0/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.4.0/cordova/events/events.endcallbutton.html
+++ b/archive/docs/ja/3.4.0/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.4.0/cordova/events/events.html
+++ b/archive/docs/ja/3.4.0/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.4.0/cordova/events/events.menubutton.html
+++ b/archive/docs/ja/3.4.0/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.4.0/cordova/events/events.pause.html
+++ b/archive/docs/ja/3.4.0/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.4.0/cordova/events/events.resume.html
+++ b/archive/docs/ja/3.4.0/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.4.0/cordova/events/events.searchbutton.html
+++ b/archive/docs/ja/3.4.0/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.4.0/cordova/events/events.startcallbutton.html
+++ b/archive/docs/ja/3.4.0/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.4.0/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/ja/3.4.0/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.4.0/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/ja/3.4.0/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.4.0/cordova/plugins/pluginapis.html
+++ b/archive/docs/ja/3.4.0/cordova/plugins/pluginapis.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.4.0/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/ja/3.4.0/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.4.0/cordova/storage/storage.html
+++ b/archive/docs/ja/3.4.0/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.4.0/guide/appdev/privacy/index.html
+++ b/archive/docs/ja/3.4.0/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.4.0/guide/appdev/whitelist/index.html
+++ b/archive/docs/ja/3.4.0/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.4.0/guide/cli/index.html
+++ b/archive/docs/ja/3.4.0/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.4.0/guide/hybrid/plugins/index.html
+++ b/archive/docs/ja/3.4.0/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.4.0/guide/hybrid/webviews/index.html
+++ b/archive/docs/ja/3.4.0/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.4.0/guide/overview/index.html
+++ b/archive/docs/ja/3.4.0/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.4.0/guide/platforms/amazonfireos/config.html
+++ b/archive/docs/ja/3.4.0/guide/platforms/amazonfireos/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.4.0/guide/platforms/amazonfireos/index.html
+++ b/archive/docs/ja/3.4.0/guide/platforms/amazonfireos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.4.0/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/ja/3.4.0/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.4.0/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/ja/3.4.0/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.4.0/guide/platforms/android/config.html
+++ b/archive/docs/ja/3.4.0/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.4.0/guide/platforms/android/index.html
+++ b/archive/docs/ja/3.4.0/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.4.0/guide/platforms/android/plugin.html
+++ b/archive/docs/ja/3.4.0/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.4.0/guide/platforms/android/tools.html
+++ b/archive/docs/ja/3.4.0/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.4.0/guide/platforms/android/upgrading.html
+++ b/archive/docs/ja/3.4.0/guide/platforms/android/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.4.0/guide/platforms/android/webview.html
+++ b/archive/docs/ja/3.4.0/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.4.0/guide/platforms/blackberry10/config.html
+++ b/archive/docs/ja/3.4.0/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.4.0/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/ja/3.4.0/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.4.0/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/ja/3.4.0/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.4.0/guide/platforms/blackberry10/upgrading.html
+++ b/archive/docs/ja/3.4.0/guide/platforms/blackberry10/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.4.0/guide/platforms/index.html
+++ b/archive/docs/ja/3.4.0/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.4.0/guide/platforms/ios/config.html
+++ b/archive/docs/ja/3.4.0/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.4.0/guide/platforms/ios/plugin.html
+++ b/archive/docs/ja/3.4.0/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.4.0/guide/platforms/ios/tools.html
+++ b/archive/docs/ja/3.4.0/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.4.0/guide/platforms/ios/upgrading.html
+++ b/archive/docs/ja/3.4.0/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.4.0/guide/platforms/ios/webview.html
+++ b/archive/docs/ja/3.4.0/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.4.0/guide/platforms/win8/tools.html
+++ b/archive/docs/ja/3.4.0/guide/platforms/win8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.4.0/guide/platforms/win8/upgrading.html
+++ b/archive/docs/ja/3.4.0/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.4.0/guide/platforms/wp8/plugin.html
+++ b/archive/docs/ja/3.4.0/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.4.0/guide/platforms/wp8/tools.html
+++ b/archive/docs/ja/3.4.0/guide/platforms/wp8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.4.0/guide/platforms/wp8/upgrading.html
+++ b/archive/docs/ja/3.4.0/guide/platforms/wp8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.4.0/guide/support/index.html
+++ b/archive/docs/ja/3.4.0/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.4.0/index.html
+++ b/archive/docs/ja/3.4.0/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.4.0/plugin_ref/plugman.html
+++ b/archive/docs/ja/3.4.0/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.5.0/config_ref/images.html
+++ b/archive/docs/ja/3.5.0/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.5.0/config_ref/index.html
+++ b/archive/docs/ja/3.5.0/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.5.0/cordova/events/events.backbutton.html
+++ b/archive/docs/ja/3.5.0/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.5.0/cordova/events/events.deviceready.html
+++ b/archive/docs/ja/3.5.0/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.5.0/cordova/events/events.endcallbutton.html
+++ b/archive/docs/ja/3.5.0/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.5.0/cordova/events/events.html
+++ b/archive/docs/ja/3.5.0/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.5.0/cordova/events/events.menubutton.html
+++ b/archive/docs/ja/3.5.0/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.5.0/cordova/events/events.pause.html
+++ b/archive/docs/ja/3.5.0/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.5.0/cordova/events/events.resume.html
+++ b/archive/docs/ja/3.5.0/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.5.0/cordova/events/events.searchbutton.html
+++ b/archive/docs/ja/3.5.0/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.5.0/cordova/events/events.startcallbutton.html
+++ b/archive/docs/ja/3.5.0/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.5.0/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/ja/3.5.0/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.5.0/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/ja/3.5.0/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.5.0/cordova/plugins/pluginapis.html
+++ b/archive/docs/ja/3.5.0/cordova/plugins/pluginapis.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.5.0/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/ja/3.5.0/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.5.0/cordova/storage/storage.html
+++ b/archive/docs/ja/3.5.0/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.5.0/guide/appdev/privacy/index.html
+++ b/archive/docs/ja/3.5.0/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.5.0/guide/appdev/whitelist/index.html
+++ b/archive/docs/ja/3.5.0/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.5.0/guide/cli/index.html
+++ b/archive/docs/ja/3.5.0/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.5.0/guide/hybrid/plugins/index.html
+++ b/archive/docs/ja/3.5.0/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.5.0/guide/hybrid/webviews/index.html
+++ b/archive/docs/ja/3.5.0/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.5.0/guide/overview/index.html
+++ b/archive/docs/ja/3.5.0/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.5.0/guide/platforms/amazonfireos/config.html
+++ b/archive/docs/ja/3.5.0/guide/platforms/amazonfireos/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.5.0/guide/platforms/amazonfireos/index.html
+++ b/archive/docs/ja/3.5.0/guide/platforms/amazonfireos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.5.0/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/ja/3.5.0/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.5.0/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/ja/3.5.0/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.5.0/guide/platforms/android/config.html
+++ b/archive/docs/ja/3.5.0/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.5.0/guide/platforms/android/index.html
+++ b/archive/docs/ja/3.5.0/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.5.0/guide/platforms/android/plugin.html
+++ b/archive/docs/ja/3.5.0/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.5.0/guide/platforms/android/tools.html
+++ b/archive/docs/ja/3.5.0/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.5.0/guide/platforms/android/upgrading.html
+++ b/archive/docs/ja/3.5.0/guide/platforms/android/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.5.0/guide/platforms/android/webview.html
+++ b/archive/docs/ja/3.5.0/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.5.0/guide/platforms/blackberry10/config.html
+++ b/archive/docs/ja/3.5.0/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.5.0/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/ja/3.5.0/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.5.0/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/ja/3.5.0/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.5.0/guide/platforms/blackberry10/upgrading.html
+++ b/archive/docs/ja/3.5.0/guide/platforms/blackberry10/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.5.0/guide/platforms/index.html
+++ b/archive/docs/ja/3.5.0/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.5.0/guide/platforms/ios/config.html
+++ b/archive/docs/ja/3.5.0/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.5.0/guide/platforms/ios/plugin.html
+++ b/archive/docs/ja/3.5.0/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.5.0/guide/platforms/ios/tools.html
+++ b/archive/docs/ja/3.5.0/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.5.0/guide/platforms/ios/upgrading.html
+++ b/archive/docs/ja/3.5.0/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.5.0/guide/platforms/ios/webview.html
+++ b/archive/docs/ja/3.5.0/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.5.0/guide/platforms/win8/tools.html
+++ b/archive/docs/ja/3.5.0/guide/platforms/win8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.5.0/guide/platforms/win8/upgrading.html
+++ b/archive/docs/ja/3.5.0/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.5.0/guide/platforms/wp8/plugin.html
+++ b/archive/docs/ja/3.5.0/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.5.0/guide/platforms/wp8/tools.html
+++ b/archive/docs/ja/3.5.0/guide/platforms/wp8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.5.0/guide/platforms/wp8/upgrading.html
+++ b/archive/docs/ja/3.5.0/guide/platforms/wp8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.5.0/guide/support/index.html
+++ b/archive/docs/ja/3.5.0/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.5.0/index.html
+++ b/archive/docs/ja/3.5.0/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/3.5.0/plugin_ref/plugman.html
+++ b/archive/docs/ja/3.5.0/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/5.4.0/config_ref/images.html
+++ b/archive/docs/ja/5.4.0/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/5.4.0/config_ref/index.html
+++ b/archive/docs/ja/5.4.0/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/5.4.0/cordova/events/events.backbutton.html
+++ b/archive/docs/ja/5.4.0/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/5.4.0/cordova/events/events.deviceready.html
+++ b/archive/docs/ja/5.4.0/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/5.4.0/cordova/events/events.endcallbutton.html
+++ b/archive/docs/ja/5.4.0/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/5.4.0/cordova/events/events.html
+++ b/archive/docs/ja/5.4.0/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/5.4.0/cordova/events/events.menubutton.html
+++ b/archive/docs/ja/5.4.0/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/5.4.0/cordova/events/events.pause.html
+++ b/archive/docs/ja/5.4.0/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/5.4.0/cordova/events/events.resume.html
+++ b/archive/docs/ja/5.4.0/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/5.4.0/cordova/events/events.searchbutton.html
+++ b/archive/docs/ja/5.4.0/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/5.4.0/cordova/events/events.startcallbutton.html
+++ b/archive/docs/ja/5.4.0/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/5.4.0/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/ja/5.4.0/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/5.4.0/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/ja/5.4.0/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/5.4.0/cordova/plugins/pluginapis.html
+++ b/archive/docs/ja/5.4.0/cordova/plugins/pluginapis.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/5.4.0/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/ja/5.4.0/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/5.4.0/cordova/storage/storage.html
+++ b/archive/docs/ja/5.4.0/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/5.4.0/guide/appdev/privacy/index.html
+++ b/archive/docs/ja/5.4.0/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/5.4.0/guide/appdev/security/index.html
+++ b/archive/docs/ja/5.4.0/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/5.4.0/guide/appdev/whitelist/index.html
+++ b/archive/docs/ja/5.4.0/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/5.4.0/guide/cli/index.html
+++ b/archive/docs/ja/5.4.0/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/5.4.0/guide/hybrid/plugins/index.html
+++ b/archive/docs/ja/5.4.0/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/5.4.0/guide/hybrid/webviews/index.html
+++ b/archive/docs/ja/5.4.0/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/5.4.0/guide/next/index.html
+++ b/archive/docs/ja/5.4.0/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/5.4.0/guide/overview/index.html
+++ b/archive/docs/ja/5.4.0/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/5.4.0/guide/platforms/amazonfireos/config.html
+++ b/archive/docs/ja/5.4.0/guide/platforms/amazonfireos/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/5.4.0/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/ja/5.4.0/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/5.4.0/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/ja/5.4.0/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/5.4.0/guide/platforms/android/config.html
+++ b/archive/docs/ja/5.4.0/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/5.4.0/guide/platforms/android/plugin.html
+++ b/archive/docs/ja/5.4.0/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/5.4.0/guide/platforms/android/upgrading.html
+++ b/archive/docs/ja/5.4.0/guide/platforms/android/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/5.4.0/guide/platforms/android/webview.html
+++ b/archive/docs/ja/5.4.0/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/5.4.0/guide/platforms/blackberry10/config.html
+++ b/archive/docs/ja/5.4.0/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/5.4.0/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/ja/5.4.0/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/5.4.0/guide/platforms/blackberry10/upgrading.html
+++ b/archive/docs/ja/5.4.0/guide/platforms/blackberry10/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/5.4.0/guide/platforms/firefoxos/index.html
+++ b/archive/docs/ja/5.4.0/guide/platforms/firefoxos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/5.4.0/guide/platforms/index.html
+++ b/archive/docs/ja/5.4.0/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/5.4.0/guide/platforms/ios/config.html
+++ b/archive/docs/ja/5.4.0/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/5.4.0/guide/platforms/ios/plugin.html
+++ b/archive/docs/ja/5.4.0/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/5.4.0/guide/platforms/ios/upgrading.html
+++ b/archive/docs/ja/5.4.0/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/5.4.0/guide/platforms/ios/webview.html
+++ b/archive/docs/ja/5.4.0/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/5.4.0/guide/platforms/win8/index.html
+++ b/archive/docs/ja/5.4.0/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/5.4.0/guide/platforms/win8/packaging.html
+++ b/archive/docs/ja/5.4.0/guide/platforms/win8/packaging.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/5.4.0/guide/platforms/win8/plugin.html
+++ b/archive/docs/ja/5.4.0/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/5.4.0/guide/platforms/win8/win10-support.html
+++ b/archive/docs/ja/5.4.0/guide/platforms/win8/win10-support.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/5.4.0/guide/platforms/wp8/plugin.html
+++ b/archive/docs/ja/5.4.0/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/5.4.0/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/ja/5.4.0/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/5.4.0/guide/platforms/wp8/webview.html
+++ b/archive/docs/ja/5.4.0/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/5.4.0/guide/support/index.html
+++ b/archive/docs/ja/5.4.0/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/5.4.0/index.html
+++ b/archive/docs/ja/5.4.0/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/5.4.0/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/ja/5.4.0/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/5.4.0/plugin_ref/plugman.html
+++ b/archive/docs/ja/5.4.0/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/5.4.0/plugin_ref/spec.html
+++ b/archive/docs/ja/5.4.0/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/6.x/config_ref/images.html
+++ b/archive/docs/ja/6.x/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/6.x/config_ref/index.html
+++ b/archive/docs/ja/6.x/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/6.x/cordova/events/events.backbutton.html
+++ b/archive/docs/ja/6.x/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/6.x/cordova/events/events.deviceready.html
+++ b/archive/docs/ja/6.x/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/6.x/cordova/events/events.endcallbutton.html
+++ b/archive/docs/ja/6.x/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/6.x/cordova/events/events.html
+++ b/archive/docs/ja/6.x/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/6.x/cordova/events/events.menubutton.html
+++ b/archive/docs/ja/6.x/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/6.x/cordova/events/events.pause.html
+++ b/archive/docs/ja/6.x/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/6.x/cordova/events/events.resume.html
+++ b/archive/docs/ja/6.x/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/6.x/cordova/events/events.searchbutton.html
+++ b/archive/docs/ja/6.x/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/6.x/cordova/events/events.startcallbutton.html
+++ b/archive/docs/ja/6.x/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/6.x/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/ja/6.x/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/6.x/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/ja/6.x/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/6.x/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/ja/6.x/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/6.x/cordova/storage/storage.html
+++ b/archive/docs/ja/6.x/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/6.x/guide/appdev/hooks/index.html
+++ b/archive/docs/ja/6.x/guide/appdev/hooks/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/6.x/guide/appdev/privacy/index.html
+++ b/archive/docs/ja/6.x/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/6.x/guide/appdev/security/index.html
+++ b/archive/docs/ja/6.x/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/6.x/guide/appdev/whitelist/index.html
+++ b/archive/docs/ja/6.x/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/6.x/guide/cli/index.html
+++ b/archive/docs/ja/6.x/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/6.x/guide/hybrid/plugins/index.html
+++ b/archive/docs/ja/6.x/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/6.x/guide/hybrid/webviews/index.html
+++ b/archive/docs/ja/6.x/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/6.x/guide/next/index.html
+++ b/archive/docs/ja/6.x/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/6.x/guide/overview/index.html
+++ b/archive/docs/ja/6.x/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/6.x/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/ja/6.x/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/6.x/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/ja/6.x/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/6.x/guide/platforms/android/config.html
+++ b/archive/docs/ja/6.x/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/6.x/guide/platforms/android/index.html
+++ b/archive/docs/ja/6.x/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/6.x/guide/platforms/android/plugin.html
+++ b/archive/docs/ja/6.x/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/6.x/guide/platforms/android/webview.html
+++ b/archive/docs/ja/6.x/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/6.x/guide/platforms/blackberry10/config.html
+++ b/archive/docs/ja/6.x/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/6.x/guide/platforms/blackberry10/home.html
+++ b/archive/docs/ja/6.x/guide/platforms/blackberry10/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/6.x/guide/platforms/blackberry10/index.html
+++ b/archive/docs/ja/6.x/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/6.x/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/ja/6.x/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/6.x/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/ja/6.x/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/6.x/guide/platforms/blackberry10/upgrade.html
+++ b/archive/docs/ja/6.x/guide/platforms/blackberry10/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/6.x/guide/platforms/ios/config.html
+++ b/archive/docs/ja/6.x/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/6.x/guide/platforms/ios/index.html
+++ b/archive/docs/ja/6.x/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/6.x/guide/platforms/ios/plugin.html
+++ b/archive/docs/ja/6.x/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/6.x/guide/platforms/ios/upgrading.html
+++ b/archive/docs/ja/6.x/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/6.x/guide/platforms/ios/webview.html
+++ b/archive/docs/ja/6.x/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/6.x/guide/platforms/ubuntu/index.html
+++ b/archive/docs/ja/6.x/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/6.x/guide/platforms/win8/index.html
+++ b/archive/docs/ja/6.x/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/6.x/guide/platforms/win8/plugin.html
+++ b/archive/docs/ja/6.x/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/6.x/guide/platforms/win8/win10-support.html
+++ b/archive/docs/ja/6.x/guide/platforms/win8/win10-support.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/6.x/guide/platforms/wp8/home.html
+++ b/archive/docs/ja/6.x/guide/platforms/wp8/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/6.x/guide/platforms/wp8/index.html
+++ b/archive/docs/ja/6.x/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/6.x/guide/platforms/wp8/plugin.html
+++ b/archive/docs/ja/6.x/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/6.x/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/ja/6.x/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/6.x/guide/platforms/wp8/webview.html
+++ b/archive/docs/ja/6.x/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/6.x/guide/support/index.html
+++ b/archive/docs/ja/6.x/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/6.x/index.html
+++ b/archive/docs/ja/6.x/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/6.x/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/ja/6.x/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/6.x/plugin_ref/plugman.html
+++ b/archive/docs/ja/6.x/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/6.x/plugin_ref/spec.html
+++ b/archive/docs/ja/6.x/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/7.x/config_ref/images.html
+++ b/archive/docs/ja/7.x/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/7.x/config_ref/index.html
+++ b/archive/docs/ja/7.x/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/7.x/cordova/events/events.backbutton.html
+++ b/archive/docs/ja/7.x/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/7.x/cordova/events/events.deviceready.html
+++ b/archive/docs/ja/7.x/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/7.x/cordova/events/events.endcallbutton.html
+++ b/archive/docs/ja/7.x/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/7.x/cordova/events/events.html
+++ b/archive/docs/ja/7.x/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/7.x/cordova/events/events.menubutton.html
+++ b/archive/docs/ja/7.x/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/7.x/cordova/events/events.pause.html
+++ b/archive/docs/ja/7.x/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/7.x/cordova/events/events.resume.html
+++ b/archive/docs/ja/7.x/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/7.x/cordova/events/events.searchbutton.html
+++ b/archive/docs/ja/7.x/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/7.x/cordova/events/events.startcallbutton.html
+++ b/archive/docs/ja/7.x/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/7.x/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/ja/7.x/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/7.x/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/ja/7.x/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/7.x/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/ja/7.x/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/7.x/cordova/storage/storage.html
+++ b/archive/docs/ja/7.x/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/7.x/guide/appdev/hooks/index.html
+++ b/archive/docs/ja/7.x/guide/appdev/hooks/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/7.x/guide/appdev/privacy/index.html
+++ b/archive/docs/ja/7.x/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/7.x/guide/appdev/security/index.html
+++ b/archive/docs/ja/7.x/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/7.x/guide/appdev/whitelist/index.html
+++ b/archive/docs/ja/7.x/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/7.x/guide/cli/index.html
+++ b/archive/docs/ja/7.x/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/7.x/guide/hybrid/plugins/index.html
+++ b/archive/docs/ja/7.x/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/7.x/guide/hybrid/webviews/index.html
+++ b/archive/docs/ja/7.x/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/7.x/guide/next/index.html
+++ b/archive/docs/ja/7.x/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/7.x/guide/overview/index.html
+++ b/archive/docs/ja/7.x/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/7.x/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/ja/7.x/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/7.x/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/ja/7.x/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/7.x/guide/platforms/android/config.html
+++ b/archive/docs/ja/7.x/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/7.x/guide/platforms/android/index.html
+++ b/archive/docs/ja/7.x/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/7.x/guide/platforms/android/plugin.html
+++ b/archive/docs/ja/7.x/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/7.x/guide/platforms/android/webview.html
+++ b/archive/docs/ja/7.x/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/7.x/guide/platforms/blackberry10/config.html
+++ b/archive/docs/ja/7.x/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/7.x/guide/platforms/blackberry10/home.html
+++ b/archive/docs/ja/7.x/guide/platforms/blackberry10/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/7.x/guide/platforms/blackberry10/index.html
+++ b/archive/docs/ja/7.x/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/7.x/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/ja/7.x/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/7.x/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/ja/7.x/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/7.x/guide/platforms/blackberry10/upgrade.html
+++ b/archive/docs/ja/7.x/guide/platforms/blackberry10/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/7.x/guide/platforms/ios/config.html
+++ b/archive/docs/ja/7.x/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/7.x/guide/platforms/ios/index.html
+++ b/archive/docs/ja/7.x/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/7.x/guide/platforms/ios/plugin.html
+++ b/archive/docs/ja/7.x/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/7.x/guide/platforms/ios/upgrading.html
+++ b/archive/docs/ja/7.x/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/7.x/guide/platforms/ios/webview.html
+++ b/archive/docs/ja/7.x/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/7.x/guide/platforms/ubuntu/index.html
+++ b/archive/docs/ja/7.x/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/7.x/guide/platforms/win8/index.html
+++ b/archive/docs/ja/7.x/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/7.x/guide/platforms/win8/plugin.html
+++ b/archive/docs/ja/7.x/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/7.x/guide/platforms/win8/win10-support.html
+++ b/archive/docs/ja/7.x/guide/platforms/win8/win10-support.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/7.x/guide/platforms/wp8/home.html
+++ b/archive/docs/ja/7.x/guide/platforms/wp8/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/7.x/guide/platforms/wp8/index.html
+++ b/archive/docs/ja/7.x/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/7.x/guide/platforms/wp8/plugin.html
+++ b/archive/docs/ja/7.x/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/7.x/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/ja/7.x/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/7.x/guide/platforms/wp8/webview.html
+++ b/archive/docs/ja/7.x/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/7.x/guide/support/index.html
+++ b/archive/docs/ja/7.x/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/7.x/index.html
+++ b/archive/docs/ja/7.x/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/7.x/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/ja/7.x/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/7.x/plugin_ref/plugman.html
+++ b/archive/docs/ja/7.x/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/7.x/plugin_ref/spec.html
+++ b/archive/docs/ja/7.x/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/8.x/config_ref/images.html
+++ b/archive/docs/ja/8.x/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/8.x/config_ref/index.html
+++ b/archive/docs/ja/8.x/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/8.x/cordova/events/events.backbutton.html
+++ b/archive/docs/ja/8.x/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/8.x/cordova/events/events.deviceready.html
+++ b/archive/docs/ja/8.x/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/8.x/cordova/events/events.endcallbutton.html
+++ b/archive/docs/ja/8.x/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/8.x/cordova/events/events.html
+++ b/archive/docs/ja/8.x/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/8.x/cordova/events/events.menubutton.html
+++ b/archive/docs/ja/8.x/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/8.x/cordova/events/events.pause.html
+++ b/archive/docs/ja/8.x/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/8.x/cordova/events/events.resume.html
+++ b/archive/docs/ja/8.x/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/8.x/cordova/events/events.searchbutton.html
+++ b/archive/docs/ja/8.x/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/8.x/cordova/events/events.startcallbutton.html
+++ b/archive/docs/ja/8.x/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/8.x/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/ja/8.x/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/8.x/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/ja/8.x/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/8.x/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/ja/8.x/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/8.x/cordova/storage/storage.html
+++ b/archive/docs/ja/8.x/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/8.x/guide/appdev/hooks/index.html
+++ b/archive/docs/ja/8.x/guide/appdev/hooks/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/8.x/guide/appdev/privacy/index.html
+++ b/archive/docs/ja/8.x/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/8.x/guide/appdev/security/index.html
+++ b/archive/docs/ja/8.x/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/8.x/guide/appdev/whitelist/index.html
+++ b/archive/docs/ja/8.x/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/8.x/guide/cli/index.html
+++ b/archive/docs/ja/8.x/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/8.x/guide/hybrid/plugins/index.html
+++ b/archive/docs/ja/8.x/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/8.x/guide/hybrid/webviews/index.html
+++ b/archive/docs/ja/8.x/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/8.x/guide/next/index.html
+++ b/archive/docs/ja/8.x/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/8.x/guide/overview/index.html
+++ b/archive/docs/ja/8.x/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/8.x/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/ja/8.x/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/8.x/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/ja/8.x/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/8.x/guide/platforms/android/config.html
+++ b/archive/docs/ja/8.x/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/8.x/guide/platforms/android/index.html
+++ b/archive/docs/ja/8.x/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/8.x/guide/platforms/android/plugin.html
+++ b/archive/docs/ja/8.x/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/8.x/guide/platforms/android/webview.html
+++ b/archive/docs/ja/8.x/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/8.x/guide/platforms/blackberry10/config.html
+++ b/archive/docs/ja/8.x/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/8.x/guide/platforms/blackberry10/home.html
+++ b/archive/docs/ja/8.x/guide/platforms/blackberry10/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/8.x/guide/platforms/blackberry10/index.html
+++ b/archive/docs/ja/8.x/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/8.x/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/ja/8.x/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/8.x/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/ja/8.x/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/8.x/guide/platforms/blackberry10/upgrade.html
+++ b/archive/docs/ja/8.x/guide/platforms/blackberry10/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/8.x/guide/platforms/ios/config.html
+++ b/archive/docs/ja/8.x/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/8.x/guide/platforms/ios/index.html
+++ b/archive/docs/ja/8.x/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/8.x/guide/platforms/ios/plugin.html
+++ b/archive/docs/ja/8.x/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/8.x/guide/platforms/ios/upgrading.html
+++ b/archive/docs/ja/8.x/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/8.x/guide/platforms/ios/webview.html
+++ b/archive/docs/ja/8.x/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/8.x/guide/platforms/ubuntu/index.html
+++ b/archive/docs/ja/8.x/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/8.x/guide/platforms/win8/index.html
+++ b/archive/docs/ja/8.x/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/8.x/guide/platforms/win8/plugin.html
+++ b/archive/docs/ja/8.x/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/8.x/guide/platforms/win8/win10-support.html
+++ b/archive/docs/ja/8.x/guide/platforms/win8/win10-support.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/8.x/guide/platforms/wp8/home.html
+++ b/archive/docs/ja/8.x/guide/platforms/wp8/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/8.x/guide/platforms/wp8/index.html
+++ b/archive/docs/ja/8.x/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/8.x/guide/platforms/wp8/plugin.html
+++ b/archive/docs/ja/8.x/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/8.x/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/ja/8.x/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/8.x/guide/platforms/wp8/webview.html
+++ b/archive/docs/ja/8.x/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/8.x/guide/support/index.html
+++ b/archive/docs/ja/8.x/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/8.x/index.html
+++ b/archive/docs/ja/8.x/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/8.x/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/ja/8.x/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/8.x/plugin_ref/plugman.html
+++ b/archive/docs/ja/8.x/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/8.x/plugin_ref/spec.html
+++ b/archive/docs/ja/8.x/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/9.x/config_ref/images.html
+++ b/archive/docs/ja/9.x/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/9.x/config_ref/index.html
+++ b/archive/docs/ja/9.x/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/9.x/cordova/events/events.backbutton.html
+++ b/archive/docs/ja/9.x/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/9.x/cordova/events/events.deviceready.html
+++ b/archive/docs/ja/9.x/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/9.x/cordova/events/events.endcallbutton.html
+++ b/archive/docs/ja/9.x/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/9.x/cordova/events/events.html
+++ b/archive/docs/ja/9.x/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/9.x/cordova/events/events.menubutton.html
+++ b/archive/docs/ja/9.x/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/9.x/cordova/events/events.pause.html
+++ b/archive/docs/ja/9.x/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/9.x/cordova/events/events.resume.html
+++ b/archive/docs/ja/9.x/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/9.x/cordova/events/events.searchbutton.html
+++ b/archive/docs/ja/9.x/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/9.x/cordova/events/events.startcallbutton.html
+++ b/archive/docs/ja/9.x/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/9.x/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/ja/9.x/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/9.x/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/ja/9.x/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/9.x/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/ja/9.x/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/9.x/cordova/storage/storage.html
+++ b/archive/docs/ja/9.x/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/9.x/guide/appdev/hooks/index.html
+++ b/archive/docs/ja/9.x/guide/appdev/hooks/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/9.x/guide/appdev/privacy/index.html
+++ b/archive/docs/ja/9.x/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/9.x/guide/appdev/security/index.html
+++ b/archive/docs/ja/9.x/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/9.x/guide/appdev/whitelist/index.html
+++ b/archive/docs/ja/9.x/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/9.x/guide/cli/index.html
+++ b/archive/docs/ja/9.x/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/9.x/guide/hybrid/plugins/index.html
+++ b/archive/docs/ja/9.x/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/9.x/guide/hybrid/webviews/index.html
+++ b/archive/docs/ja/9.x/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/9.x/guide/next/index.html
+++ b/archive/docs/ja/9.x/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/9.x/guide/overview/index.html
+++ b/archive/docs/ja/9.x/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/9.x/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/ja/9.x/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/9.x/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/ja/9.x/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/9.x/guide/platforms/android/config.html
+++ b/archive/docs/ja/9.x/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/9.x/guide/platforms/android/index.html
+++ b/archive/docs/ja/9.x/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/9.x/guide/platforms/android/plugin.html
+++ b/archive/docs/ja/9.x/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/9.x/guide/platforms/android/webview.html
+++ b/archive/docs/ja/9.x/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/9.x/guide/platforms/blackberry10/config.html
+++ b/archive/docs/ja/9.x/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/9.x/guide/platforms/blackberry10/home.html
+++ b/archive/docs/ja/9.x/guide/platforms/blackberry10/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/9.x/guide/platforms/blackberry10/index.html
+++ b/archive/docs/ja/9.x/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/9.x/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/ja/9.x/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/9.x/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/ja/9.x/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/9.x/guide/platforms/blackberry10/upgrade.html
+++ b/archive/docs/ja/9.x/guide/platforms/blackberry10/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/9.x/guide/platforms/ios/config.html
+++ b/archive/docs/ja/9.x/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/9.x/guide/platforms/ios/index.html
+++ b/archive/docs/ja/9.x/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/9.x/guide/platforms/ios/plugin.html
+++ b/archive/docs/ja/9.x/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/9.x/guide/platforms/ios/upgrading.html
+++ b/archive/docs/ja/9.x/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/9.x/guide/platforms/ios/webview.html
+++ b/archive/docs/ja/9.x/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/9.x/guide/platforms/ubuntu/index.html
+++ b/archive/docs/ja/9.x/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/9.x/guide/platforms/win8/index.html
+++ b/archive/docs/ja/9.x/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/9.x/guide/platforms/win8/plugin.html
+++ b/archive/docs/ja/9.x/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/9.x/guide/platforms/win8/win10-support.html
+++ b/archive/docs/ja/9.x/guide/platforms/win8/win10-support.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/9.x/guide/platforms/wp8/home.html
+++ b/archive/docs/ja/9.x/guide/platforms/wp8/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/9.x/guide/platforms/wp8/index.html
+++ b/archive/docs/ja/9.x/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/9.x/guide/platforms/wp8/plugin.html
+++ b/archive/docs/ja/9.x/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/9.x/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/ja/9.x/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/9.x/guide/platforms/wp8/webview.html
+++ b/archive/docs/ja/9.x/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/9.x/guide/support/index.html
+++ b/archive/docs/ja/9.x/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/9.x/index.html
+++ b/archive/docs/ja/9.x/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/9.x/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/ja/9.x/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/9.x/plugin_ref/plugman.html
+++ b/archive/docs/ja/9.x/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ja/9.x/plugin_ref/spec.html
+++ b/archive/docs/ja/9.x/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/config_ref/images.html
+++ b/archive/docs/ko/10.x/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/config_ref/index.html
+++ b/archive/docs/ko/10.x/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/cordova/events/events.backbutton.html
+++ b/archive/docs/ko/10.x/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/cordova/events/events.deviceready.html
+++ b/archive/docs/ko/10.x/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/cordova/events/events.endcallbutton.html
+++ b/archive/docs/ko/10.x/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/cordova/events/events.html
+++ b/archive/docs/ko/10.x/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/cordova/events/events.menubutton.html
+++ b/archive/docs/ko/10.x/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/cordova/events/events.pause.html
+++ b/archive/docs/ko/10.x/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/cordova/events/events.resume.html
+++ b/archive/docs/ko/10.x/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/cordova/events/events.searchbutton.html
+++ b/archive/docs/ko/10.x/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/cordova/events/events.startcallbutton.html
+++ b/archive/docs/ko/10.x/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/ko/10.x/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/ko/10.x/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/cordova/storage/database/database.html
+++ b/archive/docs/ko/10.x/cordova/storage/database/database.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/ko/10.x/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/cordova/storage/storage.html
+++ b/archive/docs/ko/10.x/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/guide/appdev/hooks/index.html
+++ b/archive/docs/ko/10.x/guide/appdev/hooks/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/guide/appdev/privacy/index.html
+++ b/archive/docs/ko/10.x/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/guide/appdev/security/index.html
+++ b/archive/docs/ko/10.x/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/guide/appdev/whitelist/index.html
+++ b/archive/docs/ko/10.x/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/guide/cli/index.html
+++ b/archive/docs/ko/10.x/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/guide/hybrid/plugins/index.html
+++ b/archive/docs/ko/10.x/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/guide/hybrid/webviews/index.html
+++ b/archive/docs/ko/10.x/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/guide/next/index.html
+++ b/archive/docs/ko/10.x/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/guide/overview/index.html
+++ b/archive/docs/ko/10.x/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/guide/platforms/amazonfireos/config.html
+++ b/archive/docs/ko/10.x/guide/platforms/amazonfireos/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/guide/platforms/amazonfireos/index.html
+++ b/archive/docs/ko/10.x/guide/platforms/amazonfireos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/ko/10.x/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/ko/10.x/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/guide/platforms/android/config.html
+++ b/archive/docs/ko/10.x/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/guide/platforms/android/index.html
+++ b/archive/docs/ko/10.x/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/guide/platforms/android/plugin.html
+++ b/archive/docs/ko/10.x/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/guide/platforms/android/tools.html
+++ b/archive/docs/ko/10.x/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/guide/platforms/android/upgrading.html
+++ b/archive/docs/ko/10.x/guide/platforms/android/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/guide/platforms/android/webview.html
+++ b/archive/docs/ko/10.x/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/guide/platforms/blackberry10/config.html
+++ b/archive/docs/ko/10.x/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/guide/platforms/blackberry10/home.html
+++ b/archive/docs/ko/10.x/guide/platforms/blackberry10/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/guide/platforms/blackberry10/index.html
+++ b/archive/docs/ko/10.x/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/ko/10.x/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/ko/10.x/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/guide/platforms/blackberry10/upgrade.html
+++ b/archive/docs/ko/10.x/guide/platforms/blackberry10/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/guide/platforms/blackberry10/upgrading.html
+++ b/archive/docs/ko/10.x/guide/platforms/blackberry10/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/guide/platforms/firefoxos/index.html
+++ b/archive/docs/ko/10.x/guide/platforms/firefoxos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/guide/platforms/index.html
+++ b/archive/docs/ko/10.x/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/guide/platforms/ios/config.html
+++ b/archive/docs/ko/10.x/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/guide/platforms/ios/index.html
+++ b/archive/docs/ko/10.x/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/guide/platforms/ios/plugin.html
+++ b/archive/docs/ko/10.x/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/guide/platforms/ios/upgrading.html
+++ b/archive/docs/ko/10.x/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/guide/platforms/ios/webview.html
+++ b/archive/docs/ko/10.x/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/guide/platforms/ubuntu/index.html
+++ b/archive/docs/ko/10.x/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/guide/platforms/win8/index.html
+++ b/archive/docs/ko/10.x/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/guide/platforms/win8/packaging.html
+++ b/archive/docs/ko/10.x/guide/platforms/win8/packaging.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/guide/platforms/win8/plugin.html
+++ b/archive/docs/ko/10.x/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/guide/platforms/win8/upgrading.html
+++ b/archive/docs/ko/10.x/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/guide/platforms/win8/win10-support.html
+++ b/archive/docs/ko/10.x/guide/platforms/win8/win10-support.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/guide/platforms/wp8/home.html
+++ b/archive/docs/ko/10.x/guide/platforms/wp8/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/guide/platforms/wp8/index.html
+++ b/archive/docs/ko/10.x/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/guide/platforms/wp8/plugin.html
+++ b/archive/docs/ko/10.x/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/ko/10.x/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/guide/platforms/wp8/webview.html
+++ b/archive/docs/ko/10.x/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/guide/support/index.html
+++ b/archive/docs/ko/10.x/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/index.html
+++ b/archive/docs/ko/10.x/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/ko/10.x/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/plugin_ref/plugman.html
+++ b/archive/docs/ko/10.x/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/10.x/plugin_ref/spec.html
+++ b/archive/docs/ko/10.x/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/accelerometer/acceleration/acceleration.html
+++ b/archive/docs/ko/2.0.0/cordova/accelerometer/acceleration/acceleration.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/accelerometer/accelerometer.clearWatch.html
+++ b/archive/docs/ko/2.0.0/cordova/accelerometer/accelerometer.clearWatch.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/accelerometer/accelerometer.getCurrentAcceleration.html
+++ b/archive/docs/ko/2.0.0/cordova/accelerometer/accelerometer.getCurrentAcceleration.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/accelerometer/accelerometer.html
+++ b/archive/docs/ko/2.0.0/cordova/accelerometer/accelerometer.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/accelerometer/accelerometer.watchAcceleration.html
+++ b/archive/docs/ko/2.0.0/cordova/accelerometer/accelerometer.watchAcceleration.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/accelerometer/parameters/accelerometerError.html
+++ b/archive/docs/ko/2.0.0/cordova/accelerometer/parameters/accelerometerError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/accelerometer/parameters/accelerometerOptions.html
+++ b/archive/docs/ko/2.0.0/cordova/accelerometer/parameters/accelerometerOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/accelerometer/parameters/accelerometerSuccess.html
+++ b/archive/docs/ko/2.0.0/cordova/accelerometer/parameters/accelerometerSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/camera/camera.cleanup.html
+++ b/archive/docs/ko/2.0.0/cordova/camera/camera.cleanup.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/camera/camera.getPicture.html
+++ b/archive/docs/ko/2.0.0/cordova/camera/camera.getPicture.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/camera/camera.html
+++ b/archive/docs/ko/2.0.0/cordova/camera/camera.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/compass/compass.clearWatch.html
+++ b/archive/docs/ko/2.0.0/cordova/compass/compass.clearWatch.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/compass/compass.getCurrentHeading.html
+++ b/archive/docs/ko/2.0.0/cordova/compass/compass.getCurrentHeading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/compass/compass.html
+++ b/archive/docs/ko/2.0.0/cordova/compass/compass.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/compass/compass.watchHeading.html
+++ b/archive/docs/ko/2.0.0/cordova/compass/compass.watchHeading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/compass/compass.watchHeadingFilter.html
+++ b/archive/docs/ko/2.0.0/cordova/compass/compass.watchHeadingFilter.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/compass/parameters/compassError.html
+++ b/archive/docs/ko/2.0.0/cordova/compass/parameters/compassError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/compass/parameters/compassHeading.html
+++ b/archive/docs/ko/2.0.0/cordova/compass/parameters/compassHeading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/compass/parameters/compassOptions.html
+++ b/archive/docs/ko/2.0.0/cordova/compass/parameters/compassOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/compass/parameters/compassSuccess.html
+++ b/archive/docs/ko/2.0.0/cordova/compass/parameters/compassSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/connection/connection.html
+++ b/archive/docs/ko/2.0.0/cordova/connection/connection.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/connection/connection.type.html
+++ b/archive/docs/ko/2.0.0/cordova/connection/connection.type.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/contacts/Contact/contact.html
+++ b/archive/docs/ko/2.0.0/cordova/contacts/Contact/contact.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/contacts/ContactAddress/contactaddress.html
+++ b/archive/docs/ko/2.0.0/cordova/contacts/ContactAddress/contactaddress.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/contacts/ContactError/contactError.html
+++ b/archive/docs/ko/2.0.0/cordova/contacts/ContactError/contactError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/contacts/ContactField/contactfield.html
+++ b/archive/docs/ko/2.0.0/cordova/contacts/ContactField/contactfield.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/contacts/ContactFindOptions/contactfindoptions.html
+++ b/archive/docs/ko/2.0.0/cordova/contacts/ContactFindOptions/contactfindoptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/contacts/ContactName/contactname.html
+++ b/archive/docs/ko/2.0.0/cordova/contacts/ContactName/contactname.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/contacts/ContactOrganization/contactorganization.html
+++ b/archive/docs/ko/2.0.0/cordova/contacts/ContactOrganization/contactorganization.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/contacts/contacts.create.html
+++ b/archive/docs/ko/2.0.0/cordova/contacts/contacts.create.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/contacts/contacts.find.html
+++ b/archive/docs/ko/2.0.0/cordova/contacts/contacts.find.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/contacts/contacts.html
+++ b/archive/docs/ko/2.0.0/cordova/contacts/contacts.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/contacts/parameters/contactError.html
+++ b/archive/docs/ko/2.0.0/cordova/contacts/parameters/contactError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/contacts/parameters/contactFields.html
+++ b/archive/docs/ko/2.0.0/cordova/contacts/parameters/contactFields.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/contacts/parameters/contactFindOptions.html
+++ b/archive/docs/ko/2.0.0/cordova/contacts/parameters/contactFindOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/contacts/parameters/contactSuccess.html
+++ b/archive/docs/ko/2.0.0/cordova/contacts/parameters/contactSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/device/device.cordova.html
+++ b/archive/docs/ko/2.0.0/cordova/device/device.cordova.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/device/device.html
+++ b/archive/docs/ko/2.0.0/cordova/device/device.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/device/device.name.html
+++ b/archive/docs/ko/2.0.0/cordova/device/device.name.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/device/device.platform.html
+++ b/archive/docs/ko/2.0.0/cordova/device/device.platform.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/device/device.uuid.html
+++ b/archive/docs/ko/2.0.0/cordova/device/device.uuid.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/device/device.version.html
+++ b/archive/docs/ko/2.0.0/cordova/device/device.version.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/events/events.backbutton.html
+++ b/archive/docs/ko/2.0.0/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/events/events.batterycritical.html
+++ b/archive/docs/ko/2.0.0/cordova/events/events.batterycritical.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/events/events.batterylow.html
+++ b/archive/docs/ko/2.0.0/cordova/events/events.batterylow.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/events/events.batterystatus.html
+++ b/archive/docs/ko/2.0.0/cordova/events/events.batterystatus.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/events/events.deviceready.html
+++ b/archive/docs/ko/2.0.0/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/events/events.endcallbutton.html
+++ b/archive/docs/ko/2.0.0/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/events/events.html
+++ b/archive/docs/ko/2.0.0/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/events/events.menubutton.html
+++ b/archive/docs/ko/2.0.0/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/events/events.offline.html
+++ b/archive/docs/ko/2.0.0/cordova/events/events.offline.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/events/events.online.html
+++ b/archive/docs/ko/2.0.0/cordova/events/events.online.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/events/events.pause.html
+++ b/archive/docs/ko/2.0.0/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/events/events.resume.html
+++ b/archive/docs/ko/2.0.0/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/events/events.searchbutton.html
+++ b/archive/docs/ko/2.0.0/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/events/events.startcallbutton.html
+++ b/archive/docs/ko/2.0.0/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/ko/2.0.0/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/ko/2.0.0/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/file/directoryentry/directoryentry.html
+++ b/archive/docs/ko/2.0.0/cordova/file/directoryentry/directoryentry.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/file/directoryreader/directoryreader.html
+++ b/archive/docs/ko/2.0.0/cordova/file/directoryreader/directoryreader.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/file/file.html
+++ b/archive/docs/ko/2.0.0/cordova/file/file.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/file/fileentry/fileentry.html
+++ b/archive/docs/ko/2.0.0/cordova/file/fileentry/fileentry.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/file/fileerror/fileerror.html
+++ b/archive/docs/ko/2.0.0/cordova/file/fileerror/fileerror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/file/fileobj/fileobj.html
+++ b/archive/docs/ko/2.0.0/cordova/file/fileobj/fileobj.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/file/filereader/filereader.html
+++ b/archive/docs/ko/2.0.0/cordova/file/filereader/filereader.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/file/filesystem/filesystem.html
+++ b/archive/docs/ko/2.0.0/cordova/file/filesystem/filesystem.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/file/filetransfer/filetransfer.html
+++ b/archive/docs/ko/2.0.0/cordova/file/filetransfer/filetransfer.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/file/filetransfererror/filetransfererror.html
+++ b/archive/docs/ko/2.0.0/cordova/file/filetransfererror/filetransfererror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/file/fileuploadoptions/fileuploadoptions.html
+++ b/archive/docs/ko/2.0.0/cordova/file/fileuploadoptions/fileuploadoptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/file/fileuploadresult/fileuploadresult.html
+++ b/archive/docs/ko/2.0.0/cordova/file/fileuploadresult/fileuploadresult.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/file/filewriter/filewriter.html
+++ b/archive/docs/ko/2.0.0/cordova/file/filewriter/filewriter.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/file/flags/flags.html
+++ b/archive/docs/ko/2.0.0/cordova/file/flags/flags.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/file/localfilesystem/localfilesystem.html
+++ b/archive/docs/ko/2.0.0/cordova/file/localfilesystem/localfilesystem.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/file/metadata/metadata.html
+++ b/archive/docs/ko/2.0.0/cordova/file/metadata/metadata.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/geolocation/Coordinates/coordinates.html
+++ b/archive/docs/ko/2.0.0/cordova/geolocation/Coordinates/coordinates.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/geolocation/Position/position.html
+++ b/archive/docs/ko/2.0.0/cordova/geolocation/Position/position.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/geolocation/PositionError/positionError.html
+++ b/archive/docs/ko/2.0.0/cordova/geolocation/PositionError/positionError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/geolocation/geolocation.clearWatch.html
+++ b/archive/docs/ko/2.0.0/cordova/geolocation/geolocation.clearWatch.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/geolocation/geolocation.getCurrentPosition.html
+++ b/archive/docs/ko/2.0.0/cordova/geolocation/geolocation.getCurrentPosition.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/geolocation/geolocation.html
+++ b/archive/docs/ko/2.0.0/cordova/geolocation/geolocation.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/geolocation/geolocation.watchPosition.html
+++ b/archive/docs/ko/2.0.0/cordova/geolocation/geolocation.watchPosition.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/geolocation/parameters/geolocation.options.html
+++ b/archive/docs/ko/2.0.0/cordova/geolocation/parameters/geolocation.options.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/geolocation/parameters/geolocationError.html
+++ b/archive/docs/ko/2.0.0/cordova/geolocation/parameters/geolocationError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/geolocation/parameters/geolocationSuccess.html
+++ b/archive/docs/ko/2.0.0/cordova/geolocation/parameters/geolocationSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/media/capture/CaptureCB.html
+++ b/archive/docs/ko/2.0.0/cordova/media/capture/CaptureCB.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/media/capture/CaptureError.html
+++ b/archive/docs/ko/2.0.0/cordova/media/capture/CaptureError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/media/capture/CaptureErrorCB.html
+++ b/archive/docs/ko/2.0.0/cordova/media/capture/CaptureErrorCB.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/media/capture/ConfigurationData.html
+++ b/archive/docs/ko/2.0.0/cordova/media/capture/ConfigurationData.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/media/capture/MediaFile.html
+++ b/archive/docs/ko/2.0.0/cordova/media/capture/MediaFile.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/media/capture/MediaFileData.html
+++ b/archive/docs/ko/2.0.0/cordova/media/capture/MediaFileData.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/media/capture/capture.html
+++ b/archive/docs/ko/2.0.0/cordova/media/capture/capture.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/media/capture/captureAudio.html
+++ b/archive/docs/ko/2.0.0/cordova/media/capture/captureAudio.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/media/capture/captureAudioOptions.html
+++ b/archive/docs/ko/2.0.0/cordova/media/capture/captureAudioOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/media/capture/captureImage.html
+++ b/archive/docs/ko/2.0.0/cordova/media/capture/captureImage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/media/capture/captureImageOptions.html
+++ b/archive/docs/ko/2.0.0/cordova/media/capture/captureImageOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/media/capture/captureVideo.html
+++ b/archive/docs/ko/2.0.0/cordova/media/capture/captureVideo.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/media/capture/captureVideoOptions.html
+++ b/archive/docs/ko/2.0.0/cordova/media/capture/captureVideoOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/media/media.getCurrentPosition.html
+++ b/archive/docs/ko/2.0.0/cordova/media/media.getCurrentPosition.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/media/media.getDuration.html
+++ b/archive/docs/ko/2.0.0/cordova/media/media.getDuration.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/media/media.html
+++ b/archive/docs/ko/2.0.0/cordova/media/media.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/media/media.pause.html
+++ b/archive/docs/ko/2.0.0/cordova/media/media.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/media/media.play.html
+++ b/archive/docs/ko/2.0.0/cordova/media/media.play.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/media/media.release.html
+++ b/archive/docs/ko/2.0.0/cordova/media/media.release.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/media/media.seekTo.html
+++ b/archive/docs/ko/2.0.0/cordova/media/media.seekTo.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/media/media.startRecord.html
+++ b/archive/docs/ko/2.0.0/cordova/media/media.startRecord.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/media/media.stop.html
+++ b/archive/docs/ko/2.0.0/cordova/media/media.stop.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/media/media.stopRecord.html
+++ b/archive/docs/ko/2.0.0/cordova/media/media.stopRecord.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/notification/notification.alert.html
+++ b/archive/docs/ko/2.0.0/cordova/notification/notification.alert.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/notification/notification.beep.html
+++ b/archive/docs/ko/2.0.0/cordova/notification/notification.beep.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/notification/notification.confirm.html
+++ b/archive/docs/ko/2.0.0/cordova/notification/notification.confirm.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/notification/notification.html
+++ b/archive/docs/ko/2.0.0/cordova/notification/notification.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/notification/notification.vibrate.html
+++ b/archive/docs/ko/2.0.0/cordova/notification/notification.vibrate.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/storage/database/database.html
+++ b/archive/docs/ko/2.0.0/cordova/storage/database/database.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/ko/2.0.0/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/storage/parameters/display_name.html
+++ b/archive/docs/ko/2.0.0/cordova/storage/parameters/display_name.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/storage/parameters/name.html
+++ b/archive/docs/ko/2.0.0/cordova/storage/parameters/name.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/storage/parameters/size.html
+++ b/archive/docs/ko/2.0.0/cordova/storage/parameters/size.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/storage/parameters/version.html
+++ b/archive/docs/ko/2.0.0/cordova/storage/parameters/version.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/storage/sqlerror/sqlerror.html
+++ b/archive/docs/ko/2.0.0/cordova/storage/sqlerror/sqlerror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/storage/sqlresultset/sqlresultset.html
+++ b/archive/docs/ko/2.0.0/cordova/storage/sqlresultset/sqlresultset.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/storage/sqlresultsetlist/sqlresultsetlist.html
+++ b/archive/docs/ko/2.0.0/cordova/storage/sqlresultsetlist/sqlresultsetlist.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/storage/sqltransaction/sqltransaction.html
+++ b/archive/docs/ko/2.0.0/cordova/storage/sqltransaction/sqltransaction.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/storage/storage.html
+++ b/archive/docs/ko/2.0.0/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/cordova/storage/storage.opendatabase.html
+++ b/archive/docs/ko/2.0.0/cordova/storage/storage.opendatabase.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/guide/command-line/index.html
+++ b/archive/docs/ko/2.0.0/guide/command-line/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/guide/cordova-webview/android.html
+++ b/archive/docs/ko/2.0.0/guide/cordova-webview/android.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/guide/cordova-webview/index.html
+++ b/archive/docs/ko/2.0.0/guide/cordova-webview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/guide/cordova-webview/ios.html
+++ b/archive/docs/ko/2.0.0/guide/cordova-webview/ios.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/guide/getting-started/android/index.html
+++ b/archive/docs/ko/2.0.0/guide/getting-started/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/guide/getting-started/bada/index.html
+++ b/archive/docs/ko/2.0.0/guide/getting-started/bada/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/guide/getting-started/blackberry/index.html
+++ b/archive/docs/ko/2.0.0/guide/getting-started/blackberry/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/guide/getting-started/index.html
+++ b/archive/docs/ko/2.0.0/guide/getting-started/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/guide/getting-started/ios/index.html
+++ b/archive/docs/ko/2.0.0/guide/getting-started/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/guide/getting-started/symbian/index.html
+++ b/archive/docs/ko/2.0.0/guide/getting-started/symbian/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/guide/getting-started/webos/index.html
+++ b/archive/docs/ko/2.0.0/guide/getting-started/webos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/guide/getting-started/windows-phone/index.html
+++ b/archive/docs/ko/2.0.0/guide/getting-started/windows-phone/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/guide/plugin-development/android/index.html
+++ b/archive/docs/ko/2.0.0/guide/plugin-development/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/guide/plugin-development/bada/index.html
+++ b/archive/docs/ko/2.0.0/guide/plugin-development/bada/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/guide/plugin-development/blackberry/index.html
+++ b/archive/docs/ko/2.0.0/guide/plugin-development/blackberry/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/guide/plugin-development/index.html
+++ b/archive/docs/ko/2.0.0/guide/plugin-development/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/guide/plugin-development/ios/index.html
+++ b/archive/docs/ko/2.0.0/guide/plugin-development/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/guide/plugin-development/webos/index.html
+++ b/archive/docs/ko/2.0.0/guide/plugin-development/webos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/guide/plugin-development/windows-phone/index.html
+++ b/archive/docs/ko/2.0.0/guide/plugin-development/windows-phone/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/guide/upgrading/android/index.html
+++ b/archive/docs/ko/2.0.0/guide/upgrading/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/guide/upgrading/bada/index.html
+++ b/archive/docs/ko/2.0.0/guide/upgrading/bada/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/guide/upgrading/blackberry/index.html
+++ b/archive/docs/ko/2.0.0/guide/upgrading/blackberry/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/guide/upgrading/index.html
+++ b/archive/docs/ko/2.0.0/guide/upgrading/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/guide/upgrading/ios/index.html
+++ b/archive/docs/ko/2.0.0/guide/upgrading/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/guide/upgrading/symbian/index.html
+++ b/archive/docs/ko/2.0.0/guide/upgrading/symbian/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/guide/upgrading/webos/index.html
+++ b/archive/docs/ko/2.0.0/guide/upgrading/webos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/guide/upgrading/windows-phone/index.html
+++ b/archive/docs/ko/2.0.0/guide/upgrading/windows-phone/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/guide/whitelist/index.html
+++ b/archive/docs/ko/2.0.0/guide/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/2.0.0/index.html
+++ b/archive/docs/ko/2.0.0/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/config_ref/images.html
+++ b/archive/docs/ko/3.1.0/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/config_ref/index.html
+++ b/archive/docs/ko/3.1.0/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/accelerometer/acceleration/acceleration.html
+++ b/archive/docs/ko/3.1.0/cordova/accelerometer/acceleration/acceleration.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/accelerometer/accelerometer.clearWatch.html
+++ b/archive/docs/ko/3.1.0/cordova/accelerometer/accelerometer.clearWatch.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/accelerometer/accelerometer.getCurrentAcceleration.html
+++ b/archive/docs/ko/3.1.0/cordova/accelerometer/accelerometer.getCurrentAcceleration.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/accelerometer/accelerometer.html
+++ b/archive/docs/ko/3.1.0/cordova/accelerometer/accelerometer.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/accelerometer/accelerometer.watchAcceleration.html
+++ b/archive/docs/ko/3.1.0/cordova/accelerometer/accelerometer.watchAcceleration.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/accelerometer/parameters/accelerometerError.html
+++ b/archive/docs/ko/3.1.0/cordova/accelerometer/parameters/accelerometerError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/accelerometer/parameters/accelerometerOptions.html
+++ b/archive/docs/ko/3.1.0/cordova/accelerometer/parameters/accelerometerOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/accelerometer/parameters/accelerometerSuccess.html
+++ b/archive/docs/ko/3.1.0/cordova/accelerometer/parameters/accelerometerSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/camera/camera.cleanup.html
+++ b/archive/docs/ko/3.1.0/cordova/camera/camera.cleanup.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/camera/camera.getPicture.html
+++ b/archive/docs/ko/3.1.0/cordova/camera/camera.getPicture.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/camera/camera.html
+++ b/archive/docs/ko/3.1.0/cordova/camera/camera.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/compass/compass.clearWatch.html
+++ b/archive/docs/ko/3.1.0/cordova/compass/compass.clearWatch.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/compass/compass.clearWatchFilter.html
+++ b/archive/docs/ko/3.1.0/cordova/compass/compass.clearWatchFilter.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/compass/compass.getCurrentHeading.html
+++ b/archive/docs/ko/3.1.0/cordova/compass/compass.getCurrentHeading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/compass/compass.html
+++ b/archive/docs/ko/3.1.0/cordova/compass/compass.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/compass/compass.watchHeading.html
+++ b/archive/docs/ko/3.1.0/cordova/compass/compass.watchHeading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/compass/compass.watchHeadingFilter.html
+++ b/archive/docs/ko/3.1.0/cordova/compass/compass.watchHeadingFilter.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/compass/parameters/compassError.html
+++ b/archive/docs/ko/3.1.0/cordova/compass/parameters/compassError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/compass/parameters/compassHeading.html
+++ b/archive/docs/ko/3.1.0/cordova/compass/parameters/compassHeading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/compass/parameters/compassOptions.html
+++ b/archive/docs/ko/3.1.0/cordova/compass/parameters/compassOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/compass/parameters/compassSuccess.html
+++ b/archive/docs/ko/3.1.0/cordova/compass/parameters/compassSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/connection/connection.html
+++ b/archive/docs/ko/3.1.0/cordova/connection/connection.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/connection/connection.type.html
+++ b/archive/docs/ko/3.1.0/cordova/connection/connection.type.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/contacts/ContactAddress/contactaddress.html
+++ b/archive/docs/ko/3.1.0/cordova/contacts/ContactAddress/contactaddress.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/contacts/ContactError/contactError.html
+++ b/archive/docs/ko/3.1.0/cordova/contacts/ContactError/contactError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/contacts/ContactField/contactfield.html
+++ b/archive/docs/ko/3.1.0/cordova/contacts/ContactField/contactfield.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/contacts/ContactFindOptions/contactfindoptions.html
+++ b/archive/docs/ko/3.1.0/cordova/contacts/ContactFindOptions/contactfindoptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/contacts/ContactName/contactname.html
+++ b/archive/docs/ko/3.1.0/cordova/contacts/ContactName/contactname.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/contacts/ContactOrganization/contactorganization.html
+++ b/archive/docs/ko/3.1.0/cordova/contacts/ContactOrganization/contactorganization.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/contacts/contacts.create.html
+++ b/archive/docs/ko/3.1.0/cordova/contacts/contacts.create.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/contacts/contacts.find.html
+++ b/archive/docs/ko/3.1.0/cordova/contacts/contacts.find.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/contacts/contacts.html
+++ b/archive/docs/ko/3.1.0/cordova/contacts/contacts.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/contacts/parameters/contactError.html
+++ b/archive/docs/ko/3.1.0/cordova/contacts/parameters/contactError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/contacts/parameters/contactFields.html
+++ b/archive/docs/ko/3.1.0/cordova/contacts/parameters/contactFields.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/contacts/parameters/contactFindOptions.html
+++ b/archive/docs/ko/3.1.0/cordova/contacts/parameters/contactFindOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/contacts/parameters/contactSuccess.html
+++ b/archive/docs/ko/3.1.0/cordova/contacts/parameters/contactSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/device/device.cordova.html
+++ b/archive/docs/ko/3.1.0/cordova/device/device.cordova.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/device/device.html
+++ b/archive/docs/ko/3.1.0/cordova/device/device.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/device/device.model.html
+++ b/archive/docs/ko/3.1.0/cordova/device/device.model.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/device/device.name.html
+++ b/archive/docs/ko/3.1.0/cordova/device/device.name.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/device/device.platform.html
+++ b/archive/docs/ko/3.1.0/cordova/device/device.platform.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/device/device.uuid.html
+++ b/archive/docs/ko/3.1.0/cordova/device/device.uuid.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/device/device.version.html
+++ b/archive/docs/ko/3.1.0/cordova/device/device.version.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/events/events.backbutton.html
+++ b/archive/docs/ko/3.1.0/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/events/events.batterycritical.html
+++ b/archive/docs/ko/3.1.0/cordova/events/events.batterycritical.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/events/events.batterylow.html
+++ b/archive/docs/ko/3.1.0/cordova/events/events.batterylow.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/events/events.batterystatus.html
+++ b/archive/docs/ko/3.1.0/cordova/events/events.batterystatus.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/events/events.deviceready.html
+++ b/archive/docs/ko/3.1.0/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/events/events.endcallbutton.html
+++ b/archive/docs/ko/3.1.0/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/events/events.html
+++ b/archive/docs/ko/3.1.0/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/events/events.menubutton.html
+++ b/archive/docs/ko/3.1.0/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/events/events.offline.html
+++ b/archive/docs/ko/3.1.0/cordova/events/events.offline.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/events/events.online.html
+++ b/archive/docs/ko/3.1.0/cordova/events/events.online.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/events/events.pause.html
+++ b/archive/docs/ko/3.1.0/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/events/events.resume.html
+++ b/archive/docs/ko/3.1.0/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/events/events.searchbutton.html
+++ b/archive/docs/ko/3.1.0/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/events/events.startcallbutton.html
+++ b/archive/docs/ko/3.1.0/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/ko/3.1.0/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/ko/3.1.0/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/file/directoryentry/directoryentry.html
+++ b/archive/docs/ko/3.1.0/cordova/file/directoryentry/directoryentry.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/file/directoryreader/directoryreader.html
+++ b/archive/docs/ko/3.1.0/cordova/file/directoryreader/directoryreader.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/file/file.html
+++ b/archive/docs/ko/3.1.0/cordova/file/file.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/file/fileentry/fileentry.html
+++ b/archive/docs/ko/3.1.0/cordova/file/fileentry/fileentry.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/file/fileerror/fileerror.html
+++ b/archive/docs/ko/3.1.0/cordova/file/fileerror/fileerror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/file/fileobj/fileobj.html
+++ b/archive/docs/ko/3.1.0/cordova/file/fileobj/fileobj.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/file/filereader/filereader.html
+++ b/archive/docs/ko/3.1.0/cordova/file/filereader/filereader.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/file/filetransfer/filetransfer.html
+++ b/archive/docs/ko/3.1.0/cordova/file/filetransfer/filetransfer.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/file/filetransfererror/filetransfererror.html
+++ b/archive/docs/ko/3.1.0/cordova/file/filetransfererror/filetransfererror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/file/fileuploadoptions/fileuploadoptions.html
+++ b/archive/docs/ko/3.1.0/cordova/file/fileuploadoptions/fileuploadoptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/file/fileuploadresult/fileuploadresult.html
+++ b/archive/docs/ko/3.1.0/cordova/file/fileuploadresult/fileuploadresult.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/file/filewriter/filewriter.html
+++ b/archive/docs/ko/3.1.0/cordova/file/filewriter/filewriter.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/file/flags/flags.html
+++ b/archive/docs/ko/3.1.0/cordova/file/flags/flags.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/file/localfilesystem/localfilesystem.html
+++ b/archive/docs/ko/3.1.0/cordova/file/localfilesystem/localfilesystem.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/file/metadata/metadata.html
+++ b/archive/docs/ko/3.1.0/cordova/file/metadata/metadata.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/geolocation/Coordinates/coordinates.html
+++ b/archive/docs/ko/3.1.0/cordova/geolocation/Coordinates/coordinates.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/geolocation/Position/position.html
+++ b/archive/docs/ko/3.1.0/cordova/geolocation/Position/position.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/geolocation/PositionError/positionError.html
+++ b/archive/docs/ko/3.1.0/cordova/geolocation/PositionError/positionError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/geolocation/geolocation.clearWatch.html
+++ b/archive/docs/ko/3.1.0/cordova/geolocation/geolocation.clearWatch.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/geolocation/geolocation.getCurrentPosition.html
+++ b/archive/docs/ko/3.1.0/cordova/geolocation/geolocation.getCurrentPosition.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/geolocation/geolocation.html
+++ b/archive/docs/ko/3.1.0/cordova/geolocation/geolocation.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/geolocation/geolocation.watchPosition.html
+++ b/archive/docs/ko/3.1.0/cordova/geolocation/geolocation.watchPosition.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/geolocation/parameters/geolocation.options.html
+++ b/archive/docs/ko/3.1.0/cordova/geolocation/parameters/geolocation.options.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/geolocation/parameters/geolocationError.html
+++ b/archive/docs/ko/3.1.0/cordova/geolocation/parameters/geolocationError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/geolocation/parameters/geolocationSuccess.html
+++ b/archive/docs/ko/3.1.0/cordova/geolocation/parameters/geolocationSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/globalization/GlobalizationError/globalizationerror.html
+++ b/archive/docs/ko/3.1.0/cordova/globalization/GlobalizationError/globalizationerror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/globalization/globalization.dateToString.html
+++ b/archive/docs/ko/3.1.0/cordova/globalization/globalization.dateToString.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/globalization/globalization.getCurrencyPattern.html
+++ b/archive/docs/ko/3.1.0/cordova/globalization/globalization.getCurrencyPattern.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/globalization/globalization.getDateNames.html
+++ b/archive/docs/ko/3.1.0/cordova/globalization/globalization.getDateNames.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/globalization/globalization.getDatePattern.html
+++ b/archive/docs/ko/3.1.0/cordova/globalization/globalization.getDatePattern.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/globalization/globalization.getFirstDayOfWeek.html
+++ b/archive/docs/ko/3.1.0/cordova/globalization/globalization.getFirstDayOfWeek.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/globalization/globalization.getLocaleName.html
+++ b/archive/docs/ko/3.1.0/cordova/globalization/globalization.getLocaleName.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/globalization/globalization.getNumberPattern.html
+++ b/archive/docs/ko/3.1.0/cordova/globalization/globalization.getNumberPattern.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/globalization/globalization.getPreferredLanguage.html
+++ b/archive/docs/ko/3.1.0/cordova/globalization/globalization.getPreferredLanguage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/globalization/globalization.html
+++ b/archive/docs/ko/3.1.0/cordova/globalization/globalization.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/globalization/globalization.isDayLightSavingsTime.html
+++ b/archive/docs/ko/3.1.0/cordova/globalization/globalization.isDayLightSavingsTime.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/globalization/globalization.numberToString.html
+++ b/archive/docs/ko/3.1.0/cordova/globalization/globalization.numberToString.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/globalization/globalization.stringToDate.html
+++ b/archive/docs/ko/3.1.0/cordova/globalization/globalization.stringToDate.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/globalization/globalization.stringToNumber.html
+++ b/archive/docs/ko/3.1.0/cordova/globalization/globalization.stringToNumber.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/inappbrowser/inappbrowser.html
+++ b/archive/docs/ko/3.1.0/cordova/inappbrowser/inappbrowser.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/media/capture/CaptureErrorCB.html
+++ b/archive/docs/ko/3.1.0/cordova/media/capture/CaptureErrorCB.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/media/capture/ConfigurationData.html
+++ b/archive/docs/ko/3.1.0/cordova/media/capture/ConfigurationData.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/media/capture/MediaFile.getFormatData.html
+++ b/archive/docs/ko/3.1.0/cordova/media/capture/MediaFile.getFormatData.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/media/capture/MediaFile.html
+++ b/archive/docs/ko/3.1.0/cordova/media/capture/MediaFile.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/media/capture/MediaFileData.html
+++ b/archive/docs/ko/3.1.0/cordova/media/capture/MediaFileData.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/media/capture/capture.html
+++ b/archive/docs/ko/3.1.0/cordova/media/capture/capture.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/media/capture/captureAudio.html
+++ b/archive/docs/ko/3.1.0/cordova/media/capture/captureAudio.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/media/capture/captureAudioOptions.html
+++ b/archive/docs/ko/3.1.0/cordova/media/capture/captureAudioOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/media/capture/captureImage.html
+++ b/archive/docs/ko/3.1.0/cordova/media/capture/captureImage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/media/capture/captureImageOptions.html
+++ b/archive/docs/ko/3.1.0/cordova/media/capture/captureImageOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/media/capture/captureVideo.html
+++ b/archive/docs/ko/3.1.0/cordova/media/capture/captureVideo.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/media/capture/captureVideoOptions.html
+++ b/archive/docs/ko/3.1.0/cordova/media/capture/captureVideoOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/media/media.html
+++ b/archive/docs/ko/3.1.0/cordova/media/media.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/notification/notification.html
+++ b/archive/docs/ko/3.1.0/cordova/notification/notification.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/splashscreen/splashscreen.hide.html
+++ b/archive/docs/ko/3.1.0/cordova/splashscreen/splashscreen.hide.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/splashscreen/splashscreen.html
+++ b/archive/docs/ko/3.1.0/cordova/splashscreen/splashscreen.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/splashscreen/splashscreen.show.html
+++ b/archive/docs/ko/3.1.0/cordova/splashscreen/splashscreen.show.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/storage/database/database.html
+++ b/archive/docs/ko/3.1.0/cordova/storage/database/database.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/ko/3.1.0/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/storage/parameters/display_name.html
+++ b/archive/docs/ko/3.1.0/cordova/storage/parameters/display_name.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/storage/parameters/name.html
+++ b/archive/docs/ko/3.1.0/cordova/storage/parameters/name.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/storage/parameters/size.html
+++ b/archive/docs/ko/3.1.0/cordova/storage/parameters/size.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/storage/parameters/version.html
+++ b/archive/docs/ko/3.1.0/cordova/storage/parameters/version.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/storage/sqlerror/sqlerror.html
+++ b/archive/docs/ko/3.1.0/cordova/storage/sqlerror/sqlerror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/storage/sqlresultset/sqlresultset.html
+++ b/archive/docs/ko/3.1.0/cordova/storage/sqlresultset/sqlresultset.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/storage/sqlresultsetrowlist/sqlresultsetrowlist.html
+++ b/archive/docs/ko/3.1.0/cordova/storage/sqlresultsetrowlist/sqlresultsetrowlist.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/storage/sqltransaction/sqltransaction.html
+++ b/archive/docs/ko/3.1.0/cordova/storage/sqltransaction/sqltransaction.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/storage/storage.html
+++ b/archive/docs/ko/3.1.0/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/cordova/storage/storage.opendatabase.html
+++ b/archive/docs/ko/3.1.0/cordova/storage/storage.opendatabase.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/guide/appdev/privacy/index.html
+++ b/archive/docs/ko/3.1.0/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/guide/appdev/whitelist/index.html
+++ b/archive/docs/ko/3.1.0/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/guide/cli/index.html
+++ b/archive/docs/ko/3.1.0/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/guide/hybrid/plugins/index.html
+++ b/archive/docs/ko/3.1.0/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/guide/hybrid/webviews/index.html
+++ b/archive/docs/ko/3.1.0/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/guide/overview/index.html
+++ b/archive/docs/ko/3.1.0/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/guide/platforms/android/config.html
+++ b/archive/docs/ko/3.1.0/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/guide/platforms/android/index.html
+++ b/archive/docs/ko/3.1.0/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/guide/platforms/android/plugin.html
+++ b/archive/docs/ko/3.1.0/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/guide/platforms/android/tools.html
+++ b/archive/docs/ko/3.1.0/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/guide/platforms/android/upgrading.html
+++ b/archive/docs/ko/3.1.0/guide/platforms/android/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/guide/platforms/android/webview.html
+++ b/archive/docs/ko/3.1.0/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/guide/platforms/blackberry/index.html
+++ b/archive/docs/ko/3.1.0/guide/platforms/blackberry/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/guide/platforms/blackberry/plugin.html
+++ b/archive/docs/ko/3.1.0/guide/platforms/blackberry/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/guide/platforms/blackberry/tools.html
+++ b/archive/docs/ko/3.1.0/guide/platforms/blackberry/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/guide/platforms/blackberry10/config.html
+++ b/archive/docs/ko/3.1.0/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/guide/platforms/blackberry10/index.html
+++ b/archive/docs/ko/3.1.0/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/ko/3.1.0/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/ko/3.1.0/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/guide/platforms/blackberry10/upgrading.html
+++ b/archive/docs/ko/3.1.0/guide/platforms/blackberry10/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/guide/platforms/index.html
+++ b/archive/docs/ko/3.1.0/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/guide/platforms/ios/config.html
+++ b/archive/docs/ko/3.1.0/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/guide/platforms/ios/plugin.html
+++ b/archive/docs/ko/3.1.0/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/guide/platforms/ios/tools.html
+++ b/archive/docs/ko/3.1.0/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/guide/platforms/ios/upgrading.html
+++ b/archive/docs/ko/3.1.0/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/guide/platforms/ios/webview.html
+++ b/archive/docs/ko/3.1.0/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/guide/platforms/win8/index.html
+++ b/archive/docs/ko/3.1.0/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/guide/platforms/win8/tools.html
+++ b/archive/docs/ko/3.1.0/guide/platforms/win8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/guide/platforms/win8/upgrading.html
+++ b/archive/docs/ko/3.1.0/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/guide/platforms/wp7/index.html
+++ b/archive/docs/ko/3.1.0/guide/platforms/wp7/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/guide/platforms/wp8/index.html
+++ b/archive/docs/ko/3.1.0/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/guide/platforms/wp8/plugin.html
+++ b/archive/docs/ko/3.1.0/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/guide/platforms/wp8/tools.html
+++ b/archive/docs/ko/3.1.0/guide/platforms/wp8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/guide/platforms/wp8/upgrading.html
+++ b/archive/docs/ko/3.1.0/guide/platforms/wp8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/index.html
+++ b/archive/docs/ko/3.1.0/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.1.0/plugin_ref/spec.html
+++ b/archive/docs/ko/3.1.0/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.4.0/config_ref/images.html
+++ b/archive/docs/ko/3.4.0/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.4.0/config_ref/index.html
+++ b/archive/docs/ko/3.4.0/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.4.0/cordova/events/events.backbutton.html
+++ b/archive/docs/ko/3.4.0/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.4.0/cordova/events/events.deviceready.html
+++ b/archive/docs/ko/3.4.0/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.4.0/cordova/events/events.endcallbutton.html
+++ b/archive/docs/ko/3.4.0/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.4.0/cordova/events/events.html
+++ b/archive/docs/ko/3.4.0/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.4.0/cordova/events/events.menubutton.html
+++ b/archive/docs/ko/3.4.0/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.4.0/cordova/events/events.pause.html
+++ b/archive/docs/ko/3.4.0/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.4.0/cordova/events/events.resume.html
+++ b/archive/docs/ko/3.4.0/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.4.0/cordova/events/events.searchbutton.html
+++ b/archive/docs/ko/3.4.0/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.4.0/cordova/events/events.startcallbutton.html
+++ b/archive/docs/ko/3.4.0/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.4.0/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/ko/3.4.0/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.4.0/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/ko/3.4.0/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.4.0/cordova/plugins/pluginapis.html
+++ b/archive/docs/ko/3.4.0/cordova/plugins/pluginapis.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.4.0/cordova/storage/database/database.html
+++ b/archive/docs/ko/3.4.0/cordova/storage/database/database.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.4.0/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/ko/3.4.0/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.4.0/cordova/storage/storage.html
+++ b/archive/docs/ko/3.4.0/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.4.0/guide/appdev/privacy/index.html
+++ b/archive/docs/ko/3.4.0/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.4.0/guide/appdev/whitelist/index.html
+++ b/archive/docs/ko/3.4.0/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.4.0/guide/cli/index.html
+++ b/archive/docs/ko/3.4.0/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.4.0/guide/hybrid/plugins/index.html
+++ b/archive/docs/ko/3.4.0/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.4.0/guide/hybrid/webviews/index.html
+++ b/archive/docs/ko/3.4.0/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.4.0/guide/overview/index.html
+++ b/archive/docs/ko/3.4.0/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.4.0/guide/platforms/amazonfireos/config.html
+++ b/archive/docs/ko/3.4.0/guide/platforms/amazonfireos/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.4.0/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/ko/3.4.0/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.4.0/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/ko/3.4.0/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.4.0/guide/platforms/android/config.html
+++ b/archive/docs/ko/3.4.0/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.4.0/guide/platforms/android/plugin.html
+++ b/archive/docs/ko/3.4.0/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.4.0/guide/platforms/android/tools.html
+++ b/archive/docs/ko/3.4.0/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.4.0/guide/platforms/android/upgrading.html
+++ b/archive/docs/ko/3.4.0/guide/platforms/android/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.4.0/guide/platforms/android/webview.html
+++ b/archive/docs/ko/3.4.0/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.4.0/guide/platforms/blackberry10/config.html
+++ b/archive/docs/ko/3.4.0/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.4.0/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/ko/3.4.0/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.4.0/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/ko/3.4.0/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.4.0/guide/platforms/blackberry10/upgrading.html
+++ b/archive/docs/ko/3.4.0/guide/platforms/blackberry10/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.4.0/guide/platforms/index.html
+++ b/archive/docs/ko/3.4.0/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.4.0/guide/platforms/ios/config.html
+++ b/archive/docs/ko/3.4.0/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.4.0/guide/platforms/ios/plugin.html
+++ b/archive/docs/ko/3.4.0/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.4.0/guide/platforms/ios/tools.html
+++ b/archive/docs/ko/3.4.0/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.4.0/guide/platforms/ios/upgrading.html
+++ b/archive/docs/ko/3.4.0/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.4.0/guide/platforms/ios/webview.html
+++ b/archive/docs/ko/3.4.0/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.4.0/guide/platforms/win8/tools.html
+++ b/archive/docs/ko/3.4.0/guide/platforms/win8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.4.0/guide/platforms/win8/upgrading.html
+++ b/archive/docs/ko/3.4.0/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.4.0/guide/platforms/wp8/plugin.html
+++ b/archive/docs/ko/3.4.0/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.4.0/guide/platforms/wp8/tools.html
+++ b/archive/docs/ko/3.4.0/guide/platforms/wp8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.4.0/guide/platforms/wp8/upgrading.html
+++ b/archive/docs/ko/3.4.0/guide/platforms/wp8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.4.0/guide/support/index.html
+++ b/archive/docs/ko/3.4.0/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.4.0/index.html
+++ b/archive/docs/ko/3.4.0/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.4.0/plugin_ref/plugman.html
+++ b/archive/docs/ko/3.4.0/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.5.0/config_ref/images.html
+++ b/archive/docs/ko/3.5.0/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.5.0/config_ref/index.html
+++ b/archive/docs/ko/3.5.0/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.5.0/cordova/events/events.backbutton.html
+++ b/archive/docs/ko/3.5.0/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.5.0/cordova/events/events.deviceready.html
+++ b/archive/docs/ko/3.5.0/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.5.0/cordova/events/events.endcallbutton.html
+++ b/archive/docs/ko/3.5.0/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.5.0/cordova/events/events.html
+++ b/archive/docs/ko/3.5.0/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.5.0/cordova/events/events.menubutton.html
+++ b/archive/docs/ko/3.5.0/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.5.0/cordova/events/events.pause.html
+++ b/archive/docs/ko/3.5.0/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.5.0/cordova/events/events.resume.html
+++ b/archive/docs/ko/3.5.0/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.5.0/cordova/events/events.searchbutton.html
+++ b/archive/docs/ko/3.5.0/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.5.0/cordova/events/events.startcallbutton.html
+++ b/archive/docs/ko/3.5.0/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.5.0/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/ko/3.5.0/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.5.0/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/ko/3.5.0/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.5.0/cordova/plugins/pluginapis.html
+++ b/archive/docs/ko/3.5.0/cordova/plugins/pluginapis.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.5.0/cordova/storage/database/database.html
+++ b/archive/docs/ko/3.5.0/cordova/storage/database/database.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.5.0/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/ko/3.5.0/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.5.0/cordova/storage/storage.html
+++ b/archive/docs/ko/3.5.0/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.5.0/guide/appdev/privacy/index.html
+++ b/archive/docs/ko/3.5.0/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.5.0/guide/appdev/whitelist/index.html
+++ b/archive/docs/ko/3.5.0/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.5.0/guide/cli/index.html
+++ b/archive/docs/ko/3.5.0/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.5.0/guide/hybrid/plugins/index.html
+++ b/archive/docs/ko/3.5.0/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.5.0/guide/hybrid/webviews/index.html
+++ b/archive/docs/ko/3.5.0/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.5.0/guide/overview/index.html
+++ b/archive/docs/ko/3.5.0/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.5.0/guide/platforms/amazonfireos/config.html
+++ b/archive/docs/ko/3.5.0/guide/platforms/amazonfireos/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.5.0/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/ko/3.5.0/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.5.0/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/ko/3.5.0/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.5.0/guide/platforms/android/config.html
+++ b/archive/docs/ko/3.5.0/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.5.0/guide/platforms/android/plugin.html
+++ b/archive/docs/ko/3.5.0/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.5.0/guide/platforms/android/tools.html
+++ b/archive/docs/ko/3.5.0/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.5.0/guide/platforms/android/upgrading.html
+++ b/archive/docs/ko/3.5.0/guide/platforms/android/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.5.0/guide/platforms/android/webview.html
+++ b/archive/docs/ko/3.5.0/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.5.0/guide/platforms/blackberry10/config.html
+++ b/archive/docs/ko/3.5.0/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.5.0/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/ko/3.5.0/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.5.0/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/ko/3.5.0/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.5.0/guide/platforms/blackberry10/upgrading.html
+++ b/archive/docs/ko/3.5.0/guide/platforms/blackberry10/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.5.0/guide/platforms/index.html
+++ b/archive/docs/ko/3.5.0/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.5.0/guide/platforms/ios/config.html
+++ b/archive/docs/ko/3.5.0/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.5.0/guide/platforms/ios/plugin.html
+++ b/archive/docs/ko/3.5.0/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.5.0/guide/platforms/ios/tools.html
+++ b/archive/docs/ko/3.5.0/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.5.0/guide/platforms/ios/upgrading.html
+++ b/archive/docs/ko/3.5.0/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.5.0/guide/platforms/ios/webview.html
+++ b/archive/docs/ko/3.5.0/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.5.0/guide/platforms/win8/tools.html
+++ b/archive/docs/ko/3.5.0/guide/platforms/win8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.5.0/guide/platforms/win8/upgrading.html
+++ b/archive/docs/ko/3.5.0/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.5.0/guide/platforms/wp8/plugin.html
+++ b/archive/docs/ko/3.5.0/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.5.0/guide/platforms/wp8/tools.html
+++ b/archive/docs/ko/3.5.0/guide/platforms/wp8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.5.0/guide/platforms/wp8/upgrading.html
+++ b/archive/docs/ko/3.5.0/guide/platforms/wp8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.5.0/guide/support/index.html
+++ b/archive/docs/ko/3.5.0/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.5.0/index.html
+++ b/archive/docs/ko/3.5.0/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/3.5.0/plugin_ref/plugman.html
+++ b/archive/docs/ko/3.5.0/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/config_ref/images.html
+++ b/archive/docs/ko/5.4.0/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/config_ref/index.html
+++ b/archive/docs/ko/5.4.0/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/cordova/events/events.backbutton.html
+++ b/archive/docs/ko/5.4.0/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/cordova/events/events.deviceready.html
+++ b/archive/docs/ko/5.4.0/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/cordova/events/events.endcallbutton.html
+++ b/archive/docs/ko/5.4.0/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/cordova/events/events.html
+++ b/archive/docs/ko/5.4.0/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/cordova/events/events.menubutton.html
+++ b/archive/docs/ko/5.4.0/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/cordova/events/events.pause.html
+++ b/archive/docs/ko/5.4.0/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/cordova/events/events.resume.html
+++ b/archive/docs/ko/5.4.0/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/cordova/events/events.searchbutton.html
+++ b/archive/docs/ko/5.4.0/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/cordova/events/events.startcallbutton.html
+++ b/archive/docs/ko/5.4.0/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/ko/5.4.0/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/ko/5.4.0/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/cordova/plugins/pluginapis.html
+++ b/archive/docs/ko/5.4.0/cordova/plugins/pluginapis.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/cordova/storage/database/database.html
+++ b/archive/docs/ko/5.4.0/cordova/storage/database/database.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/ko/5.4.0/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/cordova/storage/storage.html
+++ b/archive/docs/ko/5.4.0/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/guide/appdev/hooks/index.html
+++ b/archive/docs/ko/5.4.0/guide/appdev/hooks/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/guide/appdev/privacy/index.html
+++ b/archive/docs/ko/5.4.0/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/guide/appdev/security/index.html
+++ b/archive/docs/ko/5.4.0/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/guide/appdev/whitelist/index.html
+++ b/archive/docs/ko/5.4.0/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/guide/cli/index.html
+++ b/archive/docs/ko/5.4.0/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/guide/hybrid/plugins/index.html
+++ b/archive/docs/ko/5.4.0/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/guide/hybrid/webviews/index.html
+++ b/archive/docs/ko/5.4.0/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/guide/next/index.html
+++ b/archive/docs/ko/5.4.0/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/guide/overview/index.html
+++ b/archive/docs/ko/5.4.0/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/guide/platforms/amazonfireos/config.html
+++ b/archive/docs/ko/5.4.0/guide/platforms/amazonfireos/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/guide/platforms/amazonfireos/index.html
+++ b/archive/docs/ko/5.4.0/guide/platforms/amazonfireos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/ko/5.4.0/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/ko/5.4.0/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/guide/platforms/android/config.html
+++ b/archive/docs/ko/5.4.0/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/guide/platforms/android/index.html
+++ b/archive/docs/ko/5.4.0/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/guide/platforms/android/plugin.html
+++ b/archive/docs/ko/5.4.0/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/guide/platforms/android/tools.html
+++ b/archive/docs/ko/5.4.0/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/guide/platforms/android/upgrading.html
+++ b/archive/docs/ko/5.4.0/guide/platforms/android/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/guide/platforms/android/webview.html
+++ b/archive/docs/ko/5.4.0/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/guide/platforms/blackberry10/config.html
+++ b/archive/docs/ko/5.4.0/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/guide/platforms/blackberry10/index.html
+++ b/archive/docs/ko/5.4.0/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/ko/5.4.0/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/ko/5.4.0/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/guide/platforms/blackberry10/upgrading.html
+++ b/archive/docs/ko/5.4.0/guide/platforms/blackberry10/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/guide/platforms/firefoxos/index.html
+++ b/archive/docs/ko/5.4.0/guide/platforms/firefoxos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/guide/platforms/index.html
+++ b/archive/docs/ko/5.4.0/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/guide/platforms/ios/config.html
+++ b/archive/docs/ko/5.4.0/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/guide/platforms/ios/plugin.html
+++ b/archive/docs/ko/5.4.0/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/guide/platforms/ios/upgrading.html
+++ b/archive/docs/ko/5.4.0/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/guide/platforms/ios/webview.html
+++ b/archive/docs/ko/5.4.0/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/guide/platforms/ubuntu/index.html
+++ b/archive/docs/ko/5.4.0/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/guide/platforms/win8/index.html
+++ b/archive/docs/ko/5.4.0/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/guide/platforms/win8/packaging.html
+++ b/archive/docs/ko/5.4.0/guide/platforms/win8/packaging.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/guide/platforms/win8/plugin.html
+++ b/archive/docs/ko/5.4.0/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/guide/platforms/win8/upgrading.html
+++ b/archive/docs/ko/5.4.0/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/guide/platforms/win8/win10-support.html
+++ b/archive/docs/ko/5.4.0/guide/platforms/win8/win10-support.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/guide/platforms/wp8/index.html
+++ b/archive/docs/ko/5.4.0/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/guide/platforms/wp8/plugin.html
+++ b/archive/docs/ko/5.4.0/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/ko/5.4.0/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/guide/platforms/wp8/webview.html
+++ b/archive/docs/ko/5.4.0/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/guide/support/index.html
+++ b/archive/docs/ko/5.4.0/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/index.html
+++ b/archive/docs/ko/5.4.0/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/ko/5.4.0/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/plugin_ref/plugman.html
+++ b/archive/docs/ko/5.4.0/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/5.4.0/plugin_ref/spec.html
+++ b/archive/docs/ko/5.4.0/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/config_ref/images.html
+++ b/archive/docs/ko/6.x/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/config_ref/index.html
+++ b/archive/docs/ko/6.x/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/cordova/events/events.backbutton.html
+++ b/archive/docs/ko/6.x/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/cordova/events/events.deviceready.html
+++ b/archive/docs/ko/6.x/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/cordova/events/events.endcallbutton.html
+++ b/archive/docs/ko/6.x/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/cordova/events/events.html
+++ b/archive/docs/ko/6.x/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/cordova/events/events.menubutton.html
+++ b/archive/docs/ko/6.x/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/cordova/events/events.pause.html
+++ b/archive/docs/ko/6.x/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/cordova/events/events.resume.html
+++ b/archive/docs/ko/6.x/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/cordova/events/events.searchbutton.html
+++ b/archive/docs/ko/6.x/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/cordova/events/events.startcallbutton.html
+++ b/archive/docs/ko/6.x/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/ko/6.x/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/ko/6.x/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/cordova/storage/database/database.html
+++ b/archive/docs/ko/6.x/cordova/storage/database/database.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/ko/6.x/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/cordova/storage/storage.html
+++ b/archive/docs/ko/6.x/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/guide/appdev/hooks/index.html
+++ b/archive/docs/ko/6.x/guide/appdev/hooks/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/guide/appdev/privacy/index.html
+++ b/archive/docs/ko/6.x/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/guide/appdev/security/index.html
+++ b/archive/docs/ko/6.x/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/guide/appdev/whitelist/index.html
+++ b/archive/docs/ko/6.x/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/guide/cli/index.html
+++ b/archive/docs/ko/6.x/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/guide/hybrid/plugins/index.html
+++ b/archive/docs/ko/6.x/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/guide/hybrid/webviews/index.html
+++ b/archive/docs/ko/6.x/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/guide/next/index.html
+++ b/archive/docs/ko/6.x/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/guide/overview/index.html
+++ b/archive/docs/ko/6.x/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/guide/platforms/amazonfireos/config.html
+++ b/archive/docs/ko/6.x/guide/platforms/amazonfireos/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/guide/platforms/amazonfireos/index.html
+++ b/archive/docs/ko/6.x/guide/platforms/amazonfireos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/ko/6.x/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/ko/6.x/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/guide/platforms/android/config.html
+++ b/archive/docs/ko/6.x/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/guide/platforms/android/index.html
+++ b/archive/docs/ko/6.x/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/guide/platforms/android/plugin.html
+++ b/archive/docs/ko/6.x/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/guide/platforms/android/tools.html
+++ b/archive/docs/ko/6.x/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/guide/platforms/android/upgrading.html
+++ b/archive/docs/ko/6.x/guide/platforms/android/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/guide/platforms/android/webview.html
+++ b/archive/docs/ko/6.x/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/guide/platforms/blackberry10/config.html
+++ b/archive/docs/ko/6.x/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/guide/platforms/blackberry10/home.html
+++ b/archive/docs/ko/6.x/guide/platforms/blackberry10/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/guide/platforms/blackberry10/index.html
+++ b/archive/docs/ko/6.x/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/ko/6.x/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/ko/6.x/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/guide/platforms/blackberry10/upgrade.html
+++ b/archive/docs/ko/6.x/guide/platforms/blackberry10/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/guide/platforms/blackberry10/upgrading.html
+++ b/archive/docs/ko/6.x/guide/platforms/blackberry10/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/guide/platforms/firefoxos/index.html
+++ b/archive/docs/ko/6.x/guide/platforms/firefoxos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/guide/platforms/index.html
+++ b/archive/docs/ko/6.x/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/guide/platforms/ios/config.html
+++ b/archive/docs/ko/6.x/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/guide/platforms/ios/index.html
+++ b/archive/docs/ko/6.x/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/guide/platforms/ios/plugin.html
+++ b/archive/docs/ko/6.x/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/guide/platforms/ios/upgrading.html
+++ b/archive/docs/ko/6.x/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/guide/platforms/ios/webview.html
+++ b/archive/docs/ko/6.x/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/guide/platforms/ubuntu/index.html
+++ b/archive/docs/ko/6.x/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/guide/platforms/win8/index.html
+++ b/archive/docs/ko/6.x/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/guide/platforms/win8/packaging.html
+++ b/archive/docs/ko/6.x/guide/platforms/win8/packaging.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/guide/platforms/win8/plugin.html
+++ b/archive/docs/ko/6.x/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/guide/platforms/win8/upgrading.html
+++ b/archive/docs/ko/6.x/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/guide/platforms/win8/win10-support.html
+++ b/archive/docs/ko/6.x/guide/platforms/win8/win10-support.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/guide/platforms/wp8/home.html
+++ b/archive/docs/ko/6.x/guide/platforms/wp8/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/guide/platforms/wp8/index.html
+++ b/archive/docs/ko/6.x/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/guide/platforms/wp8/plugin.html
+++ b/archive/docs/ko/6.x/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/ko/6.x/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/guide/platforms/wp8/webview.html
+++ b/archive/docs/ko/6.x/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/guide/support/index.html
+++ b/archive/docs/ko/6.x/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/index.html
+++ b/archive/docs/ko/6.x/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/ko/6.x/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/plugin_ref/plugman.html
+++ b/archive/docs/ko/6.x/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/6.x/plugin_ref/spec.html
+++ b/archive/docs/ko/6.x/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/config_ref/images.html
+++ b/archive/docs/ko/7.x/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/config_ref/index.html
+++ b/archive/docs/ko/7.x/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/cordova/events/events.backbutton.html
+++ b/archive/docs/ko/7.x/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/cordova/events/events.deviceready.html
+++ b/archive/docs/ko/7.x/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/cordova/events/events.endcallbutton.html
+++ b/archive/docs/ko/7.x/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/cordova/events/events.html
+++ b/archive/docs/ko/7.x/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/cordova/events/events.menubutton.html
+++ b/archive/docs/ko/7.x/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/cordova/events/events.pause.html
+++ b/archive/docs/ko/7.x/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/cordova/events/events.resume.html
+++ b/archive/docs/ko/7.x/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/cordova/events/events.searchbutton.html
+++ b/archive/docs/ko/7.x/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/cordova/events/events.startcallbutton.html
+++ b/archive/docs/ko/7.x/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/ko/7.x/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/ko/7.x/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/cordova/storage/database/database.html
+++ b/archive/docs/ko/7.x/cordova/storage/database/database.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/ko/7.x/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/cordova/storage/storage.html
+++ b/archive/docs/ko/7.x/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/guide/appdev/hooks/index.html
+++ b/archive/docs/ko/7.x/guide/appdev/hooks/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/guide/appdev/privacy/index.html
+++ b/archive/docs/ko/7.x/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/guide/appdev/security/index.html
+++ b/archive/docs/ko/7.x/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/guide/appdev/whitelist/index.html
+++ b/archive/docs/ko/7.x/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/guide/cli/index.html
+++ b/archive/docs/ko/7.x/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/guide/hybrid/plugins/index.html
+++ b/archive/docs/ko/7.x/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/guide/hybrid/webviews/index.html
+++ b/archive/docs/ko/7.x/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/guide/next/index.html
+++ b/archive/docs/ko/7.x/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/guide/overview/index.html
+++ b/archive/docs/ko/7.x/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/guide/platforms/amazonfireos/config.html
+++ b/archive/docs/ko/7.x/guide/platforms/amazonfireos/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/guide/platforms/amazonfireos/index.html
+++ b/archive/docs/ko/7.x/guide/platforms/amazonfireos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/ko/7.x/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/ko/7.x/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/guide/platforms/android/config.html
+++ b/archive/docs/ko/7.x/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/guide/platforms/android/index.html
+++ b/archive/docs/ko/7.x/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/guide/platforms/android/plugin.html
+++ b/archive/docs/ko/7.x/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/guide/platforms/android/tools.html
+++ b/archive/docs/ko/7.x/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/guide/platforms/android/upgrading.html
+++ b/archive/docs/ko/7.x/guide/platforms/android/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/guide/platforms/android/webview.html
+++ b/archive/docs/ko/7.x/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/guide/platforms/blackberry10/config.html
+++ b/archive/docs/ko/7.x/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/guide/platforms/blackberry10/home.html
+++ b/archive/docs/ko/7.x/guide/platforms/blackberry10/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/guide/platforms/blackberry10/index.html
+++ b/archive/docs/ko/7.x/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/ko/7.x/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/ko/7.x/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/guide/platforms/blackberry10/upgrade.html
+++ b/archive/docs/ko/7.x/guide/platforms/blackberry10/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/guide/platforms/blackberry10/upgrading.html
+++ b/archive/docs/ko/7.x/guide/platforms/blackberry10/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/guide/platforms/firefoxos/index.html
+++ b/archive/docs/ko/7.x/guide/platforms/firefoxos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/guide/platforms/index.html
+++ b/archive/docs/ko/7.x/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/guide/platforms/ios/config.html
+++ b/archive/docs/ko/7.x/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/guide/platforms/ios/index.html
+++ b/archive/docs/ko/7.x/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/guide/platforms/ios/plugin.html
+++ b/archive/docs/ko/7.x/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/guide/platforms/ios/upgrading.html
+++ b/archive/docs/ko/7.x/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/guide/platforms/ios/webview.html
+++ b/archive/docs/ko/7.x/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/guide/platforms/ubuntu/index.html
+++ b/archive/docs/ko/7.x/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/guide/platforms/win8/index.html
+++ b/archive/docs/ko/7.x/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/guide/platforms/win8/packaging.html
+++ b/archive/docs/ko/7.x/guide/platforms/win8/packaging.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/guide/platforms/win8/plugin.html
+++ b/archive/docs/ko/7.x/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/guide/platforms/win8/upgrading.html
+++ b/archive/docs/ko/7.x/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/guide/platforms/win8/win10-support.html
+++ b/archive/docs/ko/7.x/guide/platforms/win8/win10-support.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/guide/platforms/wp8/home.html
+++ b/archive/docs/ko/7.x/guide/platforms/wp8/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/guide/platforms/wp8/index.html
+++ b/archive/docs/ko/7.x/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/guide/platforms/wp8/plugin.html
+++ b/archive/docs/ko/7.x/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/ko/7.x/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/guide/platforms/wp8/webview.html
+++ b/archive/docs/ko/7.x/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/guide/support/index.html
+++ b/archive/docs/ko/7.x/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/index.html
+++ b/archive/docs/ko/7.x/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/ko/7.x/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/plugin_ref/plugman.html
+++ b/archive/docs/ko/7.x/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/7.x/plugin_ref/spec.html
+++ b/archive/docs/ko/7.x/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/config_ref/images.html
+++ b/archive/docs/ko/8.x/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/config_ref/index.html
+++ b/archive/docs/ko/8.x/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/cordova/events/events.backbutton.html
+++ b/archive/docs/ko/8.x/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/cordova/events/events.deviceready.html
+++ b/archive/docs/ko/8.x/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/cordova/events/events.endcallbutton.html
+++ b/archive/docs/ko/8.x/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/cordova/events/events.html
+++ b/archive/docs/ko/8.x/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/cordova/events/events.menubutton.html
+++ b/archive/docs/ko/8.x/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/cordova/events/events.pause.html
+++ b/archive/docs/ko/8.x/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/cordova/events/events.resume.html
+++ b/archive/docs/ko/8.x/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/cordova/events/events.searchbutton.html
+++ b/archive/docs/ko/8.x/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/cordova/events/events.startcallbutton.html
+++ b/archive/docs/ko/8.x/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/ko/8.x/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/ko/8.x/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/cordova/storage/database/database.html
+++ b/archive/docs/ko/8.x/cordova/storage/database/database.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/ko/8.x/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/cordova/storage/storage.html
+++ b/archive/docs/ko/8.x/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/guide/appdev/hooks/index.html
+++ b/archive/docs/ko/8.x/guide/appdev/hooks/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/guide/appdev/privacy/index.html
+++ b/archive/docs/ko/8.x/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/guide/appdev/security/index.html
+++ b/archive/docs/ko/8.x/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/guide/appdev/whitelist/index.html
+++ b/archive/docs/ko/8.x/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/guide/cli/index.html
+++ b/archive/docs/ko/8.x/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/guide/hybrid/plugins/index.html
+++ b/archive/docs/ko/8.x/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/guide/hybrid/webviews/index.html
+++ b/archive/docs/ko/8.x/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/guide/next/index.html
+++ b/archive/docs/ko/8.x/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/guide/overview/index.html
+++ b/archive/docs/ko/8.x/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/guide/platforms/amazonfireos/config.html
+++ b/archive/docs/ko/8.x/guide/platforms/amazonfireos/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/guide/platforms/amazonfireos/index.html
+++ b/archive/docs/ko/8.x/guide/platforms/amazonfireos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/ko/8.x/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/ko/8.x/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/guide/platforms/android/config.html
+++ b/archive/docs/ko/8.x/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/guide/platforms/android/index.html
+++ b/archive/docs/ko/8.x/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/guide/platforms/android/plugin.html
+++ b/archive/docs/ko/8.x/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/guide/platforms/android/tools.html
+++ b/archive/docs/ko/8.x/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/guide/platforms/android/upgrading.html
+++ b/archive/docs/ko/8.x/guide/platforms/android/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/guide/platforms/android/webview.html
+++ b/archive/docs/ko/8.x/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/guide/platforms/blackberry10/config.html
+++ b/archive/docs/ko/8.x/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/guide/platforms/blackberry10/home.html
+++ b/archive/docs/ko/8.x/guide/platforms/blackberry10/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/guide/platforms/blackberry10/index.html
+++ b/archive/docs/ko/8.x/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/ko/8.x/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/ko/8.x/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/guide/platforms/blackberry10/upgrade.html
+++ b/archive/docs/ko/8.x/guide/platforms/blackberry10/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/guide/platforms/blackberry10/upgrading.html
+++ b/archive/docs/ko/8.x/guide/platforms/blackberry10/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/guide/platforms/firefoxos/index.html
+++ b/archive/docs/ko/8.x/guide/platforms/firefoxos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/guide/platforms/index.html
+++ b/archive/docs/ko/8.x/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/guide/platforms/ios/config.html
+++ b/archive/docs/ko/8.x/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/guide/platforms/ios/index.html
+++ b/archive/docs/ko/8.x/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/guide/platforms/ios/plugin.html
+++ b/archive/docs/ko/8.x/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/guide/platforms/ios/upgrading.html
+++ b/archive/docs/ko/8.x/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/guide/platforms/ios/webview.html
+++ b/archive/docs/ko/8.x/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/guide/platforms/ubuntu/index.html
+++ b/archive/docs/ko/8.x/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/guide/platforms/win8/index.html
+++ b/archive/docs/ko/8.x/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/guide/platforms/win8/packaging.html
+++ b/archive/docs/ko/8.x/guide/platforms/win8/packaging.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/guide/platforms/win8/plugin.html
+++ b/archive/docs/ko/8.x/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/guide/platforms/win8/upgrading.html
+++ b/archive/docs/ko/8.x/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/guide/platforms/win8/win10-support.html
+++ b/archive/docs/ko/8.x/guide/platforms/win8/win10-support.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/guide/platforms/wp8/home.html
+++ b/archive/docs/ko/8.x/guide/platforms/wp8/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/guide/platforms/wp8/index.html
+++ b/archive/docs/ko/8.x/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/guide/platforms/wp8/plugin.html
+++ b/archive/docs/ko/8.x/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/ko/8.x/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/guide/platforms/wp8/webview.html
+++ b/archive/docs/ko/8.x/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/guide/support/index.html
+++ b/archive/docs/ko/8.x/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/index.html
+++ b/archive/docs/ko/8.x/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/ko/8.x/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/plugin_ref/plugman.html
+++ b/archive/docs/ko/8.x/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/8.x/plugin_ref/spec.html
+++ b/archive/docs/ko/8.x/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/9.x/guide/cli/index.html
+++ b/archive/docs/ko/9.x/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="/static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="/static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/9.x/guide/overview/index.html
+++ b/archive/docs/ko/9.x/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="/static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="/static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/9.x/guide/platforms/android/index.html
+++ b/archive/docs/ko/9.x/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="/static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="/static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/9.x/guide/platforms/blackberry10/home.html
+++ b/archive/docs/ko/9.x/guide/platforms/blackberry10/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="/static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="/static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/9.x/guide/platforms/ios/index.html
+++ b/archive/docs/ko/9.x/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="/static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="/static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/9.x/guide/platforms/ubuntu/index.html
+++ b/archive/docs/ko/9.x/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="/static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="/static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/9.x/guide/support/index.html
+++ b/archive/docs/ko/9.x/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="/static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="/static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ko/9.x/index.html
+++ b/archive/docs/ko/9.x/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="/static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="/static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/config_ref/images.html
+++ b/archive/docs/pl/10.x/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/config_ref/index.html
+++ b/archive/docs/pl/10.x/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/cordova/events/events.backbutton.html
+++ b/archive/docs/pl/10.x/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/cordova/events/events.deviceready.html
+++ b/archive/docs/pl/10.x/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/cordova/events/events.endcallbutton.html
+++ b/archive/docs/pl/10.x/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/cordova/events/events.html
+++ b/archive/docs/pl/10.x/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/cordova/events/events.menubutton.html
+++ b/archive/docs/pl/10.x/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/cordova/events/events.pause.html
+++ b/archive/docs/pl/10.x/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/cordova/events/events.resume.html
+++ b/archive/docs/pl/10.x/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/cordova/events/events.searchbutton.html
+++ b/archive/docs/pl/10.x/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/cordova/events/events.startcallbutton.html
+++ b/archive/docs/pl/10.x/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/pl/10.x/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/pl/10.x/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/cordova/storage/storage.html
+++ b/archive/docs/pl/10.x/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/guide/appdev/hooks/index.html
+++ b/archive/docs/pl/10.x/guide/appdev/hooks/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/guide/appdev/privacy/index.html
+++ b/archive/docs/pl/10.x/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/guide/appdev/security/index.html
+++ b/archive/docs/pl/10.x/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/guide/appdev/whitelist/index.html
+++ b/archive/docs/pl/10.x/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/guide/cli/index.html
+++ b/archive/docs/pl/10.x/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/guide/hybrid/plugins/index.html
+++ b/archive/docs/pl/10.x/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/guide/hybrid/webviews/index.html
+++ b/archive/docs/pl/10.x/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/guide/next/index.html
+++ b/archive/docs/pl/10.x/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/guide/overview/index.html
+++ b/archive/docs/pl/10.x/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/pl/10.x/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/pl/10.x/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/guide/platforms/android/config.html
+++ b/archive/docs/pl/10.x/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/guide/platforms/android/index.html
+++ b/archive/docs/pl/10.x/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/guide/platforms/android/plugin.html
+++ b/archive/docs/pl/10.x/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/guide/platforms/android/upgrade.html
+++ b/archive/docs/pl/10.x/guide/platforms/android/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/guide/platforms/android/webview.html
+++ b/archive/docs/pl/10.x/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/guide/platforms/blackberry10/config.html
+++ b/archive/docs/pl/10.x/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/guide/platforms/blackberry10/home.html
+++ b/archive/docs/pl/10.x/guide/platforms/blackberry10/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/guide/platforms/blackberry10/index.html
+++ b/archive/docs/pl/10.x/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/pl/10.x/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/pl/10.x/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/guide/platforms/blackberry10/upgrade.html
+++ b/archive/docs/pl/10.x/guide/platforms/blackberry10/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/guide/platforms/ios/config.html
+++ b/archive/docs/pl/10.x/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/guide/platforms/ios/index.html
+++ b/archive/docs/pl/10.x/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/guide/platforms/ios/plugin.html
+++ b/archive/docs/pl/10.x/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/guide/platforms/ios/tools.html
+++ b/archive/docs/pl/10.x/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/guide/platforms/ios/upgrade.html
+++ b/archive/docs/pl/10.x/guide/platforms/ios/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/guide/platforms/ios/webview.html
+++ b/archive/docs/pl/10.x/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/guide/platforms/ubuntu/index.html
+++ b/archive/docs/pl/10.x/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/guide/platforms/win8/index.html
+++ b/archive/docs/pl/10.x/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/guide/platforms/win8/plugin.html
+++ b/archive/docs/pl/10.x/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/guide/platforms/wp8/home.html
+++ b/archive/docs/pl/10.x/guide/platforms/wp8/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/guide/platforms/wp8/index.html
+++ b/archive/docs/pl/10.x/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/guide/platforms/wp8/parallels.html
+++ b/archive/docs/pl/10.x/guide/platforms/wp8/parallels.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/guide/platforms/wp8/plugin.html
+++ b/archive/docs/pl/10.x/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/pl/10.x/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/guide/platforms/wp8/vmware.html
+++ b/archive/docs/pl/10.x/guide/platforms/wp8/vmware.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/guide/platforms/wp8/webview.html
+++ b/archive/docs/pl/10.x/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/guide/support/index.html
+++ b/archive/docs/pl/10.x/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/index.html
+++ b/archive/docs/pl/10.x/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/pl/10.x/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/plugin_ref/plugman.html
+++ b/archive/docs/pl/10.x/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/10.x/plugin_ref/spec.html
+++ b/archive/docs/pl/10.x/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/config_ref/images.html
+++ b/archive/docs/pl/5.4.0/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/config_ref/index.html
+++ b/archive/docs/pl/5.4.0/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/cordova/events/events.backbutton.html
+++ b/archive/docs/pl/5.4.0/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/cordova/events/events.deviceready.html
+++ b/archive/docs/pl/5.4.0/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/cordova/events/events.endcallbutton.html
+++ b/archive/docs/pl/5.4.0/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/cordova/events/events.html
+++ b/archive/docs/pl/5.4.0/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/cordova/events/events.menubutton.html
+++ b/archive/docs/pl/5.4.0/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/cordova/events/events.pause.html
+++ b/archive/docs/pl/5.4.0/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/cordova/events/events.resume.html
+++ b/archive/docs/pl/5.4.0/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/cordova/events/events.searchbutton.html
+++ b/archive/docs/pl/5.4.0/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/cordova/events/events.startcallbutton.html
+++ b/archive/docs/pl/5.4.0/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/pl/5.4.0/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/pl/5.4.0/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/cordova/plugins/pluginapis.html
+++ b/archive/docs/pl/5.4.0/cordova/plugins/pluginapis.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/cordova/storage/storage.html
+++ b/archive/docs/pl/5.4.0/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/guide/appdev/privacy/index.html
+++ b/archive/docs/pl/5.4.0/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/guide/appdev/security/index.html
+++ b/archive/docs/pl/5.4.0/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/guide/appdev/whitelist/index.html
+++ b/archive/docs/pl/5.4.0/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/guide/cli/index.html
+++ b/archive/docs/pl/5.4.0/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/guide/hybrid/plugins/index.html
+++ b/archive/docs/pl/5.4.0/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/guide/hybrid/webviews/index.html
+++ b/archive/docs/pl/5.4.0/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/guide/next/index.html
+++ b/archive/docs/pl/5.4.0/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/guide/overview/index.html
+++ b/archive/docs/pl/5.4.0/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/guide/platforms/amazonfireos/config.html
+++ b/archive/docs/pl/5.4.0/guide/platforms/amazonfireos/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/guide/platforms/amazonfireos/index.html
+++ b/archive/docs/pl/5.4.0/guide/platforms/amazonfireos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/pl/5.4.0/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/pl/5.4.0/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/guide/platforms/android/config.html
+++ b/archive/docs/pl/5.4.0/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/guide/platforms/android/index.html
+++ b/archive/docs/pl/5.4.0/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/guide/platforms/android/tools.html
+++ b/archive/docs/pl/5.4.0/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/guide/platforms/android/upgrade.html
+++ b/archive/docs/pl/5.4.0/guide/platforms/android/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/guide/platforms/blackberry10/config.html
+++ b/archive/docs/pl/5.4.0/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/guide/platforms/blackberry10/index.html
+++ b/archive/docs/pl/5.4.0/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/pl/5.4.0/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/pl/5.4.0/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/guide/platforms/blackberry10/upgrade.html
+++ b/archive/docs/pl/5.4.0/guide/platforms/blackberry10/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/guide/platforms/firefoxos/index.html
+++ b/archive/docs/pl/5.4.0/guide/platforms/firefoxos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/guide/platforms/index.html
+++ b/archive/docs/pl/5.4.0/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/guide/platforms/ios/config.html
+++ b/archive/docs/pl/5.4.0/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/guide/platforms/ios/index.html
+++ b/archive/docs/pl/5.4.0/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/guide/platforms/ios/plugin.html
+++ b/archive/docs/pl/5.4.0/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/guide/platforms/ios/tools.html
+++ b/archive/docs/pl/5.4.0/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/guide/platforms/ios/upgrade.html
+++ b/archive/docs/pl/5.4.0/guide/platforms/ios/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/guide/platforms/ios/webview.html
+++ b/archive/docs/pl/5.4.0/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/guide/platforms/tizen/index.html
+++ b/archive/docs/pl/5.4.0/guide/platforms/tizen/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/guide/platforms/ubuntu/index.html
+++ b/archive/docs/pl/5.4.0/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/guide/platforms/win8/index.html
+++ b/archive/docs/pl/5.4.0/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/guide/platforms/win8/packaging.html
+++ b/archive/docs/pl/5.4.0/guide/platforms/win8/packaging.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/guide/platforms/win8/plugin.html
+++ b/archive/docs/pl/5.4.0/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/guide/platforms/win8/upgrade.html
+++ b/archive/docs/pl/5.4.0/guide/platforms/win8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/guide/platforms/wp8/index.html
+++ b/archive/docs/pl/5.4.0/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/guide/platforms/wp8/parallels.html
+++ b/archive/docs/pl/5.4.0/guide/platforms/wp8/parallels.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/guide/platforms/wp8/plugin.html
+++ b/archive/docs/pl/5.4.0/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/guide/platforms/wp8/vmware.html
+++ b/archive/docs/pl/5.4.0/guide/platforms/wp8/vmware.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/guide/platforms/wp8/webview.html
+++ b/archive/docs/pl/5.4.0/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/index.html
+++ b/archive/docs/pl/5.4.0/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/pl/5.4.0/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/plugin_ref/plugman.html
+++ b/archive/docs/pl/5.4.0/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/5.4.0/plugin_ref/spec.html
+++ b/archive/docs/pl/5.4.0/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/config_ref/images.html
+++ b/archive/docs/pl/6.x/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/config_ref/index.html
+++ b/archive/docs/pl/6.x/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/cordova/events/events.backbutton.html
+++ b/archive/docs/pl/6.x/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/cordova/events/events.deviceready.html
+++ b/archive/docs/pl/6.x/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/cordova/events/events.endcallbutton.html
+++ b/archive/docs/pl/6.x/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/cordova/events/events.html
+++ b/archive/docs/pl/6.x/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/cordova/events/events.menubutton.html
+++ b/archive/docs/pl/6.x/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/cordova/events/events.pause.html
+++ b/archive/docs/pl/6.x/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/cordova/events/events.resume.html
+++ b/archive/docs/pl/6.x/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/cordova/events/events.searchbutton.html
+++ b/archive/docs/pl/6.x/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/cordova/events/events.startcallbutton.html
+++ b/archive/docs/pl/6.x/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/pl/6.x/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/pl/6.x/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/cordova/storage/storage.html
+++ b/archive/docs/pl/6.x/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/guide/appdev/hooks/index.html
+++ b/archive/docs/pl/6.x/guide/appdev/hooks/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/guide/appdev/privacy/index.html
+++ b/archive/docs/pl/6.x/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/guide/appdev/security/index.html
+++ b/archive/docs/pl/6.x/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/guide/appdev/whitelist/index.html
+++ b/archive/docs/pl/6.x/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/guide/cli/index.html
+++ b/archive/docs/pl/6.x/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/guide/hybrid/plugins/index.html
+++ b/archive/docs/pl/6.x/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/guide/hybrid/webviews/index.html
+++ b/archive/docs/pl/6.x/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/guide/next/index.html
+++ b/archive/docs/pl/6.x/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/guide/overview/index.html
+++ b/archive/docs/pl/6.x/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/pl/6.x/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/pl/6.x/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/guide/platforms/android/config.html
+++ b/archive/docs/pl/6.x/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/guide/platforms/android/index.html
+++ b/archive/docs/pl/6.x/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/guide/platforms/android/plugin.html
+++ b/archive/docs/pl/6.x/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/guide/platforms/android/upgrade.html
+++ b/archive/docs/pl/6.x/guide/platforms/android/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/guide/platforms/android/webview.html
+++ b/archive/docs/pl/6.x/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/guide/platforms/blackberry10/config.html
+++ b/archive/docs/pl/6.x/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/guide/platforms/blackberry10/home.html
+++ b/archive/docs/pl/6.x/guide/platforms/blackberry10/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/guide/platforms/blackberry10/index.html
+++ b/archive/docs/pl/6.x/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/pl/6.x/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/pl/6.x/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/guide/platforms/blackberry10/upgrade.html
+++ b/archive/docs/pl/6.x/guide/platforms/blackberry10/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/guide/platforms/ios/config.html
+++ b/archive/docs/pl/6.x/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/guide/platforms/ios/index.html
+++ b/archive/docs/pl/6.x/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/guide/platforms/ios/plugin.html
+++ b/archive/docs/pl/6.x/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/guide/platforms/ios/tools.html
+++ b/archive/docs/pl/6.x/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/guide/platforms/ios/upgrade.html
+++ b/archive/docs/pl/6.x/guide/platforms/ios/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/guide/platforms/ios/webview.html
+++ b/archive/docs/pl/6.x/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/guide/platforms/ubuntu/index.html
+++ b/archive/docs/pl/6.x/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/guide/platforms/win8/index.html
+++ b/archive/docs/pl/6.x/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/guide/platforms/win8/plugin.html
+++ b/archive/docs/pl/6.x/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/guide/platforms/wp8/home.html
+++ b/archive/docs/pl/6.x/guide/platforms/wp8/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/guide/platforms/wp8/index.html
+++ b/archive/docs/pl/6.x/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/guide/platforms/wp8/parallels.html
+++ b/archive/docs/pl/6.x/guide/platforms/wp8/parallels.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/guide/platforms/wp8/plugin.html
+++ b/archive/docs/pl/6.x/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/pl/6.x/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/guide/platforms/wp8/vmware.html
+++ b/archive/docs/pl/6.x/guide/platforms/wp8/vmware.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/guide/platforms/wp8/webview.html
+++ b/archive/docs/pl/6.x/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/guide/support/index.html
+++ b/archive/docs/pl/6.x/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/index.html
+++ b/archive/docs/pl/6.x/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/pl/6.x/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/plugin_ref/plugman.html
+++ b/archive/docs/pl/6.x/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/6.x/plugin_ref/spec.html
+++ b/archive/docs/pl/6.x/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/config_ref/images.html
+++ b/archive/docs/pl/7.x/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/config_ref/index.html
+++ b/archive/docs/pl/7.x/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/cordova/events/events.backbutton.html
+++ b/archive/docs/pl/7.x/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/cordova/events/events.deviceready.html
+++ b/archive/docs/pl/7.x/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/cordova/events/events.endcallbutton.html
+++ b/archive/docs/pl/7.x/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/cordova/events/events.html
+++ b/archive/docs/pl/7.x/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/cordova/events/events.menubutton.html
+++ b/archive/docs/pl/7.x/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/cordova/events/events.pause.html
+++ b/archive/docs/pl/7.x/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/cordova/events/events.resume.html
+++ b/archive/docs/pl/7.x/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/cordova/events/events.searchbutton.html
+++ b/archive/docs/pl/7.x/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/cordova/events/events.startcallbutton.html
+++ b/archive/docs/pl/7.x/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/pl/7.x/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/pl/7.x/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/cordova/storage/storage.html
+++ b/archive/docs/pl/7.x/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/guide/appdev/hooks/index.html
+++ b/archive/docs/pl/7.x/guide/appdev/hooks/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/guide/appdev/privacy/index.html
+++ b/archive/docs/pl/7.x/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/guide/appdev/security/index.html
+++ b/archive/docs/pl/7.x/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/guide/appdev/whitelist/index.html
+++ b/archive/docs/pl/7.x/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/guide/cli/index.html
+++ b/archive/docs/pl/7.x/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/guide/hybrid/plugins/index.html
+++ b/archive/docs/pl/7.x/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/guide/hybrid/webviews/index.html
+++ b/archive/docs/pl/7.x/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/guide/next/index.html
+++ b/archive/docs/pl/7.x/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/guide/overview/index.html
+++ b/archive/docs/pl/7.x/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/pl/7.x/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/pl/7.x/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/guide/platforms/android/config.html
+++ b/archive/docs/pl/7.x/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/guide/platforms/android/index.html
+++ b/archive/docs/pl/7.x/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/guide/platforms/android/plugin.html
+++ b/archive/docs/pl/7.x/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/guide/platforms/android/upgrade.html
+++ b/archive/docs/pl/7.x/guide/platforms/android/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/guide/platforms/android/webview.html
+++ b/archive/docs/pl/7.x/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/guide/platforms/blackberry10/config.html
+++ b/archive/docs/pl/7.x/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/guide/platforms/blackberry10/home.html
+++ b/archive/docs/pl/7.x/guide/platforms/blackberry10/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/guide/platforms/blackberry10/index.html
+++ b/archive/docs/pl/7.x/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/pl/7.x/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/pl/7.x/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/guide/platforms/blackberry10/upgrade.html
+++ b/archive/docs/pl/7.x/guide/platforms/blackberry10/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/guide/platforms/ios/config.html
+++ b/archive/docs/pl/7.x/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/guide/platforms/ios/index.html
+++ b/archive/docs/pl/7.x/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/guide/platforms/ios/plugin.html
+++ b/archive/docs/pl/7.x/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/guide/platforms/ios/tools.html
+++ b/archive/docs/pl/7.x/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/guide/platforms/ios/upgrade.html
+++ b/archive/docs/pl/7.x/guide/platforms/ios/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/guide/platforms/ios/webview.html
+++ b/archive/docs/pl/7.x/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/guide/platforms/ubuntu/index.html
+++ b/archive/docs/pl/7.x/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/guide/platforms/win8/index.html
+++ b/archive/docs/pl/7.x/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/guide/platforms/win8/plugin.html
+++ b/archive/docs/pl/7.x/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/guide/platforms/wp8/home.html
+++ b/archive/docs/pl/7.x/guide/platforms/wp8/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/guide/platforms/wp8/index.html
+++ b/archive/docs/pl/7.x/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/guide/platforms/wp8/parallels.html
+++ b/archive/docs/pl/7.x/guide/platforms/wp8/parallels.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/guide/platforms/wp8/plugin.html
+++ b/archive/docs/pl/7.x/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/pl/7.x/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/guide/platforms/wp8/vmware.html
+++ b/archive/docs/pl/7.x/guide/platforms/wp8/vmware.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/guide/platforms/wp8/webview.html
+++ b/archive/docs/pl/7.x/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/guide/support/index.html
+++ b/archive/docs/pl/7.x/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/index.html
+++ b/archive/docs/pl/7.x/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/pl/7.x/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/plugin_ref/plugman.html
+++ b/archive/docs/pl/7.x/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/7.x/plugin_ref/spec.html
+++ b/archive/docs/pl/7.x/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/config_ref/images.html
+++ b/archive/docs/pl/8.x/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/config_ref/index.html
+++ b/archive/docs/pl/8.x/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/cordova/events/events.backbutton.html
+++ b/archive/docs/pl/8.x/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/cordova/events/events.deviceready.html
+++ b/archive/docs/pl/8.x/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/cordova/events/events.endcallbutton.html
+++ b/archive/docs/pl/8.x/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/cordova/events/events.html
+++ b/archive/docs/pl/8.x/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/cordova/events/events.menubutton.html
+++ b/archive/docs/pl/8.x/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/cordova/events/events.pause.html
+++ b/archive/docs/pl/8.x/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/cordova/events/events.resume.html
+++ b/archive/docs/pl/8.x/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/cordova/events/events.searchbutton.html
+++ b/archive/docs/pl/8.x/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/cordova/events/events.startcallbutton.html
+++ b/archive/docs/pl/8.x/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/pl/8.x/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/pl/8.x/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/cordova/storage/storage.html
+++ b/archive/docs/pl/8.x/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/guide/appdev/hooks/index.html
+++ b/archive/docs/pl/8.x/guide/appdev/hooks/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/guide/appdev/privacy/index.html
+++ b/archive/docs/pl/8.x/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/guide/appdev/security/index.html
+++ b/archive/docs/pl/8.x/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/guide/appdev/whitelist/index.html
+++ b/archive/docs/pl/8.x/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/guide/cli/index.html
+++ b/archive/docs/pl/8.x/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/guide/hybrid/plugins/index.html
+++ b/archive/docs/pl/8.x/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/guide/hybrid/webviews/index.html
+++ b/archive/docs/pl/8.x/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/guide/next/index.html
+++ b/archive/docs/pl/8.x/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/guide/overview/index.html
+++ b/archive/docs/pl/8.x/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/pl/8.x/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/pl/8.x/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/guide/platforms/android/config.html
+++ b/archive/docs/pl/8.x/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/guide/platforms/android/index.html
+++ b/archive/docs/pl/8.x/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/guide/platforms/android/plugin.html
+++ b/archive/docs/pl/8.x/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/guide/platforms/android/upgrade.html
+++ b/archive/docs/pl/8.x/guide/platforms/android/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/guide/platforms/android/webview.html
+++ b/archive/docs/pl/8.x/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/guide/platforms/blackberry10/config.html
+++ b/archive/docs/pl/8.x/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/guide/platforms/blackberry10/home.html
+++ b/archive/docs/pl/8.x/guide/platforms/blackberry10/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/guide/platforms/blackberry10/index.html
+++ b/archive/docs/pl/8.x/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/pl/8.x/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/pl/8.x/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/guide/platforms/blackberry10/upgrade.html
+++ b/archive/docs/pl/8.x/guide/platforms/blackberry10/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/guide/platforms/ios/config.html
+++ b/archive/docs/pl/8.x/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/guide/platforms/ios/index.html
+++ b/archive/docs/pl/8.x/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/guide/platforms/ios/plugin.html
+++ b/archive/docs/pl/8.x/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/guide/platforms/ios/tools.html
+++ b/archive/docs/pl/8.x/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/guide/platforms/ios/upgrade.html
+++ b/archive/docs/pl/8.x/guide/platforms/ios/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/guide/platforms/ios/webview.html
+++ b/archive/docs/pl/8.x/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/guide/platforms/ubuntu/index.html
+++ b/archive/docs/pl/8.x/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/guide/platforms/win8/index.html
+++ b/archive/docs/pl/8.x/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/guide/platforms/win8/plugin.html
+++ b/archive/docs/pl/8.x/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/guide/platforms/wp8/home.html
+++ b/archive/docs/pl/8.x/guide/platforms/wp8/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/guide/platforms/wp8/index.html
+++ b/archive/docs/pl/8.x/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/guide/platforms/wp8/parallels.html
+++ b/archive/docs/pl/8.x/guide/platforms/wp8/parallels.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/guide/platforms/wp8/plugin.html
+++ b/archive/docs/pl/8.x/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/pl/8.x/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/guide/platforms/wp8/vmware.html
+++ b/archive/docs/pl/8.x/guide/platforms/wp8/vmware.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/guide/platforms/wp8/webview.html
+++ b/archive/docs/pl/8.x/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/guide/support/index.html
+++ b/archive/docs/pl/8.x/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/index.html
+++ b/archive/docs/pl/8.x/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/pl/8.x/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/plugin_ref/plugman.html
+++ b/archive/docs/pl/8.x/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/8.x/plugin_ref/spec.html
+++ b/archive/docs/pl/8.x/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/config_ref/images.html
+++ b/archive/docs/pl/9.x/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/config_ref/index.html
+++ b/archive/docs/pl/9.x/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/cordova/events/events.backbutton.html
+++ b/archive/docs/pl/9.x/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/cordova/events/events.deviceready.html
+++ b/archive/docs/pl/9.x/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/cordova/events/events.endcallbutton.html
+++ b/archive/docs/pl/9.x/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/cordova/events/events.html
+++ b/archive/docs/pl/9.x/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/cordova/events/events.menubutton.html
+++ b/archive/docs/pl/9.x/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/cordova/events/events.pause.html
+++ b/archive/docs/pl/9.x/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/cordova/events/events.resume.html
+++ b/archive/docs/pl/9.x/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/cordova/events/events.searchbutton.html
+++ b/archive/docs/pl/9.x/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/cordova/events/events.startcallbutton.html
+++ b/archive/docs/pl/9.x/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/pl/9.x/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/pl/9.x/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/cordova/storage/storage.html
+++ b/archive/docs/pl/9.x/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/guide/appdev/hooks/index.html
+++ b/archive/docs/pl/9.x/guide/appdev/hooks/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/guide/appdev/privacy/index.html
+++ b/archive/docs/pl/9.x/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/guide/appdev/security/index.html
+++ b/archive/docs/pl/9.x/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/guide/appdev/whitelist/index.html
+++ b/archive/docs/pl/9.x/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/guide/cli/index.html
+++ b/archive/docs/pl/9.x/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/guide/hybrid/plugins/index.html
+++ b/archive/docs/pl/9.x/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/guide/hybrid/webviews/index.html
+++ b/archive/docs/pl/9.x/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/guide/next/index.html
+++ b/archive/docs/pl/9.x/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/guide/overview/index.html
+++ b/archive/docs/pl/9.x/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/pl/9.x/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/pl/9.x/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/guide/platforms/android/config.html
+++ b/archive/docs/pl/9.x/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/guide/platforms/android/index.html
+++ b/archive/docs/pl/9.x/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/guide/platforms/android/plugin.html
+++ b/archive/docs/pl/9.x/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/guide/platforms/android/upgrade.html
+++ b/archive/docs/pl/9.x/guide/platforms/android/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/guide/platforms/android/webview.html
+++ b/archive/docs/pl/9.x/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/guide/platforms/blackberry10/config.html
+++ b/archive/docs/pl/9.x/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/guide/platforms/blackberry10/home.html
+++ b/archive/docs/pl/9.x/guide/platforms/blackberry10/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/guide/platforms/blackberry10/index.html
+++ b/archive/docs/pl/9.x/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/pl/9.x/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/pl/9.x/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/guide/platforms/blackberry10/upgrade.html
+++ b/archive/docs/pl/9.x/guide/platforms/blackberry10/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/guide/platforms/ios/config.html
+++ b/archive/docs/pl/9.x/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/guide/platforms/ios/index.html
+++ b/archive/docs/pl/9.x/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/guide/platforms/ios/plugin.html
+++ b/archive/docs/pl/9.x/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/guide/platforms/ios/tools.html
+++ b/archive/docs/pl/9.x/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/guide/platforms/ios/upgrade.html
+++ b/archive/docs/pl/9.x/guide/platforms/ios/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/guide/platforms/ios/webview.html
+++ b/archive/docs/pl/9.x/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/guide/platforms/ubuntu/index.html
+++ b/archive/docs/pl/9.x/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/guide/platforms/win8/index.html
+++ b/archive/docs/pl/9.x/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/guide/platforms/win8/plugin.html
+++ b/archive/docs/pl/9.x/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/guide/platforms/wp8/home.html
+++ b/archive/docs/pl/9.x/guide/platforms/wp8/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/guide/platforms/wp8/index.html
+++ b/archive/docs/pl/9.x/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/guide/platforms/wp8/parallels.html
+++ b/archive/docs/pl/9.x/guide/platforms/wp8/parallels.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/guide/platforms/wp8/plugin.html
+++ b/archive/docs/pl/9.x/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/pl/9.x/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/guide/platforms/wp8/vmware.html
+++ b/archive/docs/pl/9.x/guide/platforms/wp8/vmware.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/guide/platforms/wp8/webview.html
+++ b/archive/docs/pl/9.x/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/guide/support/index.html
+++ b/archive/docs/pl/9.x/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/index.html
+++ b/archive/docs/pl/9.x/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/pl/9.x/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/plugin_ref/plugman.html
+++ b/archive/docs/pl/9.x/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/pl/9.x/plugin_ref/spec.html
+++ b/archive/docs/pl/9.x/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/config_ref/images.html
+++ b/archive/docs/ru/10.x/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/config_ref/index.html
+++ b/archive/docs/ru/10.x/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/cordova/events/events.backbutton.html
+++ b/archive/docs/ru/10.x/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/cordova/events/events.deviceready.html
+++ b/archive/docs/ru/10.x/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/cordova/events/events.endcallbutton.html
+++ b/archive/docs/ru/10.x/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/cordova/events/events.html
+++ b/archive/docs/ru/10.x/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/cordova/events/events.menubutton.html
+++ b/archive/docs/ru/10.x/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/cordova/events/events.pause.html
+++ b/archive/docs/ru/10.x/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/cordova/events/events.resume.html
+++ b/archive/docs/ru/10.x/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/cordova/events/events.searchbutton.html
+++ b/archive/docs/ru/10.x/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/cordova/events/events.startcallbutton.html
+++ b/archive/docs/ru/10.x/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/ru/10.x/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/ru/10.x/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/cordova/storage/storage.html
+++ b/archive/docs/ru/10.x/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/guide/appdev/hooks/index.html
+++ b/archive/docs/ru/10.x/guide/appdev/hooks/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/guide/appdev/privacy/index.html
+++ b/archive/docs/ru/10.x/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/guide/appdev/security/index.html
+++ b/archive/docs/ru/10.x/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/guide/appdev/whitelist/index.html
+++ b/archive/docs/ru/10.x/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/guide/cli/index.html
+++ b/archive/docs/ru/10.x/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/guide/hybrid/plugins/index.html
+++ b/archive/docs/ru/10.x/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/guide/hybrid/webviews/index.html
+++ b/archive/docs/ru/10.x/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/guide/next/index.html
+++ b/archive/docs/ru/10.x/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/guide/overview/index.html
+++ b/archive/docs/ru/10.x/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/guide/platforms/amazonfireos/config.html
+++ b/archive/docs/ru/10.x/guide/platforms/amazonfireos/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/guide/platforms/amazonfireos/index.html
+++ b/archive/docs/ru/10.x/guide/platforms/amazonfireos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/ru/10.x/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/ru/10.x/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/guide/platforms/android/config.html
+++ b/archive/docs/ru/10.x/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/guide/platforms/android/index.html
+++ b/archive/docs/ru/10.x/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/guide/platforms/android/plugin.html
+++ b/archive/docs/ru/10.x/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/guide/platforms/android/tools.html
+++ b/archive/docs/ru/10.x/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/guide/platforms/android/upgrade.html
+++ b/archive/docs/ru/10.x/guide/platforms/android/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/guide/platforms/android/webview.html
+++ b/archive/docs/ru/10.x/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/guide/platforms/blackberry10/config.html
+++ b/archive/docs/ru/10.x/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/guide/platforms/blackberry10/home.html
+++ b/archive/docs/ru/10.x/guide/platforms/blackberry10/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/guide/platforms/blackberry10/index.html
+++ b/archive/docs/ru/10.x/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/ru/10.x/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/ru/10.x/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/guide/platforms/blackberry10/upgrade.html
+++ b/archive/docs/ru/10.x/guide/platforms/blackberry10/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/guide/platforms/firefoxos/index.html
+++ b/archive/docs/ru/10.x/guide/platforms/firefoxos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/guide/platforms/index.html
+++ b/archive/docs/ru/10.x/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/guide/platforms/ios/config.html
+++ b/archive/docs/ru/10.x/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/guide/platforms/ios/index.html
+++ b/archive/docs/ru/10.x/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/guide/platforms/ios/plugin.html
+++ b/archive/docs/ru/10.x/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/guide/platforms/ios/tools.html
+++ b/archive/docs/ru/10.x/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/guide/platforms/ios/upgrade.html
+++ b/archive/docs/ru/10.x/guide/platforms/ios/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/guide/platforms/ios/webview.html
+++ b/archive/docs/ru/10.x/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/guide/platforms/tizen/index.html
+++ b/archive/docs/ru/10.x/guide/platforms/tizen/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/guide/platforms/ubuntu/index.html
+++ b/archive/docs/ru/10.x/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/guide/platforms/win8/index.html
+++ b/archive/docs/ru/10.x/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/guide/platforms/win8/packaging.html
+++ b/archive/docs/ru/10.x/guide/platforms/win8/packaging.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/guide/platforms/win8/plugin.html
+++ b/archive/docs/ru/10.x/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/guide/platforms/win8/upgrading.html
+++ b/archive/docs/ru/10.x/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/guide/platforms/wp8/home.html
+++ b/archive/docs/ru/10.x/guide/platforms/wp8/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/guide/platforms/wp8/index.html
+++ b/archive/docs/ru/10.x/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/guide/platforms/wp8/parallels.html
+++ b/archive/docs/ru/10.x/guide/platforms/wp8/parallels.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/guide/platforms/wp8/plugin.html
+++ b/archive/docs/ru/10.x/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/ru/10.x/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/guide/platforms/wp8/vmware.html
+++ b/archive/docs/ru/10.x/guide/platforms/wp8/vmware.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/guide/platforms/wp8/webview.html
+++ b/archive/docs/ru/10.x/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/guide/support/index.html
+++ b/archive/docs/ru/10.x/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/index.html
+++ b/archive/docs/ru/10.x/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/ru/10.x/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/plugin_ref/plugman.html
+++ b/archive/docs/ru/10.x/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/10.x/plugin_ref/spec.html
+++ b/archive/docs/ru/10.x/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/config_ref/images.html
+++ b/archive/docs/ru/3.1.0/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/config_ref/index.html
+++ b/archive/docs/ru/3.1.0/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/accelerometer/acceleration/acceleration.html
+++ b/archive/docs/ru/3.1.0/cordova/accelerometer/acceleration/acceleration.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/accelerometer/accelerometer.clearWatch.html
+++ b/archive/docs/ru/3.1.0/cordova/accelerometer/accelerometer.clearWatch.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/accelerometer/accelerometer.getCurrentAcceleration.html
+++ b/archive/docs/ru/3.1.0/cordova/accelerometer/accelerometer.getCurrentAcceleration.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/accelerometer/accelerometer.html
+++ b/archive/docs/ru/3.1.0/cordova/accelerometer/accelerometer.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/accelerometer/accelerometer.watchAcceleration.html
+++ b/archive/docs/ru/3.1.0/cordova/accelerometer/accelerometer.watchAcceleration.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/accelerometer/parameters/accelerometerError.html
+++ b/archive/docs/ru/3.1.0/cordova/accelerometer/parameters/accelerometerError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/accelerometer/parameters/accelerometerOptions.html
+++ b/archive/docs/ru/3.1.0/cordova/accelerometer/parameters/accelerometerOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/accelerometer/parameters/accelerometerSuccess.html
+++ b/archive/docs/ru/3.1.0/cordova/accelerometer/parameters/accelerometerSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/camera/camera.getPicture.html
+++ b/archive/docs/ru/3.1.0/cordova/camera/camera.getPicture.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/camera/camera.html
+++ b/archive/docs/ru/3.1.0/cordova/camera/camera.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/compass/compass.clearWatch.html
+++ b/archive/docs/ru/3.1.0/cordova/compass/compass.clearWatch.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/compass/compass.clearWatchFilter.html
+++ b/archive/docs/ru/3.1.0/cordova/compass/compass.clearWatchFilter.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/compass/compass.getCurrentHeading.html
+++ b/archive/docs/ru/3.1.0/cordova/compass/compass.getCurrentHeading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/compass/compass.html
+++ b/archive/docs/ru/3.1.0/cordova/compass/compass.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/compass/compass.watchHeading.html
+++ b/archive/docs/ru/3.1.0/cordova/compass/compass.watchHeading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/compass/compass.watchHeadingFilter.html
+++ b/archive/docs/ru/3.1.0/cordova/compass/compass.watchHeadingFilter.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/compass/parameters/compassError.html
+++ b/archive/docs/ru/3.1.0/cordova/compass/parameters/compassError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/compass/parameters/compassHeading.html
+++ b/archive/docs/ru/3.1.0/cordova/compass/parameters/compassHeading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/compass/parameters/compassOptions.html
+++ b/archive/docs/ru/3.1.0/cordova/compass/parameters/compassOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/compass/parameters/compassSuccess.html
+++ b/archive/docs/ru/3.1.0/cordova/compass/parameters/compassSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/connection/connection.html
+++ b/archive/docs/ru/3.1.0/cordova/connection/connection.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/connection/connection.type.html
+++ b/archive/docs/ru/3.1.0/cordova/connection/connection.type.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/contacts/ContactAddress/contactaddress.html
+++ b/archive/docs/ru/3.1.0/cordova/contacts/ContactAddress/contactaddress.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/contacts/ContactError/contactError.html
+++ b/archive/docs/ru/3.1.0/cordova/contacts/ContactError/contactError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/contacts/ContactField/contactfield.html
+++ b/archive/docs/ru/3.1.0/cordova/contacts/ContactField/contactfield.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/contacts/ContactFindOptions/contactfindoptions.html
+++ b/archive/docs/ru/3.1.0/cordova/contacts/ContactFindOptions/contactfindoptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/contacts/ContactName/contactname.html
+++ b/archive/docs/ru/3.1.0/cordova/contacts/ContactName/contactname.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/contacts/ContactOrganization/contactorganization.html
+++ b/archive/docs/ru/3.1.0/cordova/contacts/ContactOrganization/contactorganization.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/contacts/contacts.create.html
+++ b/archive/docs/ru/3.1.0/cordova/contacts/contacts.create.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/contacts/contacts.find.html
+++ b/archive/docs/ru/3.1.0/cordova/contacts/contacts.find.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/contacts/contacts.html
+++ b/archive/docs/ru/3.1.0/cordova/contacts/contacts.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/contacts/parameters/contactError.html
+++ b/archive/docs/ru/3.1.0/cordova/contacts/parameters/contactError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/contacts/parameters/contactFields.html
+++ b/archive/docs/ru/3.1.0/cordova/contacts/parameters/contactFields.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/contacts/parameters/contactFindOptions.html
+++ b/archive/docs/ru/3.1.0/cordova/contacts/parameters/contactFindOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/contacts/parameters/contactSuccess.html
+++ b/archive/docs/ru/3.1.0/cordova/contacts/parameters/contactSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/device/device.cordova.html
+++ b/archive/docs/ru/3.1.0/cordova/device/device.cordova.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/device/device.html
+++ b/archive/docs/ru/3.1.0/cordova/device/device.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/device/device.model.html
+++ b/archive/docs/ru/3.1.0/cordova/device/device.model.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/device/device.name.html
+++ b/archive/docs/ru/3.1.0/cordova/device/device.name.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/device/device.platform.html
+++ b/archive/docs/ru/3.1.0/cordova/device/device.platform.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/device/device.uuid.html
+++ b/archive/docs/ru/3.1.0/cordova/device/device.uuid.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/device/device.version.html
+++ b/archive/docs/ru/3.1.0/cordova/device/device.version.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/events/events.backbutton.html
+++ b/archive/docs/ru/3.1.0/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/events/events.batterycritical.html
+++ b/archive/docs/ru/3.1.0/cordova/events/events.batterycritical.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/events/events.batterylow.html
+++ b/archive/docs/ru/3.1.0/cordova/events/events.batterylow.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/events/events.batterystatus.html
+++ b/archive/docs/ru/3.1.0/cordova/events/events.batterystatus.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/events/events.deviceready.html
+++ b/archive/docs/ru/3.1.0/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/events/events.endcallbutton.html
+++ b/archive/docs/ru/3.1.0/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/events/events.html
+++ b/archive/docs/ru/3.1.0/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/events/events.menubutton.html
+++ b/archive/docs/ru/3.1.0/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/events/events.offline.html
+++ b/archive/docs/ru/3.1.0/cordova/events/events.offline.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/events/events.online.html
+++ b/archive/docs/ru/3.1.0/cordova/events/events.online.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/events/events.pause.html
+++ b/archive/docs/ru/3.1.0/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/events/events.resume.html
+++ b/archive/docs/ru/3.1.0/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/events/events.searchbutton.html
+++ b/archive/docs/ru/3.1.0/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/events/events.startcallbutton.html
+++ b/archive/docs/ru/3.1.0/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/ru/3.1.0/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/ru/3.1.0/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/file/directoryentry/directoryentry.html
+++ b/archive/docs/ru/3.1.0/cordova/file/directoryentry/directoryentry.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/file/directoryreader/directoryreader.html
+++ b/archive/docs/ru/3.1.0/cordova/file/directoryreader/directoryreader.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/file/file.html
+++ b/archive/docs/ru/3.1.0/cordova/file/file.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/file/fileentry/fileentry.html
+++ b/archive/docs/ru/3.1.0/cordova/file/fileentry/fileentry.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/file/fileerror/fileerror.html
+++ b/archive/docs/ru/3.1.0/cordova/file/fileerror/fileerror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/file/fileobj/fileobj.html
+++ b/archive/docs/ru/3.1.0/cordova/file/fileobj/fileobj.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/file/filereader/filereader.html
+++ b/archive/docs/ru/3.1.0/cordova/file/filereader/filereader.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/file/filesystem/filesystem.html
+++ b/archive/docs/ru/3.1.0/cordova/file/filesystem/filesystem.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/file/filetransfer/filetransfer.html
+++ b/archive/docs/ru/3.1.0/cordova/file/filetransfer/filetransfer.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/file/filetransfererror/filetransfererror.html
+++ b/archive/docs/ru/3.1.0/cordova/file/filetransfererror/filetransfererror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/file/fileuploadoptions/fileuploadoptions.html
+++ b/archive/docs/ru/3.1.0/cordova/file/fileuploadoptions/fileuploadoptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/file/fileuploadresult/fileuploadresult.html
+++ b/archive/docs/ru/3.1.0/cordova/file/fileuploadresult/fileuploadresult.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/file/filewriter/filewriter.html
+++ b/archive/docs/ru/3.1.0/cordova/file/filewriter/filewriter.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/file/flags/flags.html
+++ b/archive/docs/ru/3.1.0/cordova/file/flags/flags.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/file/localfilesystem/localfilesystem.html
+++ b/archive/docs/ru/3.1.0/cordova/file/localfilesystem/localfilesystem.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/file/metadata/metadata.html
+++ b/archive/docs/ru/3.1.0/cordova/file/metadata/metadata.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/geolocation/PositionError/positionError.html
+++ b/archive/docs/ru/3.1.0/cordova/geolocation/PositionError/positionError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/geolocation/geolocation.clearWatch.html
+++ b/archive/docs/ru/3.1.0/cordova/geolocation/geolocation.clearWatch.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/geolocation/geolocation.getCurrentPosition.html
+++ b/archive/docs/ru/3.1.0/cordova/geolocation/geolocation.getCurrentPosition.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/geolocation/geolocation.html
+++ b/archive/docs/ru/3.1.0/cordova/geolocation/geolocation.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/geolocation/geolocation.watchPosition.html
+++ b/archive/docs/ru/3.1.0/cordova/geolocation/geolocation.watchPosition.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/geolocation/parameters/geolocation.options.html
+++ b/archive/docs/ru/3.1.0/cordova/geolocation/parameters/geolocation.options.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/geolocation/parameters/geolocationError.html
+++ b/archive/docs/ru/3.1.0/cordova/geolocation/parameters/geolocationError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/geolocation/parameters/geolocationSuccess.html
+++ b/archive/docs/ru/3.1.0/cordova/geolocation/parameters/geolocationSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/globalization/GlobalizationError/globalizationerror.html
+++ b/archive/docs/ru/3.1.0/cordova/globalization/GlobalizationError/globalizationerror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/globalization/globalization.dateToString.html
+++ b/archive/docs/ru/3.1.0/cordova/globalization/globalization.dateToString.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/globalization/globalization.getCurrencyPattern.html
+++ b/archive/docs/ru/3.1.0/cordova/globalization/globalization.getCurrencyPattern.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/globalization/globalization.getDateNames.html
+++ b/archive/docs/ru/3.1.0/cordova/globalization/globalization.getDateNames.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/globalization/globalization.getDatePattern.html
+++ b/archive/docs/ru/3.1.0/cordova/globalization/globalization.getDatePattern.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/globalization/globalization.getFirstDayOfWeek.html
+++ b/archive/docs/ru/3.1.0/cordova/globalization/globalization.getFirstDayOfWeek.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/globalization/globalization.getLocaleName.html
+++ b/archive/docs/ru/3.1.0/cordova/globalization/globalization.getLocaleName.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/globalization/globalization.getNumberPattern.html
+++ b/archive/docs/ru/3.1.0/cordova/globalization/globalization.getNumberPattern.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/globalization/globalization.getPreferredLanguage.html
+++ b/archive/docs/ru/3.1.0/cordova/globalization/globalization.getPreferredLanguage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/globalization/globalization.html
+++ b/archive/docs/ru/3.1.0/cordova/globalization/globalization.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/globalization/globalization.isDayLightSavingsTime.html
+++ b/archive/docs/ru/3.1.0/cordova/globalization/globalization.isDayLightSavingsTime.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/globalization/globalization.numberToString.html
+++ b/archive/docs/ru/3.1.0/cordova/globalization/globalization.numberToString.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/globalization/globalization.stringToDate.html
+++ b/archive/docs/ru/3.1.0/cordova/globalization/globalization.stringToDate.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/globalization/globalization.stringToNumber.html
+++ b/archive/docs/ru/3.1.0/cordova/globalization/globalization.stringToNumber.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/inappbrowser/inappbrowser.html
+++ b/archive/docs/ru/3.1.0/cordova/inappbrowser/inappbrowser.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/media/capture/CaptureErrorCB.html
+++ b/archive/docs/ru/3.1.0/cordova/media/capture/CaptureErrorCB.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/media/capture/ConfigurationData.html
+++ b/archive/docs/ru/3.1.0/cordova/media/capture/ConfigurationData.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/media/capture/MediaFile.html
+++ b/archive/docs/ru/3.1.0/cordova/media/capture/MediaFile.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/media/capture/MediaFileData.html
+++ b/archive/docs/ru/3.1.0/cordova/media/capture/MediaFileData.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/media/capture/capture.html
+++ b/archive/docs/ru/3.1.0/cordova/media/capture/capture.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/media/capture/captureAudio.html
+++ b/archive/docs/ru/3.1.0/cordova/media/capture/captureAudio.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/media/capture/captureAudioOptions.html
+++ b/archive/docs/ru/3.1.0/cordova/media/capture/captureAudioOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/media/capture/captureImage.html
+++ b/archive/docs/ru/3.1.0/cordova/media/capture/captureImage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/media/capture/captureImageOptions.html
+++ b/archive/docs/ru/3.1.0/cordova/media/capture/captureImageOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/media/capture/captureVideo.html
+++ b/archive/docs/ru/3.1.0/cordova/media/capture/captureVideo.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/media/capture/captureVideoOptions.html
+++ b/archive/docs/ru/3.1.0/cordova/media/capture/captureVideoOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/media/media.html
+++ b/archive/docs/ru/3.1.0/cordova/media/media.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/notification/notification.html
+++ b/archive/docs/ru/3.1.0/cordova/notification/notification.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/splashscreen/splashscreen.hide.html
+++ b/archive/docs/ru/3.1.0/cordova/splashscreen/splashscreen.hide.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/splashscreen/splashscreen.html
+++ b/archive/docs/ru/3.1.0/cordova/splashscreen/splashscreen.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/splashscreen/splashscreen.show.html
+++ b/archive/docs/ru/3.1.0/cordova/splashscreen/splashscreen.show.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/storage/database/database.html
+++ b/archive/docs/ru/3.1.0/cordova/storage/database/database.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/ru/3.1.0/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/storage/parameters/display_name.html
+++ b/archive/docs/ru/3.1.0/cordova/storage/parameters/display_name.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/storage/parameters/name.html
+++ b/archive/docs/ru/3.1.0/cordova/storage/parameters/name.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/storage/parameters/size.html
+++ b/archive/docs/ru/3.1.0/cordova/storage/parameters/size.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/storage/parameters/version.html
+++ b/archive/docs/ru/3.1.0/cordova/storage/parameters/version.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/storage/sqlerror/sqlerror.html
+++ b/archive/docs/ru/3.1.0/cordova/storage/sqlerror/sqlerror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/storage/sqlresultset/sqlresultset.html
+++ b/archive/docs/ru/3.1.0/cordova/storage/sqlresultset/sqlresultset.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/storage/sqlresultsetrowlist/sqlresultsetrowlist.html
+++ b/archive/docs/ru/3.1.0/cordova/storage/sqlresultsetrowlist/sqlresultsetrowlist.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/storage/sqltransaction/sqltransaction.html
+++ b/archive/docs/ru/3.1.0/cordova/storage/sqltransaction/sqltransaction.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/storage/storage.html
+++ b/archive/docs/ru/3.1.0/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/cordova/storage/storage.opendatabase.html
+++ b/archive/docs/ru/3.1.0/cordova/storage/storage.opendatabase.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/guide/appdev/privacy/index.html
+++ b/archive/docs/ru/3.1.0/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/guide/appdev/whitelist/index.html
+++ b/archive/docs/ru/3.1.0/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/guide/cli/index.html
+++ b/archive/docs/ru/3.1.0/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/guide/hybrid/plugins/index.html
+++ b/archive/docs/ru/3.1.0/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/guide/hybrid/webviews/index.html
+++ b/archive/docs/ru/3.1.0/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/guide/overview/index.html
+++ b/archive/docs/ru/3.1.0/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/guide/platforms/android/index.html
+++ b/archive/docs/ru/3.1.0/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/guide/platforms/android/tools.html
+++ b/archive/docs/ru/3.1.0/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/guide/platforms/android/upgrading.html
+++ b/archive/docs/ru/3.1.0/guide/platforms/android/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/guide/platforms/android/webview.html
+++ b/archive/docs/ru/3.1.0/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/guide/platforms/blackberry/index.html
+++ b/archive/docs/ru/3.1.0/guide/platforms/blackberry/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/guide/platforms/blackberry10/config.html
+++ b/archive/docs/ru/3.1.0/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/guide/platforms/blackberry10/upgrading.html
+++ b/archive/docs/ru/3.1.0/guide/platforms/blackberry10/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/guide/platforms/index.html
+++ b/archive/docs/ru/3.1.0/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/guide/platforms/ios/config.html
+++ b/archive/docs/ru/3.1.0/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/guide/platforms/ios/index.html
+++ b/archive/docs/ru/3.1.0/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/guide/platforms/ios/tools.html
+++ b/archive/docs/ru/3.1.0/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/guide/platforms/ios/upgrading.html
+++ b/archive/docs/ru/3.1.0/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/guide/platforms/ios/webview.html
+++ b/archive/docs/ru/3.1.0/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/guide/platforms/tizen/index.html
+++ b/archive/docs/ru/3.1.0/guide/platforms/tizen/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/guide/platforms/win8/index.html
+++ b/archive/docs/ru/3.1.0/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/guide/platforms/win8/tools.html
+++ b/archive/docs/ru/3.1.0/guide/platforms/win8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/guide/platforms/win8/upgrading.html
+++ b/archive/docs/ru/3.1.0/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/guide/platforms/wp7/index.html
+++ b/archive/docs/ru/3.1.0/guide/platforms/wp7/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/guide/platforms/wp8/index.html
+++ b/archive/docs/ru/3.1.0/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/guide/platforms/wp8/plugin.html
+++ b/archive/docs/ru/3.1.0/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/guide/platforms/wp8/tools.html
+++ b/archive/docs/ru/3.1.0/guide/platforms/wp8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/guide/platforms/wp8/upgrading.html
+++ b/archive/docs/ru/3.1.0/guide/platforms/wp8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.1.0/index.html
+++ b/archive/docs/ru/3.1.0/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.4.0/config_ref/images.html
+++ b/archive/docs/ru/3.4.0/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.4.0/config_ref/index.html
+++ b/archive/docs/ru/3.4.0/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.4.0/cordova/events/events.backbutton.html
+++ b/archive/docs/ru/3.4.0/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.4.0/cordova/events/events.deviceready.html
+++ b/archive/docs/ru/3.4.0/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.4.0/cordova/events/events.endcallbutton.html
+++ b/archive/docs/ru/3.4.0/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.4.0/cordova/events/events.html
+++ b/archive/docs/ru/3.4.0/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.4.0/cordova/events/events.menubutton.html
+++ b/archive/docs/ru/3.4.0/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.4.0/cordova/events/events.pause.html
+++ b/archive/docs/ru/3.4.0/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.4.0/cordova/events/events.resume.html
+++ b/archive/docs/ru/3.4.0/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.4.0/cordova/events/events.searchbutton.html
+++ b/archive/docs/ru/3.4.0/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.4.0/cordova/events/events.startcallbutton.html
+++ b/archive/docs/ru/3.4.0/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.4.0/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/ru/3.4.0/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.4.0/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/ru/3.4.0/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.4.0/cordova/plugins/pluginapis.html
+++ b/archive/docs/ru/3.4.0/cordova/plugins/pluginapis.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.4.0/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/ru/3.4.0/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.4.0/cordova/storage/storage.html
+++ b/archive/docs/ru/3.4.0/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.4.0/guide/appdev/privacy/index.html
+++ b/archive/docs/ru/3.4.0/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.4.0/guide/appdev/whitelist/index.html
+++ b/archive/docs/ru/3.4.0/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.4.0/guide/cli/index.html
+++ b/archive/docs/ru/3.4.0/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.4.0/guide/hybrid/plugins/index.html
+++ b/archive/docs/ru/3.4.0/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.4.0/guide/hybrid/webviews/index.html
+++ b/archive/docs/ru/3.4.0/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.4.0/guide/overview/index.html
+++ b/archive/docs/ru/3.4.0/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.4.0/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/ru/3.4.0/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.4.0/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/ru/3.4.0/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.4.0/guide/platforms/android/plugin.html
+++ b/archive/docs/ru/3.4.0/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.4.0/guide/platforms/android/webview.html
+++ b/archive/docs/ru/3.4.0/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.4.0/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/ru/3.4.0/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.4.0/guide/platforms/index.html
+++ b/archive/docs/ru/3.4.0/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.4.0/guide/platforms/ios/plugin.html
+++ b/archive/docs/ru/3.4.0/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.4.0/guide/platforms/ios/webview.html
+++ b/archive/docs/ru/3.4.0/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.4.0/guide/platforms/win8/upgrading.html
+++ b/archive/docs/ru/3.4.0/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.4.0/guide/platforms/wp8/plugin.html
+++ b/archive/docs/ru/3.4.0/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.4.0/guide/support/index.html
+++ b/archive/docs/ru/3.4.0/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.4.0/index.html
+++ b/archive/docs/ru/3.4.0/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.4.0/plugin_ref/plugman.html
+++ b/archive/docs/ru/3.4.0/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.5.0/config_ref/images.html
+++ b/archive/docs/ru/3.5.0/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.5.0/config_ref/index.html
+++ b/archive/docs/ru/3.5.0/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.5.0/cordova/events/events.backbutton.html
+++ b/archive/docs/ru/3.5.0/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.5.0/cordova/events/events.deviceready.html
+++ b/archive/docs/ru/3.5.0/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.5.0/cordova/events/events.endcallbutton.html
+++ b/archive/docs/ru/3.5.0/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.5.0/cordova/events/events.html
+++ b/archive/docs/ru/3.5.0/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.5.0/cordova/events/events.menubutton.html
+++ b/archive/docs/ru/3.5.0/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.5.0/cordova/events/events.pause.html
+++ b/archive/docs/ru/3.5.0/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.5.0/cordova/events/events.resume.html
+++ b/archive/docs/ru/3.5.0/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.5.0/cordova/events/events.searchbutton.html
+++ b/archive/docs/ru/3.5.0/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.5.0/cordova/events/events.startcallbutton.html
+++ b/archive/docs/ru/3.5.0/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.5.0/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/ru/3.5.0/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.5.0/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/ru/3.5.0/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.5.0/cordova/plugins/pluginapis.html
+++ b/archive/docs/ru/3.5.0/cordova/plugins/pluginapis.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.5.0/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/ru/3.5.0/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.5.0/cordova/storage/storage.html
+++ b/archive/docs/ru/3.5.0/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.5.0/guide/appdev/privacy/index.html
+++ b/archive/docs/ru/3.5.0/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.5.0/guide/appdev/whitelist/index.html
+++ b/archive/docs/ru/3.5.0/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.5.0/guide/cli/index.html
+++ b/archive/docs/ru/3.5.0/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.5.0/guide/hybrid/plugins/index.html
+++ b/archive/docs/ru/3.5.0/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.5.0/guide/hybrid/webviews/index.html
+++ b/archive/docs/ru/3.5.0/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.5.0/guide/overview/index.html
+++ b/archive/docs/ru/3.5.0/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.5.0/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/ru/3.5.0/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.5.0/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/ru/3.5.0/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.5.0/guide/platforms/android/plugin.html
+++ b/archive/docs/ru/3.5.0/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.5.0/guide/platforms/android/webview.html
+++ b/archive/docs/ru/3.5.0/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.5.0/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/ru/3.5.0/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.5.0/guide/platforms/index.html
+++ b/archive/docs/ru/3.5.0/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.5.0/guide/platforms/ios/plugin.html
+++ b/archive/docs/ru/3.5.0/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.5.0/guide/platforms/ios/webview.html
+++ b/archive/docs/ru/3.5.0/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.5.0/guide/platforms/win8/upgrading.html
+++ b/archive/docs/ru/3.5.0/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.5.0/guide/platforms/wp8/plugin.html
+++ b/archive/docs/ru/3.5.0/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.5.0/guide/support/index.html
+++ b/archive/docs/ru/3.5.0/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.5.0/index.html
+++ b/archive/docs/ru/3.5.0/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/3.5.0/plugin_ref/plugman.html
+++ b/archive/docs/ru/3.5.0/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/config_ref/images.html
+++ b/archive/docs/ru/5.0.0/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/config_ref/index.html
+++ b/archive/docs/ru/5.0.0/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/cordova/events/events.backbutton.html
+++ b/archive/docs/ru/5.0.0/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/cordova/events/events.deviceready.html
+++ b/archive/docs/ru/5.0.0/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/cordova/events/events.endcallbutton.html
+++ b/archive/docs/ru/5.0.0/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/cordova/events/events.html
+++ b/archive/docs/ru/5.0.0/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/cordova/events/events.menubutton.html
+++ b/archive/docs/ru/5.0.0/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/cordova/events/events.pause.html
+++ b/archive/docs/ru/5.0.0/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/cordova/events/events.resume.html
+++ b/archive/docs/ru/5.0.0/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/cordova/events/events.searchbutton.html
+++ b/archive/docs/ru/5.0.0/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/cordova/events/events.startcallbutton.html
+++ b/archive/docs/ru/5.0.0/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/ru/5.0.0/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/ru/5.0.0/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/cordova/plugins/pluginapis.html
+++ b/archive/docs/ru/5.0.0/cordova/plugins/pluginapis.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/cordova/storage/storage.html
+++ b/archive/docs/ru/5.0.0/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/guide/appdev/privacy/index.html
+++ b/archive/docs/ru/5.0.0/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/guide/appdev/security/index.html
+++ b/archive/docs/ru/5.0.0/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/guide/appdev/whitelist/index.html
+++ b/archive/docs/ru/5.0.0/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/guide/cli/index.html
+++ b/archive/docs/ru/5.0.0/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/guide/hybrid/plugins/index.html
+++ b/archive/docs/ru/5.0.0/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/guide/hybrid/webviews/index.html
+++ b/archive/docs/ru/5.0.0/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/guide/next/index.html
+++ b/archive/docs/ru/5.0.0/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/guide/overview/index.html
+++ b/archive/docs/ru/5.0.0/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/guide/platforms/amazonfireos/config.html
+++ b/archive/docs/ru/5.0.0/guide/platforms/amazonfireos/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/guide/platforms/amazonfireos/index.html
+++ b/archive/docs/ru/5.0.0/guide/platforms/amazonfireos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/ru/5.0.0/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/ru/5.0.0/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/guide/platforms/android/config.html
+++ b/archive/docs/ru/5.0.0/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/guide/platforms/android/index.html
+++ b/archive/docs/ru/5.0.0/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/guide/platforms/android/plugin.html
+++ b/archive/docs/ru/5.0.0/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/guide/platforms/android/tools.html
+++ b/archive/docs/ru/5.0.0/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/guide/platforms/android/upgrade.html
+++ b/archive/docs/ru/5.0.0/guide/platforms/android/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/guide/platforms/android/webview.html
+++ b/archive/docs/ru/5.0.0/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/guide/platforms/blackberry/upgrading.html
+++ b/archive/docs/ru/5.0.0/guide/platforms/blackberry/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/guide/platforms/blackberry10/config.html
+++ b/archive/docs/ru/5.0.0/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/guide/platforms/blackberry10/index.html
+++ b/archive/docs/ru/5.0.0/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/ru/5.0.0/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/ru/5.0.0/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/guide/platforms/firefoxos/index.html
+++ b/archive/docs/ru/5.0.0/guide/platforms/firefoxos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/guide/platforms/index.html
+++ b/archive/docs/ru/5.0.0/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/guide/platforms/ios/config.html
+++ b/archive/docs/ru/5.0.0/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/guide/platforms/ios/index.html
+++ b/archive/docs/ru/5.0.0/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/guide/platforms/ios/plugin.html
+++ b/archive/docs/ru/5.0.0/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/guide/platforms/ios/tools.html
+++ b/archive/docs/ru/5.0.0/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/guide/platforms/ios/upgrade.html
+++ b/archive/docs/ru/5.0.0/guide/platforms/ios/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/guide/platforms/ios/webview.html
+++ b/archive/docs/ru/5.0.0/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/guide/platforms/tizen/index.html
+++ b/archive/docs/ru/5.0.0/guide/platforms/tizen/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/guide/platforms/ubuntu/index.html
+++ b/archive/docs/ru/5.0.0/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/guide/platforms/win8/index.html
+++ b/archive/docs/ru/5.0.0/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/guide/platforms/win8/plugin.html
+++ b/archive/docs/ru/5.0.0/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/guide/platforms/win8/upgrading.html
+++ b/archive/docs/ru/5.0.0/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/guide/platforms/wp8/index.html
+++ b/archive/docs/ru/5.0.0/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/guide/platforms/wp8/parallels.html
+++ b/archive/docs/ru/5.0.0/guide/platforms/wp8/parallels.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/guide/platforms/wp8/upgrading.html
+++ b/archive/docs/ru/5.0.0/guide/platforms/wp8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/guide/platforms/wp8/vmware.html
+++ b/archive/docs/ru/5.0.0/guide/platforms/wp8/vmware.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/guide/platforms/wp8/webview.html
+++ b/archive/docs/ru/5.0.0/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/index.html
+++ b/archive/docs/ru/5.0.0/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.0.0/plugin_ref/plugman.html
+++ b/archive/docs/ru/5.0.0/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/config_ref/images.html
+++ b/archive/docs/ru/5.1.1/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/config_ref/index.html
+++ b/archive/docs/ru/5.1.1/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/cordova/events/events.backbutton.html
+++ b/archive/docs/ru/5.1.1/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/cordova/events/events.deviceready.html
+++ b/archive/docs/ru/5.1.1/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/cordova/events/events.endcallbutton.html
+++ b/archive/docs/ru/5.1.1/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/cordova/events/events.html
+++ b/archive/docs/ru/5.1.1/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/cordova/events/events.menubutton.html
+++ b/archive/docs/ru/5.1.1/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/cordova/events/events.pause.html
+++ b/archive/docs/ru/5.1.1/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/cordova/events/events.resume.html
+++ b/archive/docs/ru/5.1.1/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/cordova/events/events.searchbutton.html
+++ b/archive/docs/ru/5.1.1/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/cordova/events/events.startcallbutton.html
+++ b/archive/docs/ru/5.1.1/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/ru/5.1.1/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/ru/5.1.1/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/cordova/plugins/pluginapis.html
+++ b/archive/docs/ru/5.1.1/cordova/plugins/pluginapis.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/cordova/storage/storage.html
+++ b/archive/docs/ru/5.1.1/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/guide/appdev/hooks/index.html
+++ b/archive/docs/ru/5.1.1/guide/appdev/hooks/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/guide/appdev/privacy/index.html
+++ b/archive/docs/ru/5.1.1/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/guide/appdev/security/index.html
+++ b/archive/docs/ru/5.1.1/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/guide/appdev/whitelist/index.html
+++ b/archive/docs/ru/5.1.1/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/guide/cli/index.html
+++ b/archive/docs/ru/5.1.1/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/guide/hybrid/plugins/index.html
+++ b/archive/docs/ru/5.1.1/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/guide/hybrid/webviews/index.html
+++ b/archive/docs/ru/5.1.1/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/guide/next/index.html
+++ b/archive/docs/ru/5.1.1/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/guide/overview/index.html
+++ b/archive/docs/ru/5.1.1/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/guide/platforms/amazonfireos/config.html
+++ b/archive/docs/ru/5.1.1/guide/platforms/amazonfireos/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/guide/platforms/amazonfireos/index.html
+++ b/archive/docs/ru/5.1.1/guide/platforms/amazonfireos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/ru/5.1.1/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/ru/5.1.1/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/guide/platforms/android/config.html
+++ b/archive/docs/ru/5.1.1/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/guide/platforms/android/index.html
+++ b/archive/docs/ru/5.1.1/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/guide/platforms/android/plugin.html
+++ b/archive/docs/ru/5.1.1/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/guide/platforms/android/tools.html
+++ b/archive/docs/ru/5.1.1/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/guide/platforms/android/upgrade.html
+++ b/archive/docs/ru/5.1.1/guide/platforms/android/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/guide/platforms/android/webview.html
+++ b/archive/docs/ru/5.1.1/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/guide/platforms/blackberry10/config.html
+++ b/archive/docs/ru/5.1.1/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/guide/platforms/blackberry10/index.html
+++ b/archive/docs/ru/5.1.1/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/ru/5.1.1/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/ru/5.1.1/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/guide/platforms/blackberry10/upgrade.html
+++ b/archive/docs/ru/5.1.1/guide/platforms/blackberry10/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/guide/platforms/firefoxos/index.html
+++ b/archive/docs/ru/5.1.1/guide/platforms/firefoxos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/guide/platforms/index.html
+++ b/archive/docs/ru/5.1.1/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/guide/platforms/ios/config.html
+++ b/archive/docs/ru/5.1.1/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/guide/platforms/ios/index.html
+++ b/archive/docs/ru/5.1.1/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/guide/platforms/ios/plugin.html
+++ b/archive/docs/ru/5.1.1/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/guide/platforms/ios/tools.html
+++ b/archive/docs/ru/5.1.1/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/guide/platforms/ios/upgrade.html
+++ b/archive/docs/ru/5.1.1/guide/platforms/ios/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/guide/platforms/ios/webview.html
+++ b/archive/docs/ru/5.1.1/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/guide/platforms/tizen/index.html
+++ b/archive/docs/ru/5.1.1/guide/platforms/tizen/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/guide/platforms/ubuntu/index.html
+++ b/archive/docs/ru/5.1.1/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/guide/platforms/win8/index.html
+++ b/archive/docs/ru/5.1.1/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/guide/platforms/win8/packaging.html
+++ b/archive/docs/ru/5.1.1/guide/platforms/win8/packaging.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/guide/platforms/win8/plugin.html
+++ b/archive/docs/ru/5.1.1/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/guide/platforms/win8/upgrading.html
+++ b/archive/docs/ru/5.1.1/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/guide/platforms/wp8/index.html
+++ b/archive/docs/ru/5.1.1/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/guide/platforms/wp8/parallels.html
+++ b/archive/docs/ru/5.1.1/guide/platforms/wp8/parallels.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/guide/platforms/wp8/plugin.html
+++ b/archive/docs/ru/5.1.1/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/ru/5.1.1/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/guide/platforms/wp8/vmware.html
+++ b/archive/docs/ru/5.1.1/guide/platforms/wp8/vmware.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/guide/platforms/wp8/webview.html
+++ b/archive/docs/ru/5.1.1/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/guide/support/index.html
+++ b/archive/docs/ru/5.1.1/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/index.html
+++ b/archive/docs/ru/5.1.1/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/ru/5.1.1/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/plugin_ref/plugman.html
+++ b/archive/docs/ru/5.1.1/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.1.1/plugin_ref/spec.html
+++ b/archive/docs/ru/5.1.1/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/config_ref/images.html
+++ b/archive/docs/ru/5.4.0/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/config_ref/index.html
+++ b/archive/docs/ru/5.4.0/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/cordova/events/events.backbutton.html
+++ b/archive/docs/ru/5.4.0/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/cordova/events/events.deviceready.html
+++ b/archive/docs/ru/5.4.0/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/cordova/events/events.endcallbutton.html
+++ b/archive/docs/ru/5.4.0/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/cordova/events/events.html
+++ b/archive/docs/ru/5.4.0/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/cordova/events/events.menubutton.html
+++ b/archive/docs/ru/5.4.0/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/cordova/events/events.pause.html
+++ b/archive/docs/ru/5.4.0/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/cordova/events/events.resume.html
+++ b/archive/docs/ru/5.4.0/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/cordova/events/events.searchbutton.html
+++ b/archive/docs/ru/5.4.0/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/cordova/events/events.startcallbutton.html
+++ b/archive/docs/ru/5.4.0/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/ru/5.4.0/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/ru/5.4.0/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/cordova/plugins/pluginapis.html
+++ b/archive/docs/ru/5.4.0/cordova/plugins/pluginapis.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/cordova/storage/storage.html
+++ b/archive/docs/ru/5.4.0/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/guide/appdev/hooks/index.html
+++ b/archive/docs/ru/5.4.0/guide/appdev/hooks/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/guide/appdev/privacy/index.html
+++ b/archive/docs/ru/5.4.0/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/guide/appdev/security/index.html
+++ b/archive/docs/ru/5.4.0/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/guide/appdev/whitelist/index.html
+++ b/archive/docs/ru/5.4.0/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/guide/cli/index.html
+++ b/archive/docs/ru/5.4.0/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/guide/hybrid/plugins/index.html
+++ b/archive/docs/ru/5.4.0/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/guide/hybrid/webviews/index.html
+++ b/archive/docs/ru/5.4.0/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/guide/next/index.html
+++ b/archive/docs/ru/5.4.0/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/guide/overview/index.html
+++ b/archive/docs/ru/5.4.0/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/guide/platforms/amazonfireos/config.html
+++ b/archive/docs/ru/5.4.0/guide/platforms/amazonfireos/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/guide/platforms/amazonfireos/index.html
+++ b/archive/docs/ru/5.4.0/guide/platforms/amazonfireos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/ru/5.4.0/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/ru/5.4.0/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/guide/platforms/android/config.html
+++ b/archive/docs/ru/5.4.0/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/guide/platforms/android/index.html
+++ b/archive/docs/ru/5.4.0/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/guide/platforms/android/plugin.html
+++ b/archive/docs/ru/5.4.0/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/guide/platforms/android/tools.html
+++ b/archive/docs/ru/5.4.0/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/guide/platforms/android/upgrade.html
+++ b/archive/docs/ru/5.4.0/guide/platforms/android/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/guide/platforms/android/webview.html
+++ b/archive/docs/ru/5.4.0/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/guide/platforms/blackberry10/config.html
+++ b/archive/docs/ru/5.4.0/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/guide/platforms/blackberry10/index.html
+++ b/archive/docs/ru/5.4.0/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/ru/5.4.0/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/ru/5.4.0/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/guide/platforms/blackberry10/upgrade.html
+++ b/archive/docs/ru/5.4.0/guide/platforms/blackberry10/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/guide/platforms/firefoxos/index.html
+++ b/archive/docs/ru/5.4.0/guide/platforms/firefoxos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/guide/platforms/index.html
+++ b/archive/docs/ru/5.4.0/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/guide/platforms/ios/config.html
+++ b/archive/docs/ru/5.4.0/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/guide/platforms/ios/index.html
+++ b/archive/docs/ru/5.4.0/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/guide/platforms/ios/plugin.html
+++ b/archive/docs/ru/5.4.0/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/guide/platforms/ios/tools.html
+++ b/archive/docs/ru/5.4.0/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/guide/platforms/ios/upgrade.html
+++ b/archive/docs/ru/5.4.0/guide/platforms/ios/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/guide/platforms/ios/webview.html
+++ b/archive/docs/ru/5.4.0/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/guide/platforms/tizen/index.html
+++ b/archive/docs/ru/5.4.0/guide/platforms/tizen/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/guide/platforms/ubuntu/index.html
+++ b/archive/docs/ru/5.4.0/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/guide/platforms/win8/index.html
+++ b/archive/docs/ru/5.4.0/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/guide/platforms/win8/packaging.html
+++ b/archive/docs/ru/5.4.0/guide/platforms/win8/packaging.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/guide/platforms/win8/plugin.html
+++ b/archive/docs/ru/5.4.0/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/guide/platforms/win8/upgrading.html
+++ b/archive/docs/ru/5.4.0/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/guide/platforms/wp8/index.html
+++ b/archive/docs/ru/5.4.0/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/guide/platforms/wp8/parallels.html
+++ b/archive/docs/ru/5.4.0/guide/platforms/wp8/parallels.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/guide/platforms/wp8/plugin.html
+++ b/archive/docs/ru/5.4.0/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/ru/5.4.0/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/guide/platforms/wp8/vmware.html
+++ b/archive/docs/ru/5.4.0/guide/platforms/wp8/vmware.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/guide/platforms/wp8/webview.html
+++ b/archive/docs/ru/5.4.0/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/guide/support/index.html
+++ b/archive/docs/ru/5.4.0/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/index.html
+++ b/archive/docs/ru/5.4.0/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/ru/5.4.0/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/plugin_ref/plugman.html
+++ b/archive/docs/ru/5.4.0/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/5.4.0/plugin_ref/spec.html
+++ b/archive/docs/ru/5.4.0/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/config_ref/images.html
+++ b/archive/docs/ru/6.x/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/config_ref/index.html
+++ b/archive/docs/ru/6.x/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/cordova/events/events.backbutton.html
+++ b/archive/docs/ru/6.x/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/cordova/events/events.deviceready.html
+++ b/archive/docs/ru/6.x/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/cordova/events/events.endcallbutton.html
+++ b/archive/docs/ru/6.x/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/cordova/events/events.html
+++ b/archive/docs/ru/6.x/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/cordova/events/events.menubutton.html
+++ b/archive/docs/ru/6.x/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/cordova/events/events.pause.html
+++ b/archive/docs/ru/6.x/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/cordova/events/events.resume.html
+++ b/archive/docs/ru/6.x/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/cordova/events/events.searchbutton.html
+++ b/archive/docs/ru/6.x/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/cordova/events/events.startcallbutton.html
+++ b/archive/docs/ru/6.x/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/ru/6.x/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/ru/6.x/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/cordova/storage/storage.html
+++ b/archive/docs/ru/6.x/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/guide/appdev/hooks/index.html
+++ b/archive/docs/ru/6.x/guide/appdev/hooks/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/guide/appdev/privacy/index.html
+++ b/archive/docs/ru/6.x/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/guide/appdev/security/index.html
+++ b/archive/docs/ru/6.x/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/guide/appdev/whitelist/index.html
+++ b/archive/docs/ru/6.x/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/guide/cli/index.html
+++ b/archive/docs/ru/6.x/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/guide/hybrid/plugins/index.html
+++ b/archive/docs/ru/6.x/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/guide/hybrid/webviews/index.html
+++ b/archive/docs/ru/6.x/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/guide/next/index.html
+++ b/archive/docs/ru/6.x/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/guide/overview/index.html
+++ b/archive/docs/ru/6.x/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/guide/platforms/amazonfireos/config.html
+++ b/archive/docs/ru/6.x/guide/platforms/amazonfireos/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/guide/platforms/amazonfireos/index.html
+++ b/archive/docs/ru/6.x/guide/platforms/amazonfireos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/ru/6.x/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/ru/6.x/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/guide/platforms/android/config.html
+++ b/archive/docs/ru/6.x/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/guide/platforms/android/index.html
+++ b/archive/docs/ru/6.x/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/guide/platforms/android/plugin.html
+++ b/archive/docs/ru/6.x/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/guide/platforms/android/tools.html
+++ b/archive/docs/ru/6.x/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/guide/platforms/android/upgrade.html
+++ b/archive/docs/ru/6.x/guide/platforms/android/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/guide/platforms/android/webview.html
+++ b/archive/docs/ru/6.x/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/guide/platforms/blackberry10/config.html
+++ b/archive/docs/ru/6.x/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/guide/platforms/blackberry10/home.html
+++ b/archive/docs/ru/6.x/guide/platforms/blackberry10/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/guide/platforms/blackberry10/index.html
+++ b/archive/docs/ru/6.x/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/ru/6.x/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/ru/6.x/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/guide/platforms/blackberry10/upgrade.html
+++ b/archive/docs/ru/6.x/guide/platforms/blackberry10/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/guide/platforms/firefoxos/index.html
+++ b/archive/docs/ru/6.x/guide/platforms/firefoxos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/guide/platforms/index.html
+++ b/archive/docs/ru/6.x/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/guide/platforms/ios/config.html
+++ b/archive/docs/ru/6.x/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/guide/platforms/ios/index.html
+++ b/archive/docs/ru/6.x/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/guide/platforms/ios/plugin.html
+++ b/archive/docs/ru/6.x/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/guide/platforms/ios/tools.html
+++ b/archive/docs/ru/6.x/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/guide/platforms/ios/upgrade.html
+++ b/archive/docs/ru/6.x/guide/platforms/ios/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/guide/platforms/ios/webview.html
+++ b/archive/docs/ru/6.x/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/guide/platforms/tizen/index.html
+++ b/archive/docs/ru/6.x/guide/platforms/tizen/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/guide/platforms/ubuntu/index.html
+++ b/archive/docs/ru/6.x/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/guide/platforms/win8/index.html
+++ b/archive/docs/ru/6.x/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/guide/platforms/win8/packaging.html
+++ b/archive/docs/ru/6.x/guide/platforms/win8/packaging.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/guide/platforms/win8/plugin.html
+++ b/archive/docs/ru/6.x/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/guide/platforms/win8/upgrading.html
+++ b/archive/docs/ru/6.x/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/guide/platforms/wp8/home.html
+++ b/archive/docs/ru/6.x/guide/platforms/wp8/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/guide/platforms/wp8/index.html
+++ b/archive/docs/ru/6.x/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/guide/platforms/wp8/parallels.html
+++ b/archive/docs/ru/6.x/guide/platforms/wp8/parallels.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/guide/platforms/wp8/plugin.html
+++ b/archive/docs/ru/6.x/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/ru/6.x/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/guide/platforms/wp8/vmware.html
+++ b/archive/docs/ru/6.x/guide/platforms/wp8/vmware.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/guide/platforms/wp8/webview.html
+++ b/archive/docs/ru/6.x/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/guide/support/index.html
+++ b/archive/docs/ru/6.x/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/index.html
+++ b/archive/docs/ru/6.x/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/ru/6.x/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/plugin_ref/plugman.html
+++ b/archive/docs/ru/6.x/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/6.x/plugin_ref/spec.html
+++ b/archive/docs/ru/6.x/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/config_ref/images.html
+++ b/archive/docs/ru/7.x/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/config_ref/index.html
+++ b/archive/docs/ru/7.x/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/cordova/events/events.backbutton.html
+++ b/archive/docs/ru/7.x/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/cordova/events/events.deviceready.html
+++ b/archive/docs/ru/7.x/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/cordova/events/events.endcallbutton.html
+++ b/archive/docs/ru/7.x/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/cordova/events/events.html
+++ b/archive/docs/ru/7.x/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/cordova/events/events.menubutton.html
+++ b/archive/docs/ru/7.x/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/cordova/events/events.pause.html
+++ b/archive/docs/ru/7.x/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/cordova/events/events.resume.html
+++ b/archive/docs/ru/7.x/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/cordova/events/events.searchbutton.html
+++ b/archive/docs/ru/7.x/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/cordova/events/events.startcallbutton.html
+++ b/archive/docs/ru/7.x/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/ru/7.x/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/ru/7.x/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/cordova/storage/storage.html
+++ b/archive/docs/ru/7.x/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/guide/appdev/hooks/index.html
+++ b/archive/docs/ru/7.x/guide/appdev/hooks/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/guide/appdev/privacy/index.html
+++ b/archive/docs/ru/7.x/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/guide/appdev/security/index.html
+++ b/archive/docs/ru/7.x/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/guide/appdev/whitelist/index.html
+++ b/archive/docs/ru/7.x/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/guide/cli/index.html
+++ b/archive/docs/ru/7.x/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/guide/hybrid/plugins/index.html
+++ b/archive/docs/ru/7.x/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/guide/hybrid/webviews/index.html
+++ b/archive/docs/ru/7.x/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/guide/next/index.html
+++ b/archive/docs/ru/7.x/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/guide/overview/index.html
+++ b/archive/docs/ru/7.x/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/guide/platforms/amazonfireos/config.html
+++ b/archive/docs/ru/7.x/guide/platforms/amazonfireos/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/guide/platforms/amazonfireos/index.html
+++ b/archive/docs/ru/7.x/guide/platforms/amazonfireos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/ru/7.x/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/ru/7.x/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/guide/platforms/android/config.html
+++ b/archive/docs/ru/7.x/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/guide/platforms/android/index.html
+++ b/archive/docs/ru/7.x/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/guide/platforms/android/plugin.html
+++ b/archive/docs/ru/7.x/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/guide/platforms/android/tools.html
+++ b/archive/docs/ru/7.x/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/guide/platforms/android/upgrade.html
+++ b/archive/docs/ru/7.x/guide/platforms/android/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/guide/platforms/android/webview.html
+++ b/archive/docs/ru/7.x/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/guide/platforms/blackberry10/config.html
+++ b/archive/docs/ru/7.x/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/guide/platforms/blackberry10/home.html
+++ b/archive/docs/ru/7.x/guide/platforms/blackberry10/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/guide/platforms/blackberry10/index.html
+++ b/archive/docs/ru/7.x/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/ru/7.x/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/ru/7.x/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/guide/platforms/blackberry10/upgrade.html
+++ b/archive/docs/ru/7.x/guide/platforms/blackberry10/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/guide/platforms/firefoxos/index.html
+++ b/archive/docs/ru/7.x/guide/platforms/firefoxos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/guide/platforms/index.html
+++ b/archive/docs/ru/7.x/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/guide/platforms/ios/config.html
+++ b/archive/docs/ru/7.x/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/guide/platforms/ios/index.html
+++ b/archive/docs/ru/7.x/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/guide/platforms/ios/plugin.html
+++ b/archive/docs/ru/7.x/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/guide/platforms/ios/tools.html
+++ b/archive/docs/ru/7.x/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/guide/platforms/ios/upgrade.html
+++ b/archive/docs/ru/7.x/guide/platforms/ios/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/guide/platforms/ios/webview.html
+++ b/archive/docs/ru/7.x/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/guide/platforms/tizen/index.html
+++ b/archive/docs/ru/7.x/guide/platforms/tizen/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/guide/platforms/ubuntu/index.html
+++ b/archive/docs/ru/7.x/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/guide/platforms/win8/index.html
+++ b/archive/docs/ru/7.x/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/guide/platforms/win8/packaging.html
+++ b/archive/docs/ru/7.x/guide/platforms/win8/packaging.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/guide/platforms/win8/plugin.html
+++ b/archive/docs/ru/7.x/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/guide/platforms/win8/upgrading.html
+++ b/archive/docs/ru/7.x/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/guide/platforms/wp8/home.html
+++ b/archive/docs/ru/7.x/guide/platforms/wp8/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/guide/platforms/wp8/index.html
+++ b/archive/docs/ru/7.x/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/guide/platforms/wp8/parallels.html
+++ b/archive/docs/ru/7.x/guide/platforms/wp8/parallels.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/guide/platforms/wp8/plugin.html
+++ b/archive/docs/ru/7.x/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/ru/7.x/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/guide/platforms/wp8/vmware.html
+++ b/archive/docs/ru/7.x/guide/platforms/wp8/vmware.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/guide/platforms/wp8/webview.html
+++ b/archive/docs/ru/7.x/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/guide/support/index.html
+++ b/archive/docs/ru/7.x/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/index.html
+++ b/archive/docs/ru/7.x/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/ru/7.x/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/plugin_ref/plugman.html
+++ b/archive/docs/ru/7.x/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/7.x/plugin_ref/spec.html
+++ b/archive/docs/ru/7.x/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/config_ref/images.html
+++ b/archive/docs/ru/8.x/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/config_ref/index.html
+++ b/archive/docs/ru/8.x/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/cordova/events/events.backbutton.html
+++ b/archive/docs/ru/8.x/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/cordova/events/events.deviceready.html
+++ b/archive/docs/ru/8.x/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/cordova/events/events.endcallbutton.html
+++ b/archive/docs/ru/8.x/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/cordova/events/events.html
+++ b/archive/docs/ru/8.x/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/cordova/events/events.menubutton.html
+++ b/archive/docs/ru/8.x/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/cordova/events/events.pause.html
+++ b/archive/docs/ru/8.x/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/cordova/events/events.resume.html
+++ b/archive/docs/ru/8.x/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/cordova/events/events.searchbutton.html
+++ b/archive/docs/ru/8.x/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/cordova/events/events.startcallbutton.html
+++ b/archive/docs/ru/8.x/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/ru/8.x/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/ru/8.x/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/cordova/storage/storage.html
+++ b/archive/docs/ru/8.x/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/guide/appdev/hooks/index.html
+++ b/archive/docs/ru/8.x/guide/appdev/hooks/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/guide/appdev/privacy/index.html
+++ b/archive/docs/ru/8.x/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/guide/appdev/security/index.html
+++ b/archive/docs/ru/8.x/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/guide/appdev/whitelist/index.html
+++ b/archive/docs/ru/8.x/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/guide/cli/index.html
+++ b/archive/docs/ru/8.x/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/guide/hybrid/plugins/index.html
+++ b/archive/docs/ru/8.x/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/guide/hybrid/webviews/index.html
+++ b/archive/docs/ru/8.x/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/guide/next/index.html
+++ b/archive/docs/ru/8.x/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/guide/overview/index.html
+++ b/archive/docs/ru/8.x/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/guide/platforms/amazonfireos/config.html
+++ b/archive/docs/ru/8.x/guide/platforms/amazonfireos/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/guide/platforms/amazonfireos/index.html
+++ b/archive/docs/ru/8.x/guide/platforms/amazonfireos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/ru/8.x/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/ru/8.x/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/guide/platforms/android/config.html
+++ b/archive/docs/ru/8.x/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/guide/platforms/android/index.html
+++ b/archive/docs/ru/8.x/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/guide/platforms/android/plugin.html
+++ b/archive/docs/ru/8.x/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/guide/platforms/android/tools.html
+++ b/archive/docs/ru/8.x/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/guide/platforms/android/upgrade.html
+++ b/archive/docs/ru/8.x/guide/platforms/android/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/guide/platforms/android/webview.html
+++ b/archive/docs/ru/8.x/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/guide/platforms/blackberry10/config.html
+++ b/archive/docs/ru/8.x/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/guide/platforms/blackberry10/home.html
+++ b/archive/docs/ru/8.x/guide/platforms/blackberry10/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/guide/platforms/blackberry10/index.html
+++ b/archive/docs/ru/8.x/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/ru/8.x/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/ru/8.x/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/guide/platforms/blackberry10/upgrade.html
+++ b/archive/docs/ru/8.x/guide/platforms/blackberry10/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/guide/platforms/firefoxos/index.html
+++ b/archive/docs/ru/8.x/guide/platforms/firefoxos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/guide/platforms/index.html
+++ b/archive/docs/ru/8.x/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/guide/platforms/ios/config.html
+++ b/archive/docs/ru/8.x/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/guide/platforms/ios/index.html
+++ b/archive/docs/ru/8.x/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/guide/platforms/ios/plugin.html
+++ b/archive/docs/ru/8.x/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/guide/platforms/ios/tools.html
+++ b/archive/docs/ru/8.x/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/guide/platforms/ios/upgrade.html
+++ b/archive/docs/ru/8.x/guide/platforms/ios/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/guide/platforms/ios/webview.html
+++ b/archive/docs/ru/8.x/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/guide/platforms/tizen/index.html
+++ b/archive/docs/ru/8.x/guide/platforms/tizen/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/guide/platforms/ubuntu/index.html
+++ b/archive/docs/ru/8.x/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/guide/platforms/win8/index.html
+++ b/archive/docs/ru/8.x/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/guide/platforms/win8/packaging.html
+++ b/archive/docs/ru/8.x/guide/platforms/win8/packaging.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/guide/platforms/win8/plugin.html
+++ b/archive/docs/ru/8.x/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/guide/platforms/win8/upgrading.html
+++ b/archive/docs/ru/8.x/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/guide/platforms/wp8/home.html
+++ b/archive/docs/ru/8.x/guide/platforms/wp8/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/guide/platforms/wp8/index.html
+++ b/archive/docs/ru/8.x/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/guide/platforms/wp8/parallels.html
+++ b/archive/docs/ru/8.x/guide/platforms/wp8/parallels.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/guide/platforms/wp8/plugin.html
+++ b/archive/docs/ru/8.x/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/ru/8.x/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/guide/platforms/wp8/vmware.html
+++ b/archive/docs/ru/8.x/guide/platforms/wp8/vmware.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/guide/platforms/wp8/webview.html
+++ b/archive/docs/ru/8.x/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/guide/support/index.html
+++ b/archive/docs/ru/8.x/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/index.html
+++ b/archive/docs/ru/8.x/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/ru/8.x/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/plugin_ref/plugman.html
+++ b/archive/docs/ru/8.x/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/8.x/plugin_ref/spec.html
+++ b/archive/docs/ru/8.x/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/config_ref/images.html
+++ b/archive/docs/ru/9.x/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/config_ref/index.html
+++ b/archive/docs/ru/9.x/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/cordova/events/events.backbutton.html
+++ b/archive/docs/ru/9.x/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/cordova/events/events.deviceready.html
+++ b/archive/docs/ru/9.x/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/cordova/events/events.endcallbutton.html
+++ b/archive/docs/ru/9.x/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/cordova/events/events.html
+++ b/archive/docs/ru/9.x/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/cordova/events/events.menubutton.html
+++ b/archive/docs/ru/9.x/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/cordova/events/events.pause.html
+++ b/archive/docs/ru/9.x/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/cordova/events/events.resume.html
+++ b/archive/docs/ru/9.x/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/cordova/events/events.searchbutton.html
+++ b/archive/docs/ru/9.x/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/cordova/events/events.startcallbutton.html
+++ b/archive/docs/ru/9.x/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/ru/9.x/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/ru/9.x/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/cordova/storage/storage.html
+++ b/archive/docs/ru/9.x/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/guide/appdev/hooks/index.html
+++ b/archive/docs/ru/9.x/guide/appdev/hooks/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/guide/appdev/privacy/index.html
+++ b/archive/docs/ru/9.x/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/guide/appdev/security/index.html
+++ b/archive/docs/ru/9.x/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/guide/appdev/whitelist/index.html
+++ b/archive/docs/ru/9.x/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/guide/cli/index.html
+++ b/archive/docs/ru/9.x/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/guide/hybrid/plugins/index.html
+++ b/archive/docs/ru/9.x/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/guide/hybrid/webviews/index.html
+++ b/archive/docs/ru/9.x/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/guide/next/index.html
+++ b/archive/docs/ru/9.x/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/guide/overview/index.html
+++ b/archive/docs/ru/9.x/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/guide/platforms/amazonfireos/config.html
+++ b/archive/docs/ru/9.x/guide/platforms/amazonfireos/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/guide/platforms/amazonfireos/index.html
+++ b/archive/docs/ru/9.x/guide/platforms/amazonfireos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/ru/9.x/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/ru/9.x/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/guide/platforms/android/config.html
+++ b/archive/docs/ru/9.x/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/guide/platforms/android/index.html
+++ b/archive/docs/ru/9.x/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/guide/platforms/android/plugin.html
+++ b/archive/docs/ru/9.x/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/guide/platforms/android/tools.html
+++ b/archive/docs/ru/9.x/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/guide/platforms/android/upgrade.html
+++ b/archive/docs/ru/9.x/guide/platforms/android/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/guide/platforms/android/webview.html
+++ b/archive/docs/ru/9.x/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/guide/platforms/blackberry10/config.html
+++ b/archive/docs/ru/9.x/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/guide/platforms/blackberry10/home.html
+++ b/archive/docs/ru/9.x/guide/platforms/blackberry10/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/guide/platforms/blackberry10/index.html
+++ b/archive/docs/ru/9.x/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/ru/9.x/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/ru/9.x/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/guide/platforms/blackberry10/upgrade.html
+++ b/archive/docs/ru/9.x/guide/platforms/blackberry10/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/guide/platforms/firefoxos/index.html
+++ b/archive/docs/ru/9.x/guide/platforms/firefoxos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/guide/platforms/index.html
+++ b/archive/docs/ru/9.x/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/guide/platforms/ios/config.html
+++ b/archive/docs/ru/9.x/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/guide/platforms/ios/index.html
+++ b/archive/docs/ru/9.x/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/guide/platforms/ios/plugin.html
+++ b/archive/docs/ru/9.x/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/guide/platforms/ios/tools.html
+++ b/archive/docs/ru/9.x/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/guide/platforms/ios/upgrade.html
+++ b/archive/docs/ru/9.x/guide/platforms/ios/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/guide/platforms/ios/webview.html
+++ b/archive/docs/ru/9.x/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/guide/platforms/tizen/index.html
+++ b/archive/docs/ru/9.x/guide/platforms/tizen/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/guide/platforms/ubuntu/index.html
+++ b/archive/docs/ru/9.x/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/guide/platforms/win8/index.html
+++ b/archive/docs/ru/9.x/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/guide/platforms/win8/packaging.html
+++ b/archive/docs/ru/9.x/guide/platforms/win8/packaging.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/guide/platforms/win8/plugin.html
+++ b/archive/docs/ru/9.x/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/guide/platforms/win8/upgrading.html
+++ b/archive/docs/ru/9.x/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/guide/platforms/wp8/home.html
+++ b/archive/docs/ru/9.x/guide/platforms/wp8/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/guide/platforms/wp8/index.html
+++ b/archive/docs/ru/9.x/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/guide/platforms/wp8/parallels.html
+++ b/archive/docs/ru/9.x/guide/platforms/wp8/parallels.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/guide/platforms/wp8/plugin.html
+++ b/archive/docs/ru/9.x/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/ru/9.x/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/guide/platforms/wp8/vmware.html
+++ b/archive/docs/ru/9.x/guide/platforms/wp8/vmware.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/guide/platforms/wp8/webview.html
+++ b/archive/docs/ru/9.x/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/guide/support/index.html
+++ b/archive/docs/ru/9.x/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/index.html
+++ b/archive/docs/ru/9.x/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/ru/9.x/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/plugin_ref/plugman.html
+++ b/archive/docs/ru/9.x/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/ru/9.x/plugin_ref/spec.html
+++ b/archive/docs/ru/9.x/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/10.x/config_ref/images.html
+++ b/archive/docs/sl/10.x/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/10.x/config_ref/index.html
+++ b/archive/docs/sl/10.x/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/10.x/cordova/events/events.backbutton.html
+++ b/archive/docs/sl/10.x/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/10.x/cordova/events/events.deviceready.html
+++ b/archive/docs/sl/10.x/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/10.x/cordova/events/events.endcallbutton.html
+++ b/archive/docs/sl/10.x/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/10.x/cordova/events/events.html
+++ b/archive/docs/sl/10.x/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/10.x/cordova/events/events.menubutton.html
+++ b/archive/docs/sl/10.x/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/10.x/cordova/events/events.pause.html
+++ b/archive/docs/sl/10.x/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/10.x/cordova/events/events.resume.html
+++ b/archive/docs/sl/10.x/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/10.x/cordova/events/events.searchbutton.html
+++ b/archive/docs/sl/10.x/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/10.x/cordova/events/events.startcallbutton.html
+++ b/archive/docs/sl/10.x/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/10.x/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/sl/10.x/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/10.x/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/sl/10.x/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/10.x/cordova/storage/storage.html
+++ b/archive/docs/sl/10.x/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/10.x/guide/appdev/privacy/index.html
+++ b/archive/docs/sl/10.x/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/10.x/guide/appdev/whitelist/index.html
+++ b/archive/docs/sl/10.x/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/10.x/guide/cli/index.html
+++ b/archive/docs/sl/10.x/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/10.x/guide/hybrid/plugins/index.html
+++ b/archive/docs/sl/10.x/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/10.x/guide/hybrid/webviews/index.html
+++ b/archive/docs/sl/10.x/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/10.x/guide/overview/index.html
+++ b/archive/docs/sl/10.x/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/10.x/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/sl/10.x/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/10.x/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/sl/10.x/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/10.x/guide/platforms/android/config.html
+++ b/archive/docs/sl/10.x/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/10.x/guide/platforms/android/index.html
+++ b/archive/docs/sl/10.x/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/10.x/guide/platforms/android/plugin.html
+++ b/archive/docs/sl/10.x/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/10.x/guide/platforms/android/tools.html
+++ b/archive/docs/sl/10.x/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/10.x/guide/platforms/android/upgrading.html
+++ b/archive/docs/sl/10.x/guide/platforms/android/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/10.x/guide/platforms/android/webview.html
+++ b/archive/docs/sl/10.x/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/10.x/guide/platforms/blackberry10/config.html
+++ b/archive/docs/sl/10.x/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/10.x/guide/platforms/blackberry10/home.html
+++ b/archive/docs/sl/10.x/guide/platforms/blackberry10/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/10.x/guide/platforms/blackberry10/index.html
+++ b/archive/docs/sl/10.x/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/10.x/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/sl/10.x/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/10.x/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/sl/10.x/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/10.x/guide/platforms/ios/config.html
+++ b/archive/docs/sl/10.x/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/10.x/guide/platforms/ios/index.html
+++ b/archive/docs/sl/10.x/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/10.x/guide/platforms/ios/plugin.html
+++ b/archive/docs/sl/10.x/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/10.x/guide/platforms/ios/tools.html
+++ b/archive/docs/sl/10.x/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/10.x/guide/platforms/ios/upgrading.html
+++ b/archive/docs/sl/10.x/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/10.x/guide/platforms/ios/webview.html
+++ b/archive/docs/sl/10.x/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/10.x/guide/platforms/ubuntu/index.html
+++ b/archive/docs/sl/10.x/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/10.x/guide/platforms/win8/index.html
+++ b/archive/docs/sl/10.x/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/10.x/guide/platforms/win8/tools.html
+++ b/archive/docs/sl/10.x/guide/platforms/win8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/10.x/guide/platforms/win8/upgrading.html
+++ b/archive/docs/sl/10.x/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/10.x/guide/platforms/wp8/home.html
+++ b/archive/docs/sl/10.x/guide/platforms/wp8/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/10.x/guide/platforms/wp8/index.html
+++ b/archive/docs/sl/10.x/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/10.x/guide/platforms/wp8/plugin.html
+++ b/archive/docs/sl/10.x/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/10.x/guide/platforms/wp8/tools.html
+++ b/archive/docs/sl/10.x/guide/platforms/wp8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/10.x/guide/platforms/wp8/upgrading.html
+++ b/archive/docs/sl/10.x/guide/platforms/wp8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/10.x/guide/support/index.html
+++ b/archive/docs/sl/10.x/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/10.x/index.html
+++ b/archive/docs/sl/10.x/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/10.x/plugin_ref/plugman.html
+++ b/archive/docs/sl/10.x/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/10.x/plugin_ref/spec.html
+++ b/archive/docs/sl/10.x/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.4.0/config_ref/images.html
+++ b/archive/docs/sl/3.4.0/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.4.0/config_ref/index.html
+++ b/archive/docs/sl/3.4.0/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.4.0/cordova/events/events.backbutton.html
+++ b/archive/docs/sl/3.4.0/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.4.0/cordova/events/events.deviceready.html
+++ b/archive/docs/sl/3.4.0/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.4.0/cordova/events/events.endcallbutton.html
+++ b/archive/docs/sl/3.4.0/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.4.0/cordova/events/events.html
+++ b/archive/docs/sl/3.4.0/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.4.0/cordova/events/events.menubutton.html
+++ b/archive/docs/sl/3.4.0/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.4.0/cordova/events/events.pause.html
+++ b/archive/docs/sl/3.4.0/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.4.0/cordova/events/events.resume.html
+++ b/archive/docs/sl/3.4.0/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.4.0/cordova/events/events.searchbutton.html
+++ b/archive/docs/sl/3.4.0/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.4.0/cordova/events/events.startcallbutton.html
+++ b/archive/docs/sl/3.4.0/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.4.0/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/sl/3.4.0/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.4.0/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/sl/3.4.0/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.4.0/cordova/plugins/pluginapis.html
+++ b/archive/docs/sl/3.4.0/cordova/plugins/pluginapis.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.4.0/cordova/storage/storage.html
+++ b/archive/docs/sl/3.4.0/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.4.0/guide/appdev/privacy/index.html
+++ b/archive/docs/sl/3.4.0/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.4.0/guide/appdev/whitelist/index.html
+++ b/archive/docs/sl/3.4.0/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.4.0/guide/cli/index.html
+++ b/archive/docs/sl/3.4.0/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.4.0/guide/hybrid/plugins/index.html
+++ b/archive/docs/sl/3.4.0/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.4.0/guide/hybrid/webviews/index.html
+++ b/archive/docs/sl/3.4.0/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.4.0/guide/overview/index.html
+++ b/archive/docs/sl/3.4.0/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.4.0/guide/platforms/amazonfireos/config.html
+++ b/archive/docs/sl/3.4.0/guide/platforms/amazonfireos/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.4.0/guide/platforms/amazonfireos/index.html
+++ b/archive/docs/sl/3.4.0/guide/platforms/amazonfireos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.4.0/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/sl/3.4.0/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.4.0/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/sl/3.4.0/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.4.0/guide/platforms/android/config.html
+++ b/archive/docs/sl/3.4.0/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.4.0/guide/platforms/android/index.html
+++ b/archive/docs/sl/3.4.0/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.4.0/guide/platforms/android/plugin.html
+++ b/archive/docs/sl/3.4.0/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.4.0/guide/platforms/android/tools.html
+++ b/archive/docs/sl/3.4.0/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.4.0/guide/platforms/android/upgrading.html
+++ b/archive/docs/sl/3.4.0/guide/platforms/android/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.4.0/guide/platforms/android/webview.html
+++ b/archive/docs/sl/3.4.0/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.4.0/guide/platforms/blackberry10/config.html
+++ b/archive/docs/sl/3.4.0/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.4.0/guide/platforms/blackberry10/index.html
+++ b/archive/docs/sl/3.4.0/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.4.0/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/sl/3.4.0/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.4.0/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/sl/3.4.0/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.4.0/guide/platforms/blackberry10/upgrading.html
+++ b/archive/docs/sl/3.4.0/guide/platforms/blackberry10/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.4.0/guide/platforms/index.html
+++ b/archive/docs/sl/3.4.0/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.4.0/guide/platforms/ios/config.html
+++ b/archive/docs/sl/3.4.0/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.4.0/guide/platforms/ios/index.html
+++ b/archive/docs/sl/3.4.0/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.4.0/guide/platforms/ios/plugin.html
+++ b/archive/docs/sl/3.4.0/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.4.0/guide/platforms/ios/tools.html
+++ b/archive/docs/sl/3.4.0/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.4.0/guide/platforms/ios/upgrading.html
+++ b/archive/docs/sl/3.4.0/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.4.0/guide/platforms/ios/webview.html
+++ b/archive/docs/sl/3.4.0/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.4.0/guide/platforms/tizen/index.html
+++ b/archive/docs/sl/3.4.0/guide/platforms/tizen/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.4.0/guide/platforms/ubuntu/index.html
+++ b/archive/docs/sl/3.4.0/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.4.0/guide/platforms/win8/index.html
+++ b/archive/docs/sl/3.4.0/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.4.0/guide/platforms/win8/tools.html
+++ b/archive/docs/sl/3.4.0/guide/platforms/win8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.4.0/guide/platforms/win8/upgrading.html
+++ b/archive/docs/sl/3.4.0/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.4.0/guide/platforms/wp7/index.html
+++ b/archive/docs/sl/3.4.0/guide/platforms/wp7/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.4.0/guide/platforms/wp8/index.html
+++ b/archive/docs/sl/3.4.0/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.4.0/guide/platforms/wp8/plugin.html
+++ b/archive/docs/sl/3.4.0/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.4.0/guide/platforms/wp8/tools.html
+++ b/archive/docs/sl/3.4.0/guide/platforms/wp8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.4.0/guide/platforms/wp8/upgrading.html
+++ b/archive/docs/sl/3.4.0/guide/platforms/wp8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.4.0/guide/support/index.html
+++ b/archive/docs/sl/3.4.0/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.4.0/index.html
+++ b/archive/docs/sl/3.4.0/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.4.0/plugin_ref/plugman.html
+++ b/archive/docs/sl/3.4.0/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.5.0/config_ref/images.html
+++ b/archive/docs/sl/3.5.0/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.5.0/config_ref/index.html
+++ b/archive/docs/sl/3.5.0/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.5.0/cordova/events/events.backbutton.html
+++ b/archive/docs/sl/3.5.0/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.5.0/cordova/events/events.deviceready.html
+++ b/archive/docs/sl/3.5.0/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.5.0/cordova/events/events.endcallbutton.html
+++ b/archive/docs/sl/3.5.0/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.5.0/cordova/events/events.html
+++ b/archive/docs/sl/3.5.0/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.5.0/cordova/events/events.menubutton.html
+++ b/archive/docs/sl/3.5.0/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.5.0/cordova/events/events.pause.html
+++ b/archive/docs/sl/3.5.0/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.5.0/cordova/events/events.resume.html
+++ b/archive/docs/sl/3.5.0/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.5.0/cordova/events/events.searchbutton.html
+++ b/archive/docs/sl/3.5.0/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.5.0/cordova/events/events.startcallbutton.html
+++ b/archive/docs/sl/3.5.0/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.5.0/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/sl/3.5.0/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.5.0/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/sl/3.5.0/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.5.0/cordova/plugins/pluginapis.html
+++ b/archive/docs/sl/3.5.0/cordova/plugins/pluginapis.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.5.0/cordova/storage/storage.html
+++ b/archive/docs/sl/3.5.0/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.5.0/guide/appdev/privacy/index.html
+++ b/archive/docs/sl/3.5.0/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.5.0/guide/appdev/whitelist/index.html
+++ b/archive/docs/sl/3.5.0/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.5.0/guide/cli/index.html
+++ b/archive/docs/sl/3.5.0/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.5.0/guide/hybrid/plugins/index.html
+++ b/archive/docs/sl/3.5.0/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.5.0/guide/hybrid/webviews/index.html
+++ b/archive/docs/sl/3.5.0/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.5.0/guide/overview/index.html
+++ b/archive/docs/sl/3.5.0/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.5.0/guide/platforms/amazonfireos/config.html
+++ b/archive/docs/sl/3.5.0/guide/platforms/amazonfireos/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.5.0/guide/platforms/amazonfireos/index.html
+++ b/archive/docs/sl/3.5.0/guide/platforms/amazonfireos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.5.0/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/sl/3.5.0/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.5.0/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/sl/3.5.0/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.5.0/guide/platforms/android/config.html
+++ b/archive/docs/sl/3.5.0/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.5.0/guide/platforms/android/index.html
+++ b/archive/docs/sl/3.5.0/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.5.0/guide/platforms/android/plugin.html
+++ b/archive/docs/sl/3.5.0/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.5.0/guide/platforms/android/tools.html
+++ b/archive/docs/sl/3.5.0/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.5.0/guide/platforms/android/upgrading.html
+++ b/archive/docs/sl/3.5.0/guide/platforms/android/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.5.0/guide/platforms/android/webview.html
+++ b/archive/docs/sl/3.5.0/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.5.0/guide/platforms/blackberry10/config.html
+++ b/archive/docs/sl/3.5.0/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.5.0/guide/platforms/blackberry10/index.html
+++ b/archive/docs/sl/3.5.0/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.5.0/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/sl/3.5.0/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.5.0/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/sl/3.5.0/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.5.0/guide/platforms/blackberry10/upgrading.html
+++ b/archive/docs/sl/3.5.0/guide/platforms/blackberry10/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.5.0/guide/platforms/index.html
+++ b/archive/docs/sl/3.5.0/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.5.0/guide/platforms/ios/config.html
+++ b/archive/docs/sl/3.5.0/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.5.0/guide/platforms/ios/index.html
+++ b/archive/docs/sl/3.5.0/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.5.0/guide/platforms/ios/plugin.html
+++ b/archive/docs/sl/3.5.0/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.5.0/guide/platforms/ios/tools.html
+++ b/archive/docs/sl/3.5.0/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.5.0/guide/platforms/ios/upgrading.html
+++ b/archive/docs/sl/3.5.0/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.5.0/guide/platforms/ios/webview.html
+++ b/archive/docs/sl/3.5.0/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.5.0/guide/platforms/tizen/index.html
+++ b/archive/docs/sl/3.5.0/guide/platforms/tizen/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.5.0/guide/platforms/ubuntu/index.html
+++ b/archive/docs/sl/3.5.0/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.5.0/guide/platforms/win8/index.html
+++ b/archive/docs/sl/3.5.0/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.5.0/guide/platforms/win8/tools.html
+++ b/archive/docs/sl/3.5.0/guide/platforms/win8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.5.0/guide/platforms/win8/upgrading.html
+++ b/archive/docs/sl/3.5.0/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.5.0/guide/platforms/wp7/index.html
+++ b/archive/docs/sl/3.5.0/guide/platforms/wp7/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.5.0/guide/platforms/wp8/index.html
+++ b/archive/docs/sl/3.5.0/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.5.0/guide/platforms/wp8/plugin.html
+++ b/archive/docs/sl/3.5.0/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.5.0/guide/platforms/wp8/tools.html
+++ b/archive/docs/sl/3.5.0/guide/platforms/wp8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.5.0/guide/platforms/wp8/upgrading.html
+++ b/archive/docs/sl/3.5.0/guide/platforms/wp8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.5.0/guide/support/index.html
+++ b/archive/docs/sl/3.5.0/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.5.0/index.html
+++ b/archive/docs/sl/3.5.0/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/3.5.0/plugin_ref/plugman.html
+++ b/archive/docs/sl/3.5.0/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/config_ref/images.html
+++ b/archive/docs/sl/5.4.0/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/config_ref/index.html
+++ b/archive/docs/sl/5.4.0/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/cordova/events/events.backbutton.html
+++ b/archive/docs/sl/5.4.0/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/cordova/events/events.deviceready.html
+++ b/archive/docs/sl/5.4.0/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/cordova/events/events.endcallbutton.html
+++ b/archive/docs/sl/5.4.0/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/cordova/events/events.html
+++ b/archive/docs/sl/5.4.0/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/cordova/events/events.menubutton.html
+++ b/archive/docs/sl/5.4.0/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/cordova/events/events.pause.html
+++ b/archive/docs/sl/5.4.0/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/cordova/events/events.resume.html
+++ b/archive/docs/sl/5.4.0/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/cordova/events/events.searchbutton.html
+++ b/archive/docs/sl/5.4.0/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/cordova/events/events.startcallbutton.html
+++ b/archive/docs/sl/5.4.0/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/sl/5.4.0/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/sl/5.4.0/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/cordova/plugins/pluginapis.html
+++ b/archive/docs/sl/5.4.0/cordova/plugins/pluginapis.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/cordova/storage/storage.html
+++ b/archive/docs/sl/5.4.0/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/guide/appdev/privacy/index.html
+++ b/archive/docs/sl/5.4.0/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/guide/appdev/whitelist/index.html
+++ b/archive/docs/sl/5.4.0/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/guide/cli/index.html
+++ b/archive/docs/sl/5.4.0/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/guide/hybrid/plugins/index.html
+++ b/archive/docs/sl/5.4.0/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/guide/hybrid/webviews/index.html
+++ b/archive/docs/sl/5.4.0/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/guide/overview/index.html
+++ b/archive/docs/sl/5.4.0/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/guide/platforms/amazonfireos/config.html
+++ b/archive/docs/sl/5.4.0/guide/platforms/amazonfireos/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/guide/platforms/amazonfireos/index.html
+++ b/archive/docs/sl/5.4.0/guide/platforms/amazonfireos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/sl/5.4.0/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/sl/5.4.0/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/guide/platforms/android/config.html
+++ b/archive/docs/sl/5.4.0/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/guide/platforms/android/index.html
+++ b/archive/docs/sl/5.4.0/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/guide/platforms/android/plugin.html
+++ b/archive/docs/sl/5.4.0/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/guide/platforms/android/tools.html
+++ b/archive/docs/sl/5.4.0/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/guide/platforms/android/upgrading.html
+++ b/archive/docs/sl/5.4.0/guide/platforms/android/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/guide/platforms/android/webview.html
+++ b/archive/docs/sl/5.4.0/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/guide/platforms/blackberry10/config.html
+++ b/archive/docs/sl/5.4.0/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/guide/platforms/blackberry10/index.html
+++ b/archive/docs/sl/5.4.0/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/sl/5.4.0/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/sl/5.4.0/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/guide/platforms/blackberry10/upgrading.html
+++ b/archive/docs/sl/5.4.0/guide/platforms/blackberry10/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/guide/platforms/index.html
+++ b/archive/docs/sl/5.4.0/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/guide/platforms/ios/config.html
+++ b/archive/docs/sl/5.4.0/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/guide/platforms/ios/index.html
+++ b/archive/docs/sl/5.4.0/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/guide/platforms/ios/plugin.html
+++ b/archive/docs/sl/5.4.0/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/guide/platforms/ios/tools.html
+++ b/archive/docs/sl/5.4.0/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/guide/platforms/ios/upgrading.html
+++ b/archive/docs/sl/5.4.0/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/guide/platforms/ios/webview.html
+++ b/archive/docs/sl/5.4.0/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/guide/platforms/tizen/index.html
+++ b/archive/docs/sl/5.4.0/guide/platforms/tizen/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/guide/platforms/ubuntu/index.html
+++ b/archive/docs/sl/5.4.0/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/guide/platforms/win8/index.html
+++ b/archive/docs/sl/5.4.0/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/guide/platforms/win8/tools.html
+++ b/archive/docs/sl/5.4.0/guide/platforms/win8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/guide/platforms/win8/upgrading.html
+++ b/archive/docs/sl/5.4.0/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/guide/platforms/wp7/index.html
+++ b/archive/docs/sl/5.4.0/guide/platforms/wp7/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/guide/platforms/wp8/index.html
+++ b/archive/docs/sl/5.4.0/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/guide/platforms/wp8/plugin.html
+++ b/archive/docs/sl/5.4.0/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/guide/platforms/wp8/tools.html
+++ b/archive/docs/sl/5.4.0/guide/platforms/wp8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/guide/platforms/wp8/upgrading.html
+++ b/archive/docs/sl/5.4.0/guide/platforms/wp8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/guide/support/index.html
+++ b/archive/docs/sl/5.4.0/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/index.html
+++ b/archive/docs/sl/5.4.0/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/plugin_ref/plugman.html
+++ b/archive/docs/sl/5.4.0/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/5.4.0/plugin_ref/spec.html
+++ b/archive/docs/sl/5.4.0/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/6.x/config_ref/images.html
+++ b/archive/docs/sl/6.x/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/6.x/config_ref/index.html
+++ b/archive/docs/sl/6.x/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/6.x/cordova/events/events.backbutton.html
+++ b/archive/docs/sl/6.x/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/6.x/cordova/events/events.deviceready.html
+++ b/archive/docs/sl/6.x/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/6.x/cordova/events/events.endcallbutton.html
+++ b/archive/docs/sl/6.x/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/6.x/cordova/events/events.html
+++ b/archive/docs/sl/6.x/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/6.x/cordova/events/events.menubutton.html
+++ b/archive/docs/sl/6.x/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/6.x/cordova/events/events.pause.html
+++ b/archive/docs/sl/6.x/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/6.x/cordova/events/events.resume.html
+++ b/archive/docs/sl/6.x/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/6.x/cordova/events/events.searchbutton.html
+++ b/archive/docs/sl/6.x/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/6.x/cordova/events/events.startcallbutton.html
+++ b/archive/docs/sl/6.x/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/6.x/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/sl/6.x/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/6.x/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/sl/6.x/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/6.x/cordova/storage/storage.html
+++ b/archive/docs/sl/6.x/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/6.x/guide/appdev/privacy/index.html
+++ b/archive/docs/sl/6.x/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/6.x/guide/appdev/whitelist/index.html
+++ b/archive/docs/sl/6.x/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/6.x/guide/cli/index.html
+++ b/archive/docs/sl/6.x/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/6.x/guide/hybrid/plugins/index.html
+++ b/archive/docs/sl/6.x/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/6.x/guide/hybrid/webviews/index.html
+++ b/archive/docs/sl/6.x/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/6.x/guide/overview/index.html
+++ b/archive/docs/sl/6.x/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/6.x/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/sl/6.x/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/6.x/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/sl/6.x/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/6.x/guide/platforms/android/config.html
+++ b/archive/docs/sl/6.x/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/6.x/guide/platforms/android/index.html
+++ b/archive/docs/sl/6.x/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/6.x/guide/platforms/android/plugin.html
+++ b/archive/docs/sl/6.x/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/6.x/guide/platforms/android/tools.html
+++ b/archive/docs/sl/6.x/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/6.x/guide/platforms/android/upgrading.html
+++ b/archive/docs/sl/6.x/guide/platforms/android/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/6.x/guide/platforms/android/webview.html
+++ b/archive/docs/sl/6.x/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/6.x/guide/platforms/blackberry10/config.html
+++ b/archive/docs/sl/6.x/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/6.x/guide/platforms/blackberry10/home.html
+++ b/archive/docs/sl/6.x/guide/platforms/blackberry10/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/6.x/guide/platforms/blackberry10/index.html
+++ b/archive/docs/sl/6.x/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/6.x/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/sl/6.x/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/6.x/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/sl/6.x/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/6.x/guide/platforms/ios/config.html
+++ b/archive/docs/sl/6.x/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/6.x/guide/platforms/ios/index.html
+++ b/archive/docs/sl/6.x/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/6.x/guide/platforms/ios/plugin.html
+++ b/archive/docs/sl/6.x/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/6.x/guide/platforms/ios/tools.html
+++ b/archive/docs/sl/6.x/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/6.x/guide/platforms/ios/upgrading.html
+++ b/archive/docs/sl/6.x/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/6.x/guide/platforms/ios/webview.html
+++ b/archive/docs/sl/6.x/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/6.x/guide/platforms/ubuntu/index.html
+++ b/archive/docs/sl/6.x/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/6.x/guide/platforms/win8/index.html
+++ b/archive/docs/sl/6.x/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/6.x/guide/platforms/win8/tools.html
+++ b/archive/docs/sl/6.x/guide/platforms/win8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/6.x/guide/platforms/win8/upgrading.html
+++ b/archive/docs/sl/6.x/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/6.x/guide/platforms/wp8/home.html
+++ b/archive/docs/sl/6.x/guide/platforms/wp8/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/6.x/guide/platforms/wp8/index.html
+++ b/archive/docs/sl/6.x/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/6.x/guide/platforms/wp8/plugin.html
+++ b/archive/docs/sl/6.x/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/6.x/guide/platforms/wp8/tools.html
+++ b/archive/docs/sl/6.x/guide/platforms/wp8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/6.x/guide/platforms/wp8/upgrading.html
+++ b/archive/docs/sl/6.x/guide/platforms/wp8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/6.x/guide/support/index.html
+++ b/archive/docs/sl/6.x/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/6.x/index.html
+++ b/archive/docs/sl/6.x/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/6.x/plugin_ref/plugman.html
+++ b/archive/docs/sl/6.x/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/6.x/plugin_ref/spec.html
+++ b/archive/docs/sl/6.x/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/7.x/config_ref/images.html
+++ b/archive/docs/sl/7.x/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/7.x/config_ref/index.html
+++ b/archive/docs/sl/7.x/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/7.x/cordova/events/events.backbutton.html
+++ b/archive/docs/sl/7.x/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/7.x/cordova/events/events.deviceready.html
+++ b/archive/docs/sl/7.x/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/7.x/cordova/events/events.endcallbutton.html
+++ b/archive/docs/sl/7.x/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/7.x/cordova/events/events.html
+++ b/archive/docs/sl/7.x/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/7.x/cordova/events/events.menubutton.html
+++ b/archive/docs/sl/7.x/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/7.x/cordova/events/events.pause.html
+++ b/archive/docs/sl/7.x/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/7.x/cordova/events/events.resume.html
+++ b/archive/docs/sl/7.x/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/7.x/cordova/events/events.searchbutton.html
+++ b/archive/docs/sl/7.x/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/7.x/cordova/events/events.startcallbutton.html
+++ b/archive/docs/sl/7.x/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/7.x/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/sl/7.x/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/7.x/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/sl/7.x/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/7.x/cordova/storage/storage.html
+++ b/archive/docs/sl/7.x/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/7.x/guide/appdev/privacy/index.html
+++ b/archive/docs/sl/7.x/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/7.x/guide/appdev/whitelist/index.html
+++ b/archive/docs/sl/7.x/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/7.x/guide/cli/index.html
+++ b/archive/docs/sl/7.x/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/7.x/guide/hybrid/plugins/index.html
+++ b/archive/docs/sl/7.x/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/7.x/guide/hybrid/webviews/index.html
+++ b/archive/docs/sl/7.x/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/7.x/guide/overview/index.html
+++ b/archive/docs/sl/7.x/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/7.x/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/sl/7.x/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/7.x/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/sl/7.x/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/7.x/guide/platforms/android/config.html
+++ b/archive/docs/sl/7.x/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/7.x/guide/platforms/android/index.html
+++ b/archive/docs/sl/7.x/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/7.x/guide/platforms/android/plugin.html
+++ b/archive/docs/sl/7.x/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/7.x/guide/platforms/android/tools.html
+++ b/archive/docs/sl/7.x/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/7.x/guide/platforms/android/upgrading.html
+++ b/archive/docs/sl/7.x/guide/platforms/android/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/7.x/guide/platforms/android/webview.html
+++ b/archive/docs/sl/7.x/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/7.x/guide/platforms/blackberry10/config.html
+++ b/archive/docs/sl/7.x/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/7.x/guide/platforms/blackberry10/home.html
+++ b/archive/docs/sl/7.x/guide/platforms/blackberry10/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/7.x/guide/platforms/blackberry10/index.html
+++ b/archive/docs/sl/7.x/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/7.x/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/sl/7.x/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/7.x/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/sl/7.x/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/7.x/guide/platforms/ios/config.html
+++ b/archive/docs/sl/7.x/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/7.x/guide/platforms/ios/index.html
+++ b/archive/docs/sl/7.x/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/7.x/guide/platforms/ios/plugin.html
+++ b/archive/docs/sl/7.x/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/7.x/guide/platforms/ios/tools.html
+++ b/archive/docs/sl/7.x/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/7.x/guide/platforms/ios/upgrading.html
+++ b/archive/docs/sl/7.x/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/7.x/guide/platforms/ios/webview.html
+++ b/archive/docs/sl/7.x/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/7.x/guide/platforms/ubuntu/index.html
+++ b/archive/docs/sl/7.x/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/7.x/guide/platforms/win8/index.html
+++ b/archive/docs/sl/7.x/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/7.x/guide/platforms/win8/tools.html
+++ b/archive/docs/sl/7.x/guide/platforms/win8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/7.x/guide/platforms/win8/upgrading.html
+++ b/archive/docs/sl/7.x/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/7.x/guide/platforms/wp8/home.html
+++ b/archive/docs/sl/7.x/guide/platforms/wp8/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/7.x/guide/platforms/wp8/index.html
+++ b/archive/docs/sl/7.x/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/7.x/guide/platforms/wp8/plugin.html
+++ b/archive/docs/sl/7.x/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/7.x/guide/platforms/wp8/tools.html
+++ b/archive/docs/sl/7.x/guide/platforms/wp8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/7.x/guide/platforms/wp8/upgrading.html
+++ b/archive/docs/sl/7.x/guide/platforms/wp8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/7.x/guide/support/index.html
+++ b/archive/docs/sl/7.x/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/7.x/index.html
+++ b/archive/docs/sl/7.x/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/7.x/plugin_ref/plugman.html
+++ b/archive/docs/sl/7.x/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/7.x/plugin_ref/spec.html
+++ b/archive/docs/sl/7.x/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/8.x/config_ref/images.html
+++ b/archive/docs/sl/8.x/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/8.x/config_ref/index.html
+++ b/archive/docs/sl/8.x/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/8.x/cordova/events/events.backbutton.html
+++ b/archive/docs/sl/8.x/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/8.x/cordova/events/events.deviceready.html
+++ b/archive/docs/sl/8.x/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/8.x/cordova/events/events.endcallbutton.html
+++ b/archive/docs/sl/8.x/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/8.x/cordova/events/events.html
+++ b/archive/docs/sl/8.x/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/8.x/cordova/events/events.menubutton.html
+++ b/archive/docs/sl/8.x/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/8.x/cordova/events/events.pause.html
+++ b/archive/docs/sl/8.x/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/8.x/cordova/events/events.resume.html
+++ b/archive/docs/sl/8.x/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/8.x/cordova/events/events.searchbutton.html
+++ b/archive/docs/sl/8.x/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/8.x/cordova/events/events.startcallbutton.html
+++ b/archive/docs/sl/8.x/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/8.x/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/sl/8.x/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/8.x/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/sl/8.x/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/8.x/cordova/storage/storage.html
+++ b/archive/docs/sl/8.x/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/8.x/guide/appdev/privacy/index.html
+++ b/archive/docs/sl/8.x/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/8.x/guide/appdev/whitelist/index.html
+++ b/archive/docs/sl/8.x/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/8.x/guide/cli/index.html
+++ b/archive/docs/sl/8.x/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/8.x/guide/hybrid/plugins/index.html
+++ b/archive/docs/sl/8.x/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/8.x/guide/hybrid/webviews/index.html
+++ b/archive/docs/sl/8.x/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/8.x/guide/overview/index.html
+++ b/archive/docs/sl/8.x/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/8.x/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/sl/8.x/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/8.x/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/sl/8.x/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/8.x/guide/platforms/android/config.html
+++ b/archive/docs/sl/8.x/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/8.x/guide/platforms/android/index.html
+++ b/archive/docs/sl/8.x/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/8.x/guide/platforms/android/plugin.html
+++ b/archive/docs/sl/8.x/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/8.x/guide/platforms/android/tools.html
+++ b/archive/docs/sl/8.x/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/8.x/guide/platforms/android/upgrading.html
+++ b/archive/docs/sl/8.x/guide/platforms/android/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/8.x/guide/platforms/android/webview.html
+++ b/archive/docs/sl/8.x/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/8.x/guide/platforms/blackberry10/config.html
+++ b/archive/docs/sl/8.x/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/8.x/guide/platforms/blackberry10/home.html
+++ b/archive/docs/sl/8.x/guide/platforms/blackberry10/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/8.x/guide/platforms/blackberry10/index.html
+++ b/archive/docs/sl/8.x/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/8.x/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/sl/8.x/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/8.x/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/sl/8.x/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/8.x/guide/platforms/ios/config.html
+++ b/archive/docs/sl/8.x/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/8.x/guide/platforms/ios/index.html
+++ b/archive/docs/sl/8.x/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/8.x/guide/platforms/ios/plugin.html
+++ b/archive/docs/sl/8.x/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/8.x/guide/platforms/ios/tools.html
+++ b/archive/docs/sl/8.x/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/8.x/guide/platforms/ios/upgrading.html
+++ b/archive/docs/sl/8.x/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/8.x/guide/platforms/ios/webview.html
+++ b/archive/docs/sl/8.x/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/8.x/guide/platforms/ubuntu/index.html
+++ b/archive/docs/sl/8.x/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/8.x/guide/platforms/win8/index.html
+++ b/archive/docs/sl/8.x/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/8.x/guide/platforms/win8/tools.html
+++ b/archive/docs/sl/8.x/guide/platforms/win8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/8.x/guide/platforms/win8/upgrading.html
+++ b/archive/docs/sl/8.x/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/8.x/guide/platforms/wp8/home.html
+++ b/archive/docs/sl/8.x/guide/platforms/wp8/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/8.x/guide/platforms/wp8/index.html
+++ b/archive/docs/sl/8.x/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/8.x/guide/platforms/wp8/plugin.html
+++ b/archive/docs/sl/8.x/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/8.x/guide/platforms/wp8/tools.html
+++ b/archive/docs/sl/8.x/guide/platforms/wp8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/8.x/guide/platforms/wp8/upgrading.html
+++ b/archive/docs/sl/8.x/guide/platforms/wp8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/8.x/guide/support/index.html
+++ b/archive/docs/sl/8.x/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/8.x/index.html
+++ b/archive/docs/sl/8.x/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/8.x/plugin_ref/plugman.html
+++ b/archive/docs/sl/8.x/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/8.x/plugin_ref/spec.html
+++ b/archive/docs/sl/8.x/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/9.x/config_ref/images.html
+++ b/archive/docs/sl/9.x/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/9.x/config_ref/index.html
+++ b/archive/docs/sl/9.x/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/9.x/cordova/events/events.backbutton.html
+++ b/archive/docs/sl/9.x/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/9.x/cordova/events/events.deviceready.html
+++ b/archive/docs/sl/9.x/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/9.x/cordova/events/events.endcallbutton.html
+++ b/archive/docs/sl/9.x/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/9.x/cordova/events/events.html
+++ b/archive/docs/sl/9.x/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/9.x/cordova/events/events.menubutton.html
+++ b/archive/docs/sl/9.x/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/9.x/cordova/events/events.pause.html
+++ b/archive/docs/sl/9.x/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/9.x/cordova/events/events.resume.html
+++ b/archive/docs/sl/9.x/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/9.x/cordova/events/events.searchbutton.html
+++ b/archive/docs/sl/9.x/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/9.x/cordova/events/events.startcallbutton.html
+++ b/archive/docs/sl/9.x/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/9.x/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/sl/9.x/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/9.x/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/sl/9.x/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/9.x/cordova/storage/storage.html
+++ b/archive/docs/sl/9.x/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/9.x/guide/appdev/privacy/index.html
+++ b/archive/docs/sl/9.x/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/9.x/guide/appdev/whitelist/index.html
+++ b/archive/docs/sl/9.x/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/9.x/guide/cli/index.html
+++ b/archive/docs/sl/9.x/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/9.x/guide/hybrid/plugins/index.html
+++ b/archive/docs/sl/9.x/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/9.x/guide/hybrid/webviews/index.html
+++ b/archive/docs/sl/9.x/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/9.x/guide/overview/index.html
+++ b/archive/docs/sl/9.x/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/9.x/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/sl/9.x/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/9.x/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/sl/9.x/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/9.x/guide/platforms/android/config.html
+++ b/archive/docs/sl/9.x/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/9.x/guide/platforms/android/index.html
+++ b/archive/docs/sl/9.x/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/9.x/guide/platforms/android/plugin.html
+++ b/archive/docs/sl/9.x/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/9.x/guide/platforms/android/tools.html
+++ b/archive/docs/sl/9.x/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/9.x/guide/platforms/android/upgrading.html
+++ b/archive/docs/sl/9.x/guide/platforms/android/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/9.x/guide/platforms/android/webview.html
+++ b/archive/docs/sl/9.x/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/9.x/guide/platforms/blackberry10/config.html
+++ b/archive/docs/sl/9.x/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/9.x/guide/platforms/blackberry10/home.html
+++ b/archive/docs/sl/9.x/guide/platforms/blackberry10/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/9.x/guide/platforms/blackberry10/index.html
+++ b/archive/docs/sl/9.x/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/9.x/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/sl/9.x/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/9.x/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/sl/9.x/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/9.x/guide/platforms/ios/config.html
+++ b/archive/docs/sl/9.x/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/9.x/guide/platforms/ios/index.html
+++ b/archive/docs/sl/9.x/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/9.x/guide/platforms/ios/plugin.html
+++ b/archive/docs/sl/9.x/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/9.x/guide/platforms/ios/tools.html
+++ b/archive/docs/sl/9.x/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/9.x/guide/platforms/ios/upgrading.html
+++ b/archive/docs/sl/9.x/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/9.x/guide/platforms/ios/webview.html
+++ b/archive/docs/sl/9.x/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/9.x/guide/platforms/ubuntu/index.html
+++ b/archive/docs/sl/9.x/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/9.x/guide/platforms/win8/index.html
+++ b/archive/docs/sl/9.x/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/9.x/guide/platforms/win8/tools.html
+++ b/archive/docs/sl/9.x/guide/platforms/win8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/9.x/guide/platforms/win8/upgrading.html
+++ b/archive/docs/sl/9.x/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/9.x/guide/platforms/wp8/home.html
+++ b/archive/docs/sl/9.x/guide/platforms/wp8/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/9.x/guide/platforms/wp8/index.html
+++ b/archive/docs/sl/9.x/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/9.x/guide/platforms/wp8/plugin.html
+++ b/archive/docs/sl/9.x/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/9.x/guide/platforms/wp8/tools.html
+++ b/archive/docs/sl/9.x/guide/platforms/wp8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/9.x/guide/platforms/wp8/upgrading.html
+++ b/archive/docs/sl/9.x/guide/platforms/wp8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/9.x/guide/support/index.html
+++ b/archive/docs/sl/9.x/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/9.x/index.html
+++ b/archive/docs/sl/9.x/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/9.x/plugin_ref/plugman.html
+++ b/archive/docs/sl/9.x/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/sl/9.x/plugin_ref/spec.html
+++ b/archive/docs/sl/9.x/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/10.x/config_ref/images.html
+++ b/archive/docs/zh-cn/10.x/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/10.x/config_ref/index.html
+++ b/archive/docs/zh-cn/10.x/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/10.x/cordova/events/events.backbutton.html
+++ b/archive/docs/zh-cn/10.x/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/10.x/cordova/events/events.deviceready.html
+++ b/archive/docs/zh-cn/10.x/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/10.x/cordova/events/events.endcallbutton.html
+++ b/archive/docs/zh-cn/10.x/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/10.x/cordova/events/events.html
+++ b/archive/docs/zh-cn/10.x/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/10.x/cordova/events/events.menubutton.html
+++ b/archive/docs/zh-cn/10.x/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/10.x/cordova/events/events.pause.html
+++ b/archive/docs/zh-cn/10.x/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/10.x/cordova/events/events.resume.html
+++ b/archive/docs/zh-cn/10.x/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/10.x/cordova/events/events.searchbutton.html
+++ b/archive/docs/zh-cn/10.x/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/10.x/cordova/events/events.startcallbutton.html
+++ b/archive/docs/zh-cn/10.x/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/10.x/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/zh-cn/10.x/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/10.x/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/zh-cn/10.x/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/10.x/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/zh-cn/10.x/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/10.x/cordova/storage/storage.html
+++ b/archive/docs/zh-cn/10.x/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/10.x/guide/appdev/hooks/index.html
+++ b/archive/docs/zh-cn/10.x/guide/appdev/hooks/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/10.x/guide/appdev/privacy/index.html
+++ b/archive/docs/zh-cn/10.x/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/10.x/guide/appdev/security/index.html
+++ b/archive/docs/zh-cn/10.x/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/10.x/guide/appdev/whitelist/index.html
+++ b/archive/docs/zh-cn/10.x/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/10.x/guide/cli/index.html
+++ b/archive/docs/zh-cn/10.x/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/10.x/guide/hybrid/plugins/index.html
+++ b/archive/docs/zh-cn/10.x/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/10.x/guide/hybrid/webviews/index.html
+++ b/archive/docs/zh-cn/10.x/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/10.x/guide/next/index.html
+++ b/archive/docs/zh-cn/10.x/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/10.x/guide/overview/index.html
+++ b/archive/docs/zh-cn/10.x/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/10.x/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/zh-cn/10.x/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/10.x/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/zh-cn/10.x/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/10.x/guide/platforms/android/config.html
+++ b/archive/docs/zh-cn/10.x/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/10.x/guide/platforms/android/index.html
+++ b/archive/docs/zh-cn/10.x/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/10.x/guide/platforms/android/plugin.html
+++ b/archive/docs/zh-cn/10.x/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/10.x/guide/platforms/android/webview.html
+++ b/archive/docs/zh-cn/10.x/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/10.x/guide/platforms/blackberry10/config.html
+++ b/archive/docs/zh-cn/10.x/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/10.x/guide/platforms/blackberry10/home.html
+++ b/archive/docs/zh-cn/10.x/guide/platforms/blackberry10/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/10.x/guide/platforms/blackberry10/index.html
+++ b/archive/docs/zh-cn/10.x/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/10.x/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/zh-cn/10.x/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/10.x/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/zh-cn/10.x/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/10.x/guide/platforms/blackberry10/upgrade.html
+++ b/archive/docs/zh-cn/10.x/guide/platforms/blackberry10/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/10.x/guide/platforms/ios/config.html
+++ b/archive/docs/zh-cn/10.x/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/10.x/guide/platforms/ios/index.html
+++ b/archive/docs/zh-cn/10.x/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/10.x/guide/platforms/ios/plugin.html
+++ b/archive/docs/zh-cn/10.x/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/10.x/guide/platforms/ios/tools.html
+++ b/archive/docs/zh-cn/10.x/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/10.x/guide/platforms/ios/upgrading.html
+++ b/archive/docs/zh-cn/10.x/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/10.x/guide/platforms/ios/webview.html
+++ b/archive/docs/zh-cn/10.x/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/10.x/guide/platforms/ubuntu/index.html
+++ b/archive/docs/zh-cn/10.x/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/10.x/guide/platforms/win8/index.html
+++ b/archive/docs/zh-cn/10.x/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/10.x/guide/platforms/win8/plugin.html
+++ b/archive/docs/zh-cn/10.x/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/10.x/guide/platforms/wp8/home.html
+++ b/archive/docs/zh-cn/10.x/guide/platforms/wp8/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/10.x/guide/platforms/wp8/index.html
+++ b/archive/docs/zh-cn/10.x/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/10.x/guide/platforms/wp8/plugin.html
+++ b/archive/docs/zh-cn/10.x/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/10.x/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/zh-cn/10.x/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/10.x/guide/platforms/wp8/webview.html
+++ b/archive/docs/zh-cn/10.x/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/10.x/guide/support/index.html
+++ b/archive/docs/zh-cn/10.x/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/10.x/index.html
+++ b/archive/docs/zh-cn/10.x/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/10.x/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/zh-cn/10.x/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/10.x/plugin_ref/plugman.html
+++ b/archive/docs/zh-cn/10.x/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/10.x/plugin_ref/spec.html
+++ b/archive/docs/zh-cn/10.x/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/config_ref/images.html
+++ b/archive/docs/zh-cn/3.1.0/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/config_ref/index.html
+++ b/archive/docs/zh-cn/3.1.0/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/accelerometer/acceleration/acceleration.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/accelerometer/acceleration/acceleration.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/accelerometer/accelerometer.clearWatch.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/accelerometer/accelerometer.clearWatch.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/accelerometer/accelerometer.getCurrentAcceleration.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/accelerometer/accelerometer.getCurrentAcceleration.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/accelerometer/accelerometer.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/accelerometer/accelerometer.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/accelerometer/accelerometer.watchAcceleration.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/accelerometer/accelerometer.watchAcceleration.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/accelerometer/parameters/accelerometerError.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/accelerometer/parameters/accelerometerError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/accelerometer/parameters/accelerometerOptions.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/accelerometer/parameters/accelerometerOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/accelerometer/parameters/accelerometerSuccess.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/accelerometer/parameters/accelerometerSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/camera/camera.cleanup.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/camera/camera.cleanup.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/camera/camera.getPicture.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/camera/camera.getPicture.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/camera/camera.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/camera/camera.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/compass/compass.clearWatch.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/compass/compass.clearWatch.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/compass/compass.clearWatchFilter.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/compass/compass.clearWatchFilter.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/compass/compass.getCurrentHeading.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/compass/compass.getCurrentHeading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/compass/compass.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/compass/compass.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/compass/compass.watchHeading.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/compass/compass.watchHeading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/compass/compass.watchHeadingFilter.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/compass/compass.watchHeadingFilter.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/compass/parameters/compassError.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/compass/parameters/compassError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/compass/parameters/compassHeading.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/compass/parameters/compassHeading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/compass/parameters/compassOptions.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/compass/parameters/compassOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/compass/parameters/compassSuccess.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/compass/parameters/compassSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/connection/connection.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/connection/connection.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/connection/connection.type.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/connection/connection.type.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/contacts/ContactAddress/contactaddress.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/contacts/ContactAddress/contactaddress.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/contacts/ContactError/contactError.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/contacts/ContactError/contactError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/contacts/ContactField/contactfield.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/contacts/ContactField/contactfield.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/contacts/ContactFindOptions/contactfindoptions.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/contacts/ContactFindOptions/contactfindoptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/contacts/ContactName/contactname.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/contacts/ContactName/contactname.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/contacts/ContactOrganization/contactorganization.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/contacts/ContactOrganization/contactorganization.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/contacts/contacts.create.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/contacts/contacts.create.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/contacts/contacts.find.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/contacts/contacts.find.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/contacts/contacts.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/contacts/contacts.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/contacts/parameters/contactError.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/contacts/parameters/contactError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/contacts/parameters/contactFields.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/contacts/parameters/contactFields.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/contacts/parameters/contactFindOptions.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/contacts/parameters/contactFindOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/contacts/parameters/contactSuccess.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/contacts/parameters/contactSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/device/device.cordova.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/device/device.cordova.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/device/device.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/device/device.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/device/device.model.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/device/device.model.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/device/device.name.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/device/device.name.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/device/device.platform.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/device/device.platform.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/device/device.uuid.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/device/device.uuid.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/device/device.version.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/device/device.version.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/events/events.backbutton.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/events/events.batterycritical.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/events/events.batterycritical.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/events/events.batterylow.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/events/events.batterylow.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/events/events.batterystatus.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/events/events.batterystatus.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/events/events.deviceready.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/events/events.endcallbutton.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/events/events.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/events/events.menubutton.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/events/events.offline.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/events/events.offline.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/events/events.online.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/events/events.online.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/events/events.pause.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/events/events.resume.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/events/events.searchbutton.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/events/events.startcallbutton.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/file/directoryentry/directoryentry.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/file/directoryentry/directoryentry.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/file/directoryreader/directoryreader.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/file/directoryreader/directoryreader.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/file/file.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/file/file.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/file/fileentry/fileentry.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/file/fileentry/fileentry.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/file/fileerror/fileerror.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/file/fileerror/fileerror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/file/fileobj/fileobj.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/file/fileobj/fileobj.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/file/filereader/filereader.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/file/filereader/filereader.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/file/filesystem/filesystem.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/file/filesystem/filesystem.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/file/filetransfer/filetransfer.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/file/filetransfer/filetransfer.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/file/filetransfererror/filetransfererror.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/file/filetransfererror/filetransfererror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/file/fileuploadoptions/fileuploadoptions.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/file/fileuploadoptions/fileuploadoptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/file/fileuploadresult/fileuploadresult.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/file/fileuploadresult/fileuploadresult.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/file/filewriter/filewriter.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/file/filewriter/filewriter.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/file/flags/flags.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/file/flags/flags.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/file/localfilesystem/localfilesystem.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/file/localfilesystem/localfilesystem.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/file/metadata/metadata.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/file/metadata/metadata.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/geolocation/Position/position.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/geolocation/Position/position.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/geolocation/PositionError/positionError.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/geolocation/PositionError/positionError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/geolocation/geolocation.clearWatch.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/geolocation/geolocation.clearWatch.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/geolocation/geolocation.getCurrentPosition.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/geolocation/geolocation.getCurrentPosition.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/geolocation/geolocation.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/geolocation/geolocation.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/geolocation/geolocation.watchPosition.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/geolocation/geolocation.watchPosition.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/geolocation/parameters/geolocation.options.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/geolocation/parameters/geolocation.options.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/geolocation/parameters/geolocationError.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/geolocation/parameters/geolocationError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/geolocation/parameters/geolocationSuccess.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/geolocation/parameters/geolocationSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/globalization/GlobalizationError/globalizationerror.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/globalization/GlobalizationError/globalizationerror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/globalization/globalization.dateToString.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/globalization/globalization.dateToString.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/globalization/globalization.getCurrencyPattern.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/globalization/globalization.getCurrencyPattern.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/globalization/globalization.getDateNames.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/globalization/globalization.getDateNames.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/globalization/globalization.getDatePattern.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/globalization/globalization.getDatePattern.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/globalization/globalization.getFirstDayOfWeek.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/globalization/globalization.getFirstDayOfWeek.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/globalization/globalization.getLocaleName.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/globalization/globalization.getLocaleName.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/globalization/globalization.getNumberPattern.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/globalization/globalization.getNumberPattern.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/globalization/globalization.getPreferredLanguage.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/globalization/globalization.getPreferredLanguage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/globalization/globalization.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/globalization/globalization.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/globalization/globalization.isDayLightSavingsTime.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/globalization/globalization.isDayLightSavingsTime.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/globalization/globalization.numberToString.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/globalization/globalization.numberToString.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/globalization/globalization.stringToDate.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/globalization/globalization.stringToDate.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/globalization/globalization.stringToNumber.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/globalization/globalization.stringToNumber.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/inappbrowser/inappbrowser.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/inappbrowser/inappbrowser.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/media/capture/CaptureErrorCB.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/media/capture/CaptureErrorCB.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/media/capture/ConfigurationData.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/media/capture/ConfigurationData.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/media/capture/MediaFile.getFormatData.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/media/capture/MediaFile.getFormatData.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/media/capture/MediaFileData.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/media/capture/MediaFileData.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/media/capture/capture.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/media/capture/capture.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/media/capture/captureAudio.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/media/capture/captureAudio.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/media/capture/captureAudioOptions.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/media/capture/captureAudioOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/media/capture/captureImage.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/media/capture/captureImage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/media/capture/captureImageOptions.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/media/capture/captureImageOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/media/capture/captureVideo.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/media/capture/captureVideo.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/media/capture/captureVideoOptions.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/media/capture/captureVideoOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/media/media.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/media/media.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/notification/notification.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/notification/notification.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/splashscreen/splashscreen.hide.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/splashscreen/splashscreen.hide.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/splashscreen/splashscreen.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/splashscreen/splashscreen.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/splashscreen/splashscreen.show.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/splashscreen/splashscreen.show.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/storage/database/database.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/storage/database/database.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/storage/parameters/display_name.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/storage/parameters/display_name.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/storage/parameters/name.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/storage/parameters/name.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/storage/parameters/size.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/storage/parameters/size.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/storage/parameters/version.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/storage/parameters/version.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/storage/sqlerror/sqlerror.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/storage/sqlerror/sqlerror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/storage/sqlresultset/sqlresultset.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/storage/sqlresultset/sqlresultset.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/storage/sqlresultsetrowlist/sqlresultsetrowlist.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/storage/sqlresultsetrowlist/sqlresultsetrowlist.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/storage/sqltransaction/sqltransaction.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/storage/sqltransaction/sqltransaction.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/storage/storage.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/cordova/storage/storage.opendatabase.html
+++ b/archive/docs/zh-cn/3.1.0/cordova/storage/storage.opendatabase.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/guide/appdev/privacy/index.html
+++ b/archive/docs/zh-cn/3.1.0/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/guide/appdev/whitelist/index.html
+++ b/archive/docs/zh-cn/3.1.0/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/guide/cli/index.html
+++ b/archive/docs/zh-cn/3.1.0/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/guide/hybrid/plugins/index.html
+++ b/archive/docs/zh-cn/3.1.0/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/guide/hybrid/webviews/index.html
+++ b/archive/docs/zh-cn/3.1.0/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/guide/overview/index.html
+++ b/archive/docs/zh-cn/3.1.0/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/guide/platforms/android/config.html
+++ b/archive/docs/zh-cn/3.1.0/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/guide/platforms/android/index.html
+++ b/archive/docs/zh-cn/3.1.0/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/guide/platforms/android/plugin.html
+++ b/archive/docs/zh-cn/3.1.0/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/guide/platforms/android/tools.html
+++ b/archive/docs/zh-cn/3.1.0/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/guide/platforms/android/upgrading.html
+++ b/archive/docs/zh-cn/3.1.0/guide/platforms/android/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/guide/platforms/android/webview.html
+++ b/archive/docs/zh-cn/3.1.0/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/guide/platforms/blackberry/index.html
+++ b/archive/docs/zh-cn/3.1.0/guide/platforms/blackberry/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/guide/platforms/blackberry/plugin.html
+++ b/archive/docs/zh-cn/3.1.0/guide/platforms/blackberry/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/guide/platforms/blackberry/tools.html
+++ b/archive/docs/zh-cn/3.1.0/guide/platforms/blackberry/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/guide/platforms/blackberry10/config.html
+++ b/archive/docs/zh-cn/3.1.0/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/guide/platforms/blackberry10/index.html
+++ b/archive/docs/zh-cn/3.1.0/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/zh-cn/3.1.0/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/zh-cn/3.1.0/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/guide/platforms/blackberry10/upgrading.html
+++ b/archive/docs/zh-cn/3.1.0/guide/platforms/blackberry10/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/guide/platforms/index.html
+++ b/archive/docs/zh-cn/3.1.0/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/guide/platforms/ios/config.html
+++ b/archive/docs/zh-cn/3.1.0/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/guide/platforms/ios/index.html
+++ b/archive/docs/zh-cn/3.1.0/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/guide/platforms/ios/plugin.html
+++ b/archive/docs/zh-cn/3.1.0/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/guide/platforms/ios/tools.html
+++ b/archive/docs/zh-cn/3.1.0/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/guide/platforms/ios/upgrading.html
+++ b/archive/docs/zh-cn/3.1.0/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/guide/platforms/ios/webview.html
+++ b/archive/docs/zh-cn/3.1.0/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/guide/platforms/tizen/index.html
+++ b/archive/docs/zh-cn/3.1.0/guide/platforms/tizen/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/guide/platforms/win8/index.html
+++ b/archive/docs/zh-cn/3.1.0/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/guide/platforms/win8/tools.html
+++ b/archive/docs/zh-cn/3.1.0/guide/platforms/win8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/guide/platforms/win8/upgrading.html
+++ b/archive/docs/zh-cn/3.1.0/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/guide/platforms/wp7/index.html
+++ b/archive/docs/zh-cn/3.1.0/guide/platforms/wp7/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/guide/platforms/wp8/index.html
+++ b/archive/docs/zh-cn/3.1.0/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/guide/platforms/wp8/plugin.html
+++ b/archive/docs/zh-cn/3.1.0/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/guide/platforms/wp8/tools.html
+++ b/archive/docs/zh-cn/3.1.0/guide/platforms/wp8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/guide/platforms/wp8/upgrading.html
+++ b/archive/docs/zh-cn/3.1.0/guide/platforms/wp8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/index.html
+++ b/archive/docs/zh-cn/3.1.0/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.1.0/plugin_ref/spec.html
+++ b/archive/docs/zh-cn/3.1.0/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.4.0/config_ref/images.html
+++ b/archive/docs/zh-cn/3.4.0/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.4.0/config_ref/index.html
+++ b/archive/docs/zh-cn/3.4.0/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.4.0/cordova/events/events.backbutton.html
+++ b/archive/docs/zh-cn/3.4.0/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.4.0/cordova/events/events.deviceready.html
+++ b/archive/docs/zh-cn/3.4.0/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.4.0/cordova/events/events.endcallbutton.html
+++ b/archive/docs/zh-cn/3.4.0/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.4.0/cordova/events/events.html
+++ b/archive/docs/zh-cn/3.4.0/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.4.0/cordova/events/events.menubutton.html
+++ b/archive/docs/zh-cn/3.4.0/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.4.0/cordova/events/events.pause.html
+++ b/archive/docs/zh-cn/3.4.0/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.4.0/cordova/events/events.resume.html
+++ b/archive/docs/zh-cn/3.4.0/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.4.0/cordova/events/events.searchbutton.html
+++ b/archive/docs/zh-cn/3.4.0/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.4.0/cordova/events/events.startcallbutton.html
+++ b/archive/docs/zh-cn/3.4.0/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.4.0/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/zh-cn/3.4.0/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.4.0/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/zh-cn/3.4.0/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.4.0/cordova/plugins/pluginapis.html
+++ b/archive/docs/zh-cn/3.4.0/cordova/plugins/pluginapis.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.4.0/cordova/storage/storage.html
+++ b/archive/docs/zh-cn/3.4.0/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.4.0/guide/appdev/privacy/index.html
+++ b/archive/docs/zh-cn/3.4.0/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.4.0/guide/appdev/whitelist/index.html
+++ b/archive/docs/zh-cn/3.4.0/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.4.0/guide/cli/index.html
+++ b/archive/docs/zh-cn/3.4.0/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.4.0/guide/hybrid/plugins/index.html
+++ b/archive/docs/zh-cn/3.4.0/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.4.0/guide/hybrid/webviews/index.html
+++ b/archive/docs/zh-cn/3.4.0/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.4.0/guide/overview/index.html
+++ b/archive/docs/zh-cn/3.4.0/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.4.0/guide/platforms/amazonfireos/config.html
+++ b/archive/docs/zh-cn/3.4.0/guide/platforms/amazonfireos/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.4.0/guide/platforms/amazonfireos/index.html
+++ b/archive/docs/zh-cn/3.4.0/guide/platforms/amazonfireos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.4.0/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/zh-cn/3.4.0/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.4.0/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/zh-cn/3.4.0/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.4.0/guide/platforms/android/config.html
+++ b/archive/docs/zh-cn/3.4.0/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.4.0/guide/platforms/android/index.html
+++ b/archive/docs/zh-cn/3.4.0/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.4.0/guide/platforms/android/plugin.html
+++ b/archive/docs/zh-cn/3.4.0/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.4.0/guide/platforms/android/tools.html
+++ b/archive/docs/zh-cn/3.4.0/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.4.0/guide/platforms/android/upgrading.html
+++ b/archive/docs/zh-cn/3.4.0/guide/platforms/android/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.4.0/guide/platforms/android/webview.html
+++ b/archive/docs/zh-cn/3.4.0/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.4.0/guide/platforms/blackberry10/config.html
+++ b/archive/docs/zh-cn/3.4.0/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.4.0/guide/platforms/blackberry10/index.html
+++ b/archive/docs/zh-cn/3.4.0/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.4.0/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/zh-cn/3.4.0/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.4.0/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/zh-cn/3.4.0/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.4.0/guide/platforms/blackberry10/upgrading.html
+++ b/archive/docs/zh-cn/3.4.0/guide/platforms/blackberry10/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.4.0/guide/platforms/index.html
+++ b/archive/docs/zh-cn/3.4.0/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.4.0/guide/platforms/ios/config.html
+++ b/archive/docs/zh-cn/3.4.0/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.4.0/guide/platforms/ios/index.html
+++ b/archive/docs/zh-cn/3.4.0/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.4.0/guide/platforms/ios/plugin.html
+++ b/archive/docs/zh-cn/3.4.0/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.4.0/guide/platforms/ios/tools.html
+++ b/archive/docs/zh-cn/3.4.0/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.4.0/guide/platforms/ios/upgrading.html
+++ b/archive/docs/zh-cn/3.4.0/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.4.0/guide/platforms/ios/webview.html
+++ b/archive/docs/zh-cn/3.4.0/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.4.0/guide/platforms/tizen/index.html
+++ b/archive/docs/zh-cn/3.4.0/guide/platforms/tizen/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.4.0/guide/platforms/ubuntu/index.html
+++ b/archive/docs/zh-cn/3.4.0/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.4.0/guide/platforms/win8/index.html
+++ b/archive/docs/zh-cn/3.4.0/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.4.0/guide/platforms/win8/tools.html
+++ b/archive/docs/zh-cn/3.4.0/guide/platforms/win8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.4.0/guide/platforms/win8/upgrading.html
+++ b/archive/docs/zh-cn/3.4.0/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.4.0/guide/platforms/wp7/index.html
+++ b/archive/docs/zh-cn/3.4.0/guide/platforms/wp7/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.4.0/guide/platforms/wp8/index.html
+++ b/archive/docs/zh-cn/3.4.0/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.4.0/guide/platforms/wp8/plugin.html
+++ b/archive/docs/zh-cn/3.4.0/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.4.0/guide/platforms/wp8/tools.html
+++ b/archive/docs/zh-cn/3.4.0/guide/platforms/wp8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.4.0/guide/platforms/wp8/upgrading.html
+++ b/archive/docs/zh-cn/3.4.0/guide/platforms/wp8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.4.0/guide/support/index.html
+++ b/archive/docs/zh-cn/3.4.0/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.4.0/index.html
+++ b/archive/docs/zh-cn/3.4.0/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.4.0/plugin_ref/plugman.html
+++ b/archive/docs/zh-cn/3.4.0/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.5.0/config_ref/images.html
+++ b/archive/docs/zh-cn/3.5.0/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.5.0/config_ref/index.html
+++ b/archive/docs/zh-cn/3.5.0/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.5.0/cordova/events/events.backbutton.html
+++ b/archive/docs/zh-cn/3.5.0/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.5.0/cordova/events/events.deviceready.html
+++ b/archive/docs/zh-cn/3.5.0/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.5.0/cordova/events/events.endcallbutton.html
+++ b/archive/docs/zh-cn/3.5.0/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.5.0/cordova/events/events.html
+++ b/archive/docs/zh-cn/3.5.0/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.5.0/cordova/events/events.menubutton.html
+++ b/archive/docs/zh-cn/3.5.0/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.5.0/cordova/events/events.pause.html
+++ b/archive/docs/zh-cn/3.5.0/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.5.0/cordova/events/events.resume.html
+++ b/archive/docs/zh-cn/3.5.0/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.5.0/cordova/events/events.searchbutton.html
+++ b/archive/docs/zh-cn/3.5.0/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.5.0/cordova/events/events.startcallbutton.html
+++ b/archive/docs/zh-cn/3.5.0/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.5.0/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/zh-cn/3.5.0/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.5.0/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/zh-cn/3.5.0/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.5.0/cordova/plugins/pluginapis.html
+++ b/archive/docs/zh-cn/3.5.0/cordova/plugins/pluginapis.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.5.0/cordova/storage/storage.html
+++ b/archive/docs/zh-cn/3.5.0/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.5.0/guide/appdev/privacy/index.html
+++ b/archive/docs/zh-cn/3.5.0/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.5.0/guide/appdev/whitelist/index.html
+++ b/archive/docs/zh-cn/3.5.0/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.5.0/guide/cli/index.html
+++ b/archive/docs/zh-cn/3.5.0/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.5.0/guide/hybrid/plugins/index.html
+++ b/archive/docs/zh-cn/3.5.0/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.5.0/guide/hybrid/webviews/index.html
+++ b/archive/docs/zh-cn/3.5.0/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.5.0/guide/overview/index.html
+++ b/archive/docs/zh-cn/3.5.0/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.5.0/guide/platforms/amazonfireos/config.html
+++ b/archive/docs/zh-cn/3.5.0/guide/platforms/amazonfireos/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.5.0/guide/platforms/amazonfireos/index.html
+++ b/archive/docs/zh-cn/3.5.0/guide/platforms/amazonfireos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.5.0/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/zh-cn/3.5.0/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.5.0/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/zh-cn/3.5.0/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.5.0/guide/platforms/android/config.html
+++ b/archive/docs/zh-cn/3.5.0/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.5.0/guide/platforms/android/index.html
+++ b/archive/docs/zh-cn/3.5.0/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.5.0/guide/platforms/android/plugin.html
+++ b/archive/docs/zh-cn/3.5.0/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.5.0/guide/platforms/android/tools.html
+++ b/archive/docs/zh-cn/3.5.0/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.5.0/guide/platforms/android/upgrading.html
+++ b/archive/docs/zh-cn/3.5.0/guide/platforms/android/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.5.0/guide/platforms/android/webview.html
+++ b/archive/docs/zh-cn/3.5.0/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.5.0/guide/platforms/blackberry10/config.html
+++ b/archive/docs/zh-cn/3.5.0/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.5.0/guide/platforms/blackberry10/index.html
+++ b/archive/docs/zh-cn/3.5.0/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.5.0/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/zh-cn/3.5.0/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.5.0/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/zh-cn/3.5.0/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.5.0/guide/platforms/blackberry10/upgrading.html
+++ b/archive/docs/zh-cn/3.5.0/guide/platforms/blackberry10/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.5.0/guide/platforms/index.html
+++ b/archive/docs/zh-cn/3.5.0/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.5.0/guide/platforms/ios/config.html
+++ b/archive/docs/zh-cn/3.5.0/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.5.0/guide/platforms/ios/index.html
+++ b/archive/docs/zh-cn/3.5.0/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.5.0/guide/platforms/ios/plugin.html
+++ b/archive/docs/zh-cn/3.5.0/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.5.0/guide/platforms/ios/tools.html
+++ b/archive/docs/zh-cn/3.5.0/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.5.0/guide/platforms/ios/upgrading.html
+++ b/archive/docs/zh-cn/3.5.0/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.5.0/guide/platforms/ios/webview.html
+++ b/archive/docs/zh-cn/3.5.0/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.5.0/guide/platforms/tizen/index.html
+++ b/archive/docs/zh-cn/3.5.0/guide/platforms/tizen/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.5.0/guide/platforms/ubuntu/index.html
+++ b/archive/docs/zh-cn/3.5.0/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.5.0/guide/platforms/win8/index.html
+++ b/archive/docs/zh-cn/3.5.0/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.5.0/guide/platforms/win8/tools.html
+++ b/archive/docs/zh-cn/3.5.0/guide/platforms/win8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.5.0/guide/platforms/win8/upgrading.html
+++ b/archive/docs/zh-cn/3.5.0/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.5.0/guide/platforms/wp7/index.html
+++ b/archive/docs/zh-cn/3.5.0/guide/platforms/wp7/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.5.0/guide/platforms/wp8/index.html
+++ b/archive/docs/zh-cn/3.5.0/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.5.0/guide/platforms/wp8/plugin.html
+++ b/archive/docs/zh-cn/3.5.0/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.5.0/guide/platforms/wp8/tools.html
+++ b/archive/docs/zh-cn/3.5.0/guide/platforms/wp8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.5.0/guide/platforms/wp8/upgrading.html
+++ b/archive/docs/zh-cn/3.5.0/guide/platforms/wp8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.5.0/guide/support/index.html
+++ b/archive/docs/zh-cn/3.5.0/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.5.0/index.html
+++ b/archive/docs/zh-cn/3.5.0/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/3.5.0/plugin_ref/plugman.html
+++ b/archive/docs/zh-cn/3.5.0/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/config_ref/images.html
+++ b/archive/docs/zh-cn/5.4.0/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/config_ref/index.html
+++ b/archive/docs/zh-cn/5.4.0/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/cordova/events/events.backbutton.html
+++ b/archive/docs/zh-cn/5.4.0/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/cordova/events/events.deviceready.html
+++ b/archive/docs/zh-cn/5.4.0/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/cordova/events/events.endcallbutton.html
+++ b/archive/docs/zh-cn/5.4.0/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/cordova/events/events.html
+++ b/archive/docs/zh-cn/5.4.0/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/cordova/events/events.menubutton.html
+++ b/archive/docs/zh-cn/5.4.0/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/cordova/events/events.pause.html
+++ b/archive/docs/zh-cn/5.4.0/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/cordova/events/events.resume.html
+++ b/archive/docs/zh-cn/5.4.0/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/cordova/events/events.searchbutton.html
+++ b/archive/docs/zh-cn/5.4.0/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/cordova/events/events.startcallbutton.html
+++ b/archive/docs/zh-cn/5.4.0/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/zh-cn/5.4.0/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/zh-cn/5.4.0/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/cordova/plugins/pluginapis.html
+++ b/archive/docs/zh-cn/5.4.0/cordova/plugins/pluginapis.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/zh-cn/5.4.0/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/cordova/storage/storage.html
+++ b/archive/docs/zh-cn/5.4.0/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/guide/appdev/privacy/index.html
+++ b/archive/docs/zh-cn/5.4.0/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/guide/appdev/security/index.html
+++ b/archive/docs/zh-cn/5.4.0/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/guide/appdev/whitelist/index.html
+++ b/archive/docs/zh-cn/5.4.0/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/guide/cli/index.html
+++ b/archive/docs/zh-cn/5.4.0/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/guide/hybrid/plugins/index.html
+++ b/archive/docs/zh-cn/5.4.0/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/guide/hybrid/webviews/index.html
+++ b/archive/docs/zh-cn/5.4.0/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/guide/overview/index.html
+++ b/archive/docs/zh-cn/5.4.0/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/guide/platforms/amazonfireos/config.html
+++ b/archive/docs/zh-cn/5.4.0/guide/platforms/amazonfireos/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/guide/platforms/amazonfireos/index.html
+++ b/archive/docs/zh-cn/5.4.0/guide/platforms/amazonfireos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/zh-cn/5.4.0/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/zh-cn/5.4.0/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/guide/platforms/android/config.html
+++ b/archive/docs/zh-cn/5.4.0/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/guide/platforms/android/index.html
+++ b/archive/docs/zh-cn/5.4.0/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/guide/platforms/android/plugin.html
+++ b/archive/docs/zh-cn/5.4.0/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/guide/platforms/android/tools.html
+++ b/archive/docs/zh-cn/5.4.0/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/guide/platforms/android/upgrading.html
+++ b/archive/docs/zh-cn/5.4.0/guide/platforms/android/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/guide/platforms/android/webview.html
+++ b/archive/docs/zh-cn/5.4.0/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/guide/platforms/blackberry10/config.html
+++ b/archive/docs/zh-cn/5.4.0/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/guide/platforms/blackberry10/index.html
+++ b/archive/docs/zh-cn/5.4.0/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/zh-cn/5.4.0/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/zh-cn/5.4.0/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/guide/platforms/blackberry10/upgrading.html
+++ b/archive/docs/zh-cn/5.4.0/guide/platforms/blackberry10/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/guide/platforms/firefoxos/index.html
+++ b/archive/docs/zh-cn/5.4.0/guide/platforms/firefoxos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/guide/platforms/index.html
+++ b/archive/docs/zh-cn/5.4.0/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/guide/platforms/ios/config.html
+++ b/archive/docs/zh-cn/5.4.0/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/guide/platforms/ios/index.html
+++ b/archive/docs/zh-cn/5.4.0/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/guide/platforms/ios/plugin.html
+++ b/archive/docs/zh-cn/5.4.0/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/guide/platforms/ios/tools.html
+++ b/archive/docs/zh-cn/5.4.0/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/guide/platforms/ios/upgrading.html
+++ b/archive/docs/zh-cn/5.4.0/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/guide/platforms/ios/webview.html
+++ b/archive/docs/zh-cn/5.4.0/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/guide/platforms/tizen/index.html
+++ b/archive/docs/zh-cn/5.4.0/guide/platforms/tizen/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/guide/platforms/ubuntu/index.html
+++ b/archive/docs/zh-cn/5.4.0/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/guide/platforms/win8/index.html
+++ b/archive/docs/zh-cn/5.4.0/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/guide/platforms/win8/packaging.html
+++ b/archive/docs/zh-cn/5.4.0/guide/platforms/win8/packaging.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/guide/platforms/win8/plugin.html
+++ b/archive/docs/zh-cn/5.4.0/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/guide/platforms/win8/upgrading.html
+++ b/archive/docs/zh-cn/5.4.0/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/guide/platforms/wp8/index.html
+++ b/archive/docs/zh-cn/5.4.0/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/guide/platforms/wp8/plugin.html
+++ b/archive/docs/zh-cn/5.4.0/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/zh-cn/5.4.0/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/guide/platforms/wp8/webview.html
+++ b/archive/docs/zh-cn/5.4.0/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/guide/support/index.html
+++ b/archive/docs/zh-cn/5.4.0/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/index.html
+++ b/archive/docs/zh-cn/5.4.0/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/zh-cn/5.4.0/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/plugin_ref/plugman.html
+++ b/archive/docs/zh-cn/5.4.0/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/5.4.0/plugin_ref/spec.html
+++ b/archive/docs/zh-cn/5.4.0/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/6.x/config_ref/images.html
+++ b/archive/docs/zh-cn/6.x/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/6.x/config_ref/index.html
+++ b/archive/docs/zh-cn/6.x/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/6.x/cordova/events/events.backbutton.html
+++ b/archive/docs/zh-cn/6.x/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/6.x/cordova/events/events.deviceready.html
+++ b/archive/docs/zh-cn/6.x/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/6.x/cordova/events/events.endcallbutton.html
+++ b/archive/docs/zh-cn/6.x/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/6.x/cordova/events/events.html
+++ b/archive/docs/zh-cn/6.x/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/6.x/cordova/events/events.menubutton.html
+++ b/archive/docs/zh-cn/6.x/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/6.x/cordova/events/events.pause.html
+++ b/archive/docs/zh-cn/6.x/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/6.x/cordova/events/events.resume.html
+++ b/archive/docs/zh-cn/6.x/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/6.x/cordova/events/events.searchbutton.html
+++ b/archive/docs/zh-cn/6.x/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/6.x/cordova/events/events.startcallbutton.html
+++ b/archive/docs/zh-cn/6.x/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/6.x/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/zh-cn/6.x/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/6.x/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/zh-cn/6.x/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/6.x/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/zh-cn/6.x/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/6.x/cordova/storage/storage.html
+++ b/archive/docs/zh-cn/6.x/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/6.x/guide/appdev/hooks/index.html
+++ b/archive/docs/zh-cn/6.x/guide/appdev/hooks/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/6.x/guide/appdev/privacy/index.html
+++ b/archive/docs/zh-cn/6.x/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/6.x/guide/appdev/security/index.html
+++ b/archive/docs/zh-cn/6.x/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/6.x/guide/appdev/whitelist/index.html
+++ b/archive/docs/zh-cn/6.x/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/6.x/guide/cli/index.html
+++ b/archive/docs/zh-cn/6.x/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/6.x/guide/hybrid/plugins/index.html
+++ b/archive/docs/zh-cn/6.x/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/6.x/guide/hybrid/webviews/index.html
+++ b/archive/docs/zh-cn/6.x/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/6.x/guide/next/index.html
+++ b/archive/docs/zh-cn/6.x/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/6.x/guide/overview/index.html
+++ b/archive/docs/zh-cn/6.x/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/6.x/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/zh-cn/6.x/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/6.x/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/zh-cn/6.x/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/6.x/guide/platforms/android/config.html
+++ b/archive/docs/zh-cn/6.x/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/6.x/guide/platforms/android/index.html
+++ b/archive/docs/zh-cn/6.x/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/6.x/guide/platforms/android/plugin.html
+++ b/archive/docs/zh-cn/6.x/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/6.x/guide/platforms/android/webview.html
+++ b/archive/docs/zh-cn/6.x/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/6.x/guide/platforms/blackberry10/config.html
+++ b/archive/docs/zh-cn/6.x/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/6.x/guide/platforms/blackberry10/home.html
+++ b/archive/docs/zh-cn/6.x/guide/platforms/blackberry10/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/6.x/guide/platforms/blackberry10/index.html
+++ b/archive/docs/zh-cn/6.x/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/6.x/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/zh-cn/6.x/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/6.x/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/zh-cn/6.x/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/6.x/guide/platforms/blackberry10/upgrade.html
+++ b/archive/docs/zh-cn/6.x/guide/platforms/blackberry10/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/6.x/guide/platforms/ios/config.html
+++ b/archive/docs/zh-cn/6.x/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/6.x/guide/platforms/ios/index.html
+++ b/archive/docs/zh-cn/6.x/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/6.x/guide/platforms/ios/plugin.html
+++ b/archive/docs/zh-cn/6.x/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/6.x/guide/platforms/ios/tools.html
+++ b/archive/docs/zh-cn/6.x/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/6.x/guide/platforms/ios/upgrading.html
+++ b/archive/docs/zh-cn/6.x/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/6.x/guide/platforms/ios/webview.html
+++ b/archive/docs/zh-cn/6.x/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/6.x/guide/platforms/ubuntu/index.html
+++ b/archive/docs/zh-cn/6.x/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/6.x/guide/platforms/win8/index.html
+++ b/archive/docs/zh-cn/6.x/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/6.x/guide/platforms/win8/plugin.html
+++ b/archive/docs/zh-cn/6.x/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/6.x/guide/platforms/wp8/home.html
+++ b/archive/docs/zh-cn/6.x/guide/platforms/wp8/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/6.x/guide/platforms/wp8/index.html
+++ b/archive/docs/zh-cn/6.x/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/6.x/guide/platforms/wp8/plugin.html
+++ b/archive/docs/zh-cn/6.x/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/6.x/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/zh-cn/6.x/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/6.x/guide/platforms/wp8/webview.html
+++ b/archive/docs/zh-cn/6.x/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/6.x/guide/support/index.html
+++ b/archive/docs/zh-cn/6.x/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/6.x/index.html
+++ b/archive/docs/zh-cn/6.x/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/6.x/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/zh-cn/6.x/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/6.x/plugin_ref/plugman.html
+++ b/archive/docs/zh-cn/6.x/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/6.x/plugin_ref/spec.html
+++ b/archive/docs/zh-cn/6.x/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/7.x/config_ref/images.html
+++ b/archive/docs/zh-cn/7.x/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/7.x/config_ref/index.html
+++ b/archive/docs/zh-cn/7.x/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/7.x/cordova/events/events.backbutton.html
+++ b/archive/docs/zh-cn/7.x/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/7.x/cordova/events/events.deviceready.html
+++ b/archive/docs/zh-cn/7.x/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/7.x/cordova/events/events.endcallbutton.html
+++ b/archive/docs/zh-cn/7.x/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/7.x/cordova/events/events.html
+++ b/archive/docs/zh-cn/7.x/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/7.x/cordova/events/events.menubutton.html
+++ b/archive/docs/zh-cn/7.x/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/7.x/cordova/events/events.pause.html
+++ b/archive/docs/zh-cn/7.x/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/7.x/cordova/events/events.resume.html
+++ b/archive/docs/zh-cn/7.x/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/7.x/cordova/events/events.searchbutton.html
+++ b/archive/docs/zh-cn/7.x/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/7.x/cordova/events/events.startcallbutton.html
+++ b/archive/docs/zh-cn/7.x/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/7.x/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/zh-cn/7.x/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/7.x/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/zh-cn/7.x/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/7.x/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/zh-cn/7.x/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/7.x/cordova/storage/storage.html
+++ b/archive/docs/zh-cn/7.x/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/7.x/guide/appdev/hooks/index.html
+++ b/archive/docs/zh-cn/7.x/guide/appdev/hooks/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/7.x/guide/appdev/privacy/index.html
+++ b/archive/docs/zh-cn/7.x/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/7.x/guide/appdev/security/index.html
+++ b/archive/docs/zh-cn/7.x/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/7.x/guide/appdev/whitelist/index.html
+++ b/archive/docs/zh-cn/7.x/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/7.x/guide/cli/index.html
+++ b/archive/docs/zh-cn/7.x/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/7.x/guide/hybrid/plugins/index.html
+++ b/archive/docs/zh-cn/7.x/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/7.x/guide/hybrid/webviews/index.html
+++ b/archive/docs/zh-cn/7.x/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/7.x/guide/next/index.html
+++ b/archive/docs/zh-cn/7.x/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/7.x/guide/overview/index.html
+++ b/archive/docs/zh-cn/7.x/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/7.x/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/zh-cn/7.x/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/7.x/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/zh-cn/7.x/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/7.x/guide/platforms/android/config.html
+++ b/archive/docs/zh-cn/7.x/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/7.x/guide/platforms/android/index.html
+++ b/archive/docs/zh-cn/7.x/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/7.x/guide/platforms/android/plugin.html
+++ b/archive/docs/zh-cn/7.x/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/7.x/guide/platforms/android/webview.html
+++ b/archive/docs/zh-cn/7.x/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/7.x/guide/platforms/blackberry10/config.html
+++ b/archive/docs/zh-cn/7.x/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/7.x/guide/platforms/blackberry10/home.html
+++ b/archive/docs/zh-cn/7.x/guide/platforms/blackberry10/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/7.x/guide/platforms/blackberry10/index.html
+++ b/archive/docs/zh-cn/7.x/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/7.x/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/zh-cn/7.x/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/7.x/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/zh-cn/7.x/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/7.x/guide/platforms/blackberry10/upgrade.html
+++ b/archive/docs/zh-cn/7.x/guide/platforms/blackberry10/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/7.x/guide/platforms/ios/config.html
+++ b/archive/docs/zh-cn/7.x/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/7.x/guide/platforms/ios/index.html
+++ b/archive/docs/zh-cn/7.x/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/7.x/guide/platforms/ios/plugin.html
+++ b/archive/docs/zh-cn/7.x/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/7.x/guide/platforms/ios/tools.html
+++ b/archive/docs/zh-cn/7.x/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/7.x/guide/platforms/ios/upgrading.html
+++ b/archive/docs/zh-cn/7.x/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/7.x/guide/platforms/ios/webview.html
+++ b/archive/docs/zh-cn/7.x/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/7.x/guide/platforms/ubuntu/index.html
+++ b/archive/docs/zh-cn/7.x/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/7.x/guide/platforms/win8/index.html
+++ b/archive/docs/zh-cn/7.x/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/7.x/guide/platforms/win8/plugin.html
+++ b/archive/docs/zh-cn/7.x/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/7.x/guide/platforms/wp8/home.html
+++ b/archive/docs/zh-cn/7.x/guide/platforms/wp8/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/7.x/guide/platforms/wp8/index.html
+++ b/archive/docs/zh-cn/7.x/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/7.x/guide/platforms/wp8/plugin.html
+++ b/archive/docs/zh-cn/7.x/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/7.x/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/zh-cn/7.x/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/7.x/guide/platforms/wp8/webview.html
+++ b/archive/docs/zh-cn/7.x/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/7.x/guide/support/index.html
+++ b/archive/docs/zh-cn/7.x/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/7.x/index.html
+++ b/archive/docs/zh-cn/7.x/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/7.x/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/zh-cn/7.x/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/7.x/plugin_ref/plugman.html
+++ b/archive/docs/zh-cn/7.x/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/7.x/plugin_ref/spec.html
+++ b/archive/docs/zh-cn/7.x/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/8.x/config_ref/images.html
+++ b/archive/docs/zh-cn/8.x/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/8.x/config_ref/index.html
+++ b/archive/docs/zh-cn/8.x/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/8.x/cordova/events/events.backbutton.html
+++ b/archive/docs/zh-cn/8.x/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/8.x/cordova/events/events.deviceready.html
+++ b/archive/docs/zh-cn/8.x/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/8.x/cordova/events/events.endcallbutton.html
+++ b/archive/docs/zh-cn/8.x/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/8.x/cordova/events/events.html
+++ b/archive/docs/zh-cn/8.x/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/8.x/cordova/events/events.menubutton.html
+++ b/archive/docs/zh-cn/8.x/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/8.x/cordova/events/events.pause.html
+++ b/archive/docs/zh-cn/8.x/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/8.x/cordova/events/events.resume.html
+++ b/archive/docs/zh-cn/8.x/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/8.x/cordova/events/events.searchbutton.html
+++ b/archive/docs/zh-cn/8.x/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/8.x/cordova/events/events.startcallbutton.html
+++ b/archive/docs/zh-cn/8.x/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/8.x/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/zh-cn/8.x/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/8.x/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/zh-cn/8.x/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/8.x/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/zh-cn/8.x/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/8.x/cordova/storage/storage.html
+++ b/archive/docs/zh-cn/8.x/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/8.x/guide/appdev/hooks/index.html
+++ b/archive/docs/zh-cn/8.x/guide/appdev/hooks/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/8.x/guide/appdev/privacy/index.html
+++ b/archive/docs/zh-cn/8.x/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/8.x/guide/appdev/security/index.html
+++ b/archive/docs/zh-cn/8.x/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/8.x/guide/appdev/whitelist/index.html
+++ b/archive/docs/zh-cn/8.x/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/8.x/guide/cli/index.html
+++ b/archive/docs/zh-cn/8.x/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/8.x/guide/hybrid/plugins/index.html
+++ b/archive/docs/zh-cn/8.x/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/8.x/guide/hybrid/webviews/index.html
+++ b/archive/docs/zh-cn/8.x/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/8.x/guide/next/index.html
+++ b/archive/docs/zh-cn/8.x/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/8.x/guide/overview/index.html
+++ b/archive/docs/zh-cn/8.x/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/8.x/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/zh-cn/8.x/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/8.x/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/zh-cn/8.x/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/8.x/guide/platforms/android/config.html
+++ b/archive/docs/zh-cn/8.x/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/8.x/guide/platforms/android/index.html
+++ b/archive/docs/zh-cn/8.x/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/8.x/guide/platforms/android/plugin.html
+++ b/archive/docs/zh-cn/8.x/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/8.x/guide/platforms/android/webview.html
+++ b/archive/docs/zh-cn/8.x/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/8.x/guide/platforms/blackberry10/config.html
+++ b/archive/docs/zh-cn/8.x/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/8.x/guide/platforms/blackberry10/home.html
+++ b/archive/docs/zh-cn/8.x/guide/platforms/blackberry10/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/8.x/guide/platforms/blackberry10/index.html
+++ b/archive/docs/zh-cn/8.x/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/8.x/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/zh-cn/8.x/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/8.x/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/zh-cn/8.x/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/8.x/guide/platforms/blackberry10/upgrade.html
+++ b/archive/docs/zh-cn/8.x/guide/platforms/blackberry10/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/8.x/guide/platforms/ios/config.html
+++ b/archive/docs/zh-cn/8.x/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/8.x/guide/platforms/ios/index.html
+++ b/archive/docs/zh-cn/8.x/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/8.x/guide/platforms/ios/plugin.html
+++ b/archive/docs/zh-cn/8.x/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/8.x/guide/platforms/ios/tools.html
+++ b/archive/docs/zh-cn/8.x/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/8.x/guide/platforms/ios/upgrading.html
+++ b/archive/docs/zh-cn/8.x/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/8.x/guide/platforms/ios/webview.html
+++ b/archive/docs/zh-cn/8.x/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/8.x/guide/platforms/ubuntu/index.html
+++ b/archive/docs/zh-cn/8.x/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/8.x/guide/platforms/win8/index.html
+++ b/archive/docs/zh-cn/8.x/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/8.x/guide/platforms/win8/plugin.html
+++ b/archive/docs/zh-cn/8.x/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/8.x/guide/platforms/wp8/home.html
+++ b/archive/docs/zh-cn/8.x/guide/platforms/wp8/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/8.x/guide/platforms/wp8/index.html
+++ b/archive/docs/zh-cn/8.x/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/8.x/guide/platforms/wp8/plugin.html
+++ b/archive/docs/zh-cn/8.x/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/8.x/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/zh-cn/8.x/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/8.x/guide/platforms/wp8/webview.html
+++ b/archive/docs/zh-cn/8.x/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/8.x/guide/support/index.html
+++ b/archive/docs/zh-cn/8.x/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/8.x/index.html
+++ b/archive/docs/zh-cn/8.x/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/8.x/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/zh-cn/8.x/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/8.x/plugin_ref/plugman.html
+++ b/archive/docs/zh-cn/8.x/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/8.x/plugin_ref/spec.html
+++ b/archive/docs/zh-cn/8.x/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/9.x/config_ref/images.html
+++ b/archive/docs/zh-cn/9.x/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/9.x/config_ref/index.html
+++ b/archive/docs/zh-cn/9.x/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/9.x/cordova/events/events.backbutton.html
+++ b/archive/docs/zh-cn/9.x/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/9.x/cordova/events/events.deviceready.html
+++ b/archive/docs/zh-cn/9.x/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/9.x/cordova/events/events.endcallbutton.html
+++ b/archive/docs/zh-cn/9.x/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/9.x/cordova/events/events.html
+++ b/archive/docs/zh-cn/9.x/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/9.x/cordova/events/events.menubutton.html
+++ b/archive/docs/zh-cn/9.x/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/9.x/cordova/events/events.pause.html
+++ b/archive/docs/zh-cn/9.x/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/9.x/cordova/events/events.resume.html
+++ b/archive/docs/zh-cn/9.x/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/9.x/cordova/events/events.searchbutton.html
+++ b/archive/docs/zh-cn/9.x/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/9.x/cordova/events/events.startcallbutton.html
+++ b/archive/docs/zh-cn/9.x/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/9.x/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/zh-cn/9.x/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/9.x/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/zh-cn/9.x/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/9.x/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/zh-cn/9.x/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/9.x/cordova/storage/storage.html
+++ b/archive/docs/zh-cn/9.x/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/9.x/guide/appdev/hooks/index.html
+++ b/archive/docs/zh-cn/9.x/guide/appdev/hooks/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/9.x/guide/appdev/privacy/index.html
+++ b/archive/docs/zh-cn/9.x/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/9.x/guide/appdev/security/index.html
+++ b/archive/docs/zh-cn/9.x/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/9.x/guide/appdev/whitelist/index.html
+++ b/archive/docs/zh-cn/9.x/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/9.x/guide/cli/index.html
+++ b/archive/docs/zh-cn/9.x/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/9.x/guide/hybrid/plugins/index.html
+++ b/archive/docs/zh-cn/9.x/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/9.x/guide/hybrid/webviews/index.html
+++ b/archive/docs/zh-cn/9.x/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/9.x/guide/next/index.html
+++ b/archive/docs/zh-cn/9.x/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/9.x/guide/overview/index.html
+++ b/archive/docs/zh-cn/9.x/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/9.x/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/zh-cn/9.x/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/9.x/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/zh-cn/9.x/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/9.x/guide/platforms/android/config.html
+++ b/archive/docs/zh-cn/9.x/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/9.x/guide/platforms/android/index.html
+++ b/archive/docs/zh-cn/9.x/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/9.x/guide/platforms/android/plugin.html
+++ b/archive/docs/zh-cn/9.x/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/9.x/guide/platforms/android/webview.html
+++ b/archive/docs/zh-cn/9.x/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/9.x/guide/platforms/blackberry10/config.html
+++ b/archive/docs/zh-cn/9.x/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/9.x/guide/platforms/blackberry10/home.html
+++ b/archive/docs/zh-cn/9.x/guide/platforms/blackberry10/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/9.x/guide/platforms/blackberry10/index.html
+++ b/archive/docs/zh-cn/9.x/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/9.x/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/zh-cn/9.x/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/9.x/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/zh-cn/9.x/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/9.x/guide/platforms/blackberry10/upgrade.html
+++ b/archive/docs/zh-cn/9.x/guide/platforms/blackberry10/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/9.x/guide/platforms/ios/config.html
+++ b/archive/docs/zh-cn/9.x/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/9.x/guide/platforms/ios/index.html
+++ b/archive/docs/zh-cn/9.x/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/9.x/guide/platforms/ios/plugin.html
+++ b/archive/docs/zh-cn/9.x/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/9.x/guide/platforms/ios/tools.html
+++ b/archive/docs/zh-cn/9.x/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/9.x/guide/platforms/ios/upgrading.html
+++ b/archive/docs/zh-cn/9.x/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/9.x/guide/platforms/ios/webview.html
+++ b/archive/docs/zh-cn/9.x/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/9.x/guide/platforms/ubuntu/index.html
+++ b/archive/docs/zh-cn/9.x/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/9.x/guide/platforms/win8/index.html
+++ b/archive/docs/zh-cn/9.x/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/9.x/guide/platforms/win8/plugin.html
+++ b/archive/docs/zh-cn/9.x/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/9.x/guide/platforms/wp8/home.html
+++ b/archive/docs/zh-cn/9.x/guide/platforms/wp8/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/9.x/guide/platforms/wp8/index.html
+++ b/archive/docs/zh-cn/9.x/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/9.x/guide/platforms/wp8/plugin.html
+++ b/archive/docs/zh-cn/9.x/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/9.x/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/zh-cn/9.x/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/9.x/guide/platforms/wp8/webview.html
+++ b/archive/docs/zh-cn/9.x/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/9.x/guide/support/index.html
+++ b/archive/docs/zh-cn/9.x/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/9.x/index.html
+++ b/archive/docs/zh-cn/9.x/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/9.x/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/zh-cn/9.x/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/9.x/plugin_ref/plugman.html
+++ b/archive/docs/zh-cn/9.x/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-cn/9.x/plugin_ref/spec.html
+++ b/archive/docs/zh-cn/9.x/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/10.x/config_ref/images.html
+++ b/archive/docs/zh-tw/10.x/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/10.x/config_ref/index.html
+++ b/archive/docs/zh-tw/10.x/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/10.x/cordova/events/events.backbutton.html
+++ b/archive/docs/zh-tw/10.x/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/10.x/cordova/events/events.deviceready.html
+++ b/archive/docs/zh-tw/10.x/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/10.x/cordova/events/events.endcallbutton.html
+++ b/archive/docs/zh-tw/10.x/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/10.x/cordova/events/events.html
+++ b/archive/docs/zh-tw/10.x/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/10.x/cordova/events/events.menubutton.html
+++ b/archive/docs/zh-tw/10.x/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/10.x/cordova/events/events.pause.html
+++ b/archive/docs/zh-tw/10.x/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/10.x/cordova/events/events.resume.html
+++ b/archive/docs/zh-tw/10.x/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/10.x/cordova/events/events.searchbutton.html
+++ b/archive/docs/zh-tw/10.x/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/10.x/cordova/events/events.startcallbutton.html
+++ b/archive/docs/zh-tw/10.x/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/10.x/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/zh-tw/10.x/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/10.x/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/zh-tw/10.x/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/10.x/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/zh-tw/10.x/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/10.x/cordova/storage/storage.html
+++ b/archive/docs/zh-tw/10.x/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/10.x/guide/appdev/hooks/index.html
+++ b/archive/docs/zh-tw/10.x/guide/appdev/hooks/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/10.x/guide/appdev/privacy/index.html
+++ b/archive/docs/zh-tw/10.x/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/10.x/guide/appdev/security/index.html
+++ b/archive/docs/zh-tw/10.x/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/10.x/guide/appdev/whitelist/index.html
+++ b/archive/docs/zh-tw/10.x/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/10.x/guide/cli/index.html
+++ b/archive/docs/zh-tw/10.x/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/10.x/guide/hybrid/plugins/index.html
+++ b/archive/docs/zh-tw/10.x/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/10.x/guide/hybrid/webviews/index.html
+++ b/archive/docs/zh-tw/10.x/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/10.x/guide/next/index.html
+++ b/archive/docs/zh-tw/10.x/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/10.x/guide/overview/index.html
+++ b/archive/docs/zh-tw/10.x/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/10.x/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/zh-tw/10.x/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/10.x/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/zh-tw/10.x/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/10.x/guide/platforms/android/config.html
+++ b/archive/docs/zh-tw/10.x/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/10.x/guide/platforms/android/index.html
+++ b/archive/docs/zh-tw/10.x/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/10.x/guide/platforms/android/plugin.html
+++ b/archive/docs/zh-tw/10.x/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/10.x/guide/platforms/android/webview.html
+++ b/archive/docs/zh-tw/10.x/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/10.x/guide/platforms/blackberry10/config.html
+++ b/archive/docs/zh-tw/10.x/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/10.x/guide/platforms/blackberry10/home.html
+++ b/archive/docs/zh-tw/10.x/guide/platforms/blackberry10/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/10.x/guide/platforms/blackberry10/index.html
+++ b/archive/docs/zh-tw/10.x/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/10.x/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/zh-tw/10.x/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/10.x/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/zh-tw/10.x/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/10.x/guide/platforms/blackberry10/upgrade.html
+++ b/archive/docs/zh-tw/10.x/guide/platforms/blackberry10/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/10.x/guide/platforms/ios/config.html
+++ b/archive/docs/zh-tw/10.x/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/10.x/guide/platforms/ios/index.html
+++ b/archive/docs/zh-tw/10.x/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/10.x/guide/platforms/ios/plugin.html
+++ b/archive/docs/zh-tw/10.x/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/10.x/guide/platforms/ios/tools.html
+++ b/archive/docs/zh-tw/10.x/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/10.x/guide/platforms/ios/upgrading.html
+++ b/archive/docs/zh-tw/10.x/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/10.x/guide/platforms/ios/webview.html
+++ b/archive/docs/zh-tw/10.x/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/10.x/guide/platforms/ubuntu/index.html
+++ b/archive/docs/zh-tw/10.x/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/10.x/guide/platforms/win8/index.html
+++ b/archive/docs/zh-tw/10.x/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/10.x/guide/platforms/win8/plugin.html
+++ b/archive/docs/zh-tw/10.x/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/10.x/guide/platforms/wp8/home.html
+++ b/archive/docs/zh-tw/10.x/guide/platforms/wp8/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/10.x/guide/platforms/wp8/index.html
+++ b/archive/docs/zh-tw/10.x/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/10.x/guide/platforms/wp8/plugin.html
+++ b/archive/docs/zh-tw/10.x/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/10.x/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/zh-tw/10.x/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/10.x/guide/platforms/wp8/webview.html
+++ b/archive/docs/zh-tw/10.x/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/10.x/guide/support/index.html
+++ b/archive/docs/zh-tw/10.x/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/10.x/index.html
+++ b/archive/docs/zh-tw/10.x/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/10.x/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/zh-tw/10.x/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/10.x/plugin_ref/plugman.html
+++ b/archive/docs/zh-tw/10.x/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/10.x/plugin_ref/spec.html
+++ b/archive/docs/zh-tw/10.x/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/config_ref/images.html
+++ b/archive/docs/zh-tw/3.1.0/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/config_ref/index.html
+++ b/archive/docs/zh-tw/3.1.0/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/accelerometer/acceleration/acceleration.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/accelerometer/acceleration/acceleration.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/accelerometer/accelerometer.clearWatch.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/accelerometer/accelerometer.clearWatch.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/accelerometer/accelerometer.getCurrentAcceleration.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/accelerometer/accelerometer.getCurrentAcceleration.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/accelerometer/accelerometer.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/accelerometer/accelerometer.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/accelerometer/accelerometer.watchAcceleration.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/accelerometer/accelerometer.watchAcceleration.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/accelerometer/parameters/accelerometerError.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/accelerometer/parameters/accelerometerError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/accelerometer/parameters/accelerometerOptions.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/accelerometer/parameters/accelerometerOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/accelerometer/parameters/accelerometerSuccess.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/accelerometer/parameters/accelerometerSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/camera/camera.cleanup.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/camera/camera.cleanup.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/camera/camera.getPicture.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/camera/camera.getPicture.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/camera/camera.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/camera/camera.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/compass/compass.clearWatch.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/compass/compass.clearWatch.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/compass/compass.clearWatchFilter.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/compass/compass.clearWatchFilter.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/compass/compass.getCurrentHeading.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/compass/compass.getCurrentHeading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/compass/compass.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/compass/compass.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/compass/compass.watchHeading.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/compass/compass.watchHeading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/compass/compass.watchHeadingFilter.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/compass/compass.watchHeadingFilter.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/compass/parameters/compassError.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/compass/parameters/compassError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/compass/parameters/compassHeading.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/compass/parameters/compassHeading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/compass/parameters/compassOptions.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/compass/parameters/compassOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/compass/parameters/compassSuccess.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/compass/parameters/compassSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/connection/connection.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/connection/connection.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/connection/connection.type.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/connection/connection.type.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/contacts/ContactAddress/contactaddress.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/contacts/ContactAddress/contactaddress.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/contacts/ContactError/contactError.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/contacts/ContactError/contactError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/contacts/ContactField/contactfield.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/contacts/ContactField/contactfield.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/contacts/ContactFindOptions/contactfindoptions.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/contacts/ContactFindOptions/contactfindoptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/contacts/ContactName/contactname.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/contacts/ContactName/contactname.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/contacts/ContactOrganization/contactorganization.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/contacts/ContactOrganization/contactorganization.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/contacts/contacts.create.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/contacts/contacts.create.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/contacts/contacts.find.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/contacts/contacts.find.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/contacts/contacts.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/contacts/contacts.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/contacts/parameters/contactError.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/contacts/parameters/contactError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/contacts/parameters/contactFields.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/contacts/parameters/contactFields.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/contacts/parameters/contactFindOptions.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/contacts/parameters/contactFindOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/contacts/parameters/contactSuccess.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/contacts/parameters/contactSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/device/device.cordova.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/device/device.cordova.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/device/device.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/device/device.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/device/device.model.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/device/device.model.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/device/device.name.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/device/device.name.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/device/device.platform.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/device/device.platform.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/device/device.uuid.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/device/device.uuid.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/device/device.version.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/device/device.version.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/events/events.backbutton.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/events/events.batterycritical.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/events/events.batterycritical.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/events/events.batterylow.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/events/events.batterylow.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/events/events.batterystatus.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/events/events.batterystatus.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/events/events.deviceready.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/events/events.endcallbutton.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/events/events.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/events/events.menubutton.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/events/events.offline.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/events/events.offline.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/events/events.online.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/events/events.online.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/events/events.pause.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/events/events.resume.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/events/events.searchbutton.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/events/events.startcallbutton.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/file/directoryentry/directoryentry.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/file/directoryentry/directoryentry.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/file/directoryreader/directoryreader.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/file/directoryreader/directoryreader.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/file/file.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/file/file.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/file/fileentry/fileentry.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/file/fileentry/fileentry.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/file/fileerror/fileerror.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/file/fileerror/fileerror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/file/fileobj/fileobj.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/file/fileobj/fileobj.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/file/filereader/filereader.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/file/filereader/filereader.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/file/filesystem/filesystem.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/file/filesystem/filesystem.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/file/filetransfer/filetransfer.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/file/filetransfer/filetransfer.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/file/filetransfererror/filetransfererror.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/file/filetransfererror/filetransfererror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/file/fileuploadoptions/fileuploadoptions.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/file/fileuploadoptions/fileuploadoptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/file/fileuploadresult/fileuploadresult.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/file/fileuploadresult/fileuploadresult.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/file/filewriter/filewriter.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/file/filewriter/filewriter.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/file/flags/flags.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/file/flags/flags.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/file/localfilesystem/localfilesystem.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/file/localfilesystem/localfilesystem.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/file/metadata/metadata.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/file/metadata/metadata.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/geolocation/Position/position.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/geolocation/Position/position.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/geolocation/PositionError/positionError.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/geolocation/PositionError/positionError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/geolocation/geolocation.clearWatch.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/geolocation/geolocation.clearWatch.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/geolocation/geolocation.getCurrentPosition.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/geolocation/geolocation.getCurrentPosition.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/geolocation/geolocation.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/geolocation/geolocation.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/geolocation/geolocation.watchPosition.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/geolocation/geolocation.watchPosition.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/geolocation/parameters/geolocation.options.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/geolocation/parameters/geolocation.options.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/geolocation/parameters/geolocationError.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/geolocation/parameters/geolocationError.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/geolocation/parameters/geolocationSuccess.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/geolocation/parameters/geolocationSuccess.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/globalization/GlobalizationError/globalizationerror.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/globalization/GlobalizationError/globalizationerror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/globalization/globalization.dateToString.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/globalization/globalization.dateToString.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/globalization/globalization.getCurrencyPattern.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/globalization/globalization.getCurrencyPattern.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/globalization/globalization.getDateNames.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/globalization/globalization.getDateNames.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/globalization/globalization.getDatePattern.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/globalization/globalization.getDatePattern.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/globalization/globalization.getFirstDayOfWeek.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/globalization/globalization.getFirstDayOfWeek.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/globalization/globalization.getLocaleName.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/globalization/globalization.getLocaleName.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/globalization/globalization.getNumberPattern.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/globalization/globalization.getNumberPattern.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/globalization/globalization.getPreferredLanguage.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/globalization/globalization.getPreferredLanguage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/globalization/globalization.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/globalization/globalization.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/globalization/globalization.isDayLightSavingsTime.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/globalization/globalization.isDayLightSavingsTime.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/globalization/globalization.numberToString.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/globalization/globalization.numberToString.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/globalization/globalization.stringToDate.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/globalization/globalization.stringToDate.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/globalization/globalization.stringToNumber.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/globalization/globalization.stringToNumber.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/inappbrowser/inappbrowser.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/inappbrowser/inappbrowser.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/media/capture/CaptureErrorCB.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/media/capture/CaptureErrorCB.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/media/capture/ConfigurationData.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/media/capture/ConfigurationData.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/media/capture/MediaFile.getFormatData.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/media/capture/MediaFile.getFormatData.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/media/capture/MediaFileData.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/media/capture/MediaFileData.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/media/capture/capture.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/media/capture/capture.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/media/capture/captureAudio.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/media/capture/captureAudio.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/media/capture/captureAudioOptions.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/media/capture/captureAudioOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/media/capture/captureImage.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/media/capture/captureImage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/media/capture/captureImageOptions.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/media/capture/captureImageOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/media/capture/captureVideo.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/media/capture/captureVideo.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/media/capture/captureVideoOptions.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/media/capture/captureVideoOptions.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/media/media.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/media/media.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/notification/notification.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/notification/notification.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/splashscreen/splashscreen.hide.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/splashscreen/splashscreen.hide.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/splashscreen/splashscreen.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/splashscreen/splashscreen.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/splashscreen/splashscreen.show.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/splashscreen/splashscreen.show.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/storage/database/database.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/storage/database/database.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/storage/parameters/display_name.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/storage/parameters/display_name.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/storage/parameters/name.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/storage/parameters/name.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/storage/parameters/size.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/storage/parameters/size.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/storage/parameters/version.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/storage/parameters/version.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/storage/sqlerror/sqlerror.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/storage/sqlerror/sqlerror.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/storage/sqlresultset/sqlresultset.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/storage/sqlresultset/sqlresultset.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/storage/sqlresultsetrowlist/sqlresultsetrowlist.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/storage/sqlresultsetrowlist/sqlresultsetrowlist.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/storage/sqltransaction/sqltransaction.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/storage/sqltransaction/sqltransaction.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/storage/storage.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/cordova/storage/storage.opendatabase.html
+++ b/archive/docs/zh-tw/3.1.0/cordova/storage/storage.opendatabase.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/guide/appdev/privacy/index.html
+++ b/archive/docs/zh-tw/3.1.0/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/guide/appdev/whitelist/index.html
+++ b/archive/docs/zh-tw/3.1.0/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/guide/cli/index.html
+++ b/archive/docs/zh-tw/3.1.0/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/guide/hybrid/plugins/index.html
+++ b/archive/docs/zh-tw/3.1.0/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/guide/hybrid/webviews/index.html
+++ b/archive/docs/zh-tw/3.1.0/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/guide/overview/index.html
+++ b/archive/docs/zh-tw/3.1.0/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/guide/platforms/android/config.html
+++ b/archive/docs/zh-tw/3.1.0/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/guide/platforms/android/index.html
+++ b/archive/docs/zh-tw/3.1.0/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/guide/platforms/android/plugin.html
+++ b/archive/docs/zh-tw/3.1.0/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/guide/platforms/android/tools.html
+++ b/archive/docs/zh-tw/3.1.0/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/guide/platforms/android/upgrading.html
+++ b/archive/docs/zh-tw/3.1.0/guide/platforms/android/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/guide/platforms/android/webview.html
+++ b/archive/docs/zh-tw/3.1.0/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/guide/platforms/blackberry/index.html
+++ b/archive/docs/zh-tw/3.1.0/guide/platforms/blackberry/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/guide/platforms/blackberry/plugin.html
+++ b/archive/docs/zh-tw/3.1.0/guide/platforms/blackberry/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/guide/platforms/blackberry/tools.html
+++ b/archive/docs/zh-tw/3.1.0/guide/platforms/blackberry/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/guide/platforms/blackberry10/config.html
+++ b/archive/docs/zh-tw/3.1.0/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/guide/platforms/blackberry10/index.html
+++ b/archive/docs/zh-tw/3.1.0/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/zh-tw/3.1.0/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/zh-tw/3.1.0/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/guide/platforms/blackberry10/upgrading.html
+++ b/archive/docs/zh-tw/3.1.0/guide/platforms/blackberry10/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/guide/platforms/index.html
+++ b/archive/docs/zh-tw/3.1.0/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/guide/platforms/ios/config.html
+++ b/archive/docs/zh-tw/3.1.0/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/guide/platforms/ios/index.html
+++ b/archive/docs/zh-tw/3.1.0/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/guide/platforms/ios/plugin.html
+++ b/archive/docs/zh-tw/3.1.0/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/guide/platforms/ios/tools.html
+++ b/archive/docs/zh-tw/3.1.0/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/guide/platforms/ios/upgrading.html
+++ b/archive/docs/zh-tw/3.1.0/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/guide/platforms/ios/webview.html
+++ b/archive/docs/zh-tw/3.1.0/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/guide/platforms/tizen/index.html
+++ b/archive/docs/zh-tw/3.1.0/guide/platforms/tizen/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/guide/platforms/win8/index.html
+++ b/archive/docs/zh-tw/3.1.0/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/guide/platforms/win8/tools.html
+++ b/archive/docs/zh-tw/3.1.0/guide/platforms/win8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/guide/platforms/win8/upgrading.html
+++ b/archive/docs/zh-tw/3.1.0/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/guide/platforms/wp7/index.html
+++ b/archive/docs/zh-tw/3.1.0/guide/platforms/wp7/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/guide/platforms/wp8/index.html
+++ b/archive/docs/zh-tw/3.1.0/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/guide/platforms/wp8/plugin.html
+++ b/archive/docs/zh-tw/3.1.0/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/guide/platforms/wp8/tools.html
+++ b/archive/docs/zh-tw/3.1.0/guide/platforms/wp8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/guide/platforms/wp8/upgrading.html
+++ b/archive/docs/zh-tw/3.1.0/guide/platforms/wp8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/index.html
+++ b/archive/docs/zh-tw/3.1.0/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.1.0/plugin_ref/spec.html
+++ b/archive/docs/zh-tw/3.1.0/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.4.0/config_ref/images.html
+++ b/archive/docs/zh-tw/3.4.0/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.4.0/config_ref/index.html
+++ b/archive/docs/zh-tw/3.4.0/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.4.0/cordova/events/events.backbutton.html
+++ b/archive/docs/zh-tw/3.4.0/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.4.0/cordova/events/events.deviceready.html
+++ b/archive/docs/zh-tw/3.4.0/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.4.0/cordova/events/events.endcallbutton.html
+++ b/archive/docs/zh-tw/3.4.0/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.4.0/cordova/events/events.html
+++ b/archive/docs/zh-tw/3.4.0/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.4.0/cordova/events/events.menubutton.html
+++ b/archive/docs/zh-tw/3.4.0/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.4.0/cordova/events/events.pause.html
+++ b/archive/docs/zh-tw/3.4.0/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.4.0/cordova/events/events.resume.html
+++ b/archive/docs/zh-tw/3.4.0/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.4.0/cordova/events/events.searchbutton.html
+++ b/archive/docs/zh-tw/3.4.0/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.4.0/cordova/events/events.startcallbutton.html
+++ b/archive/docs/zh-tw/3.4.0/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.4.0/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/zh-tw/3.4.0/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.4.0/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/zh-tw/3.4.0/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.4.0/cordova/plugins/pluginapis.html
+++ b/archive/docs/zh-tw/3.4.0/cordova/plugins/pluginapis.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.4.0/cordova/storage/storage.html
+++ b/archive/docs/zh-tw/3.4.0/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.4.0/guide/appdev/privacy/index.html
+++ b/archive/docs/zh-tw/3.4.0/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.4.0/guide/appdev/whitelist/index.html
+++ b/archive/docs/zh-tw/3.4.0/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.4.0/guide/cli/index.html
+++ b/archive/docs/zh-tw/3.4.0/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.4.0/guide/hybrid/plugins/index.html
+++ b/archive/docs/zh-tw/3.4.0/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.4.0/guide/hybrid/webviews/index.html
+++ b/archive/docs/zh-tw/3.4.0/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.4.0/guide/overview/index.html
+++ b/archive/docs/zh-tw/3.4.0/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.4.0/guide/platforms/amazonfireos/config.html
+++ b/archive/docs/zh-tw/3.4.0/guide/platforms/amazonfireos/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.4.0/guide/platforms/amazonfireos/index.html
+++ b/archive/docs/zh-tw/3.4.0/guide/platforms/amazonfireos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.4.0/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/zh-tw/3.4.0/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.4.0/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/zh-tw/3.4.0/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.4.0/guide/platforms/android/config.html
+++ b/archive/docs/zh-tw/3.4.0/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.4.0/guide/platforms/android/index.html
+++ b/archive/docs/zh-tw/3.4.0/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.4.0/guide/platforms/android/plugin.html
+++ b/archive/docs/zh-tw/3.4.0/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.4.0/guide/platforms/android/tools.html
+++ b/archive/docs/zh-tw/3.4.0/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.4.0/guide/platforms/android/upgrading.html
+++ b/archive/docs/zh-tw/3.4.0/guide/platforms/android/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.4.0/guide/platforms/android/webview.html
+++ b/archive/docs/zh-tw/3.4.0/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.4.0/guide/platforms/blackberry10/config.html
+++ b/archive/docs/zh-tw/3.4.0/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.4.0/guide/platforms/blackberry10/index.html
+++ b/archive/docs/zh-tw/3.4.0/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.4.0/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/zh-tw/3.4.0/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.4.0/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/zh-tw/3.4.0/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.4.0/guide/platforms/blackberry10/upgrading.html
+++ b/archive/docs/zh-tw/3.4.0/guide/platforms/blackberry10/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.4.0/guide/platforms/index.html
+++ b/archive/docs/zh-tw/3.4.0/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.4.0/guide/platforms/ios/config.html
+++ b/archive/docs/zh-tw/3.4.0/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.4.0/guide/platforms/ios/index.html
+++ b/archive/docs/zh-tw/3.4.0/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.4.0/guide/platforms/ios/plugin.html
+++ b/archive/docs/zh-tw/3.4.0/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.4.0/guide/platforms/ios/tools.html
+++ b/archive/docs/zh-tw/3.4.0/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.4.0/guide/platforms/ios/upgrading.html
+++ b/archive/docs/zh-tw/3.4.0/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.4.0/guide/platforms/ios/webview.html
+++ b/archive/docs/zh-tw/3.4.0/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.4.0/guide/platforms/tizen/index.html
+++ b/archive/docs/zh-tw/3.4.0/guide/platforms/tizen/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.4.0/guide/platforms/ubuntu/index.html
+++ b/archive/docs/zh-tw/3.4.0/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.4.0/guide/platforms/win8/index.html
+++ b/archive/docs/zh-tw/3.4.0/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.4.0/guide/platforms/win8/tools.html
+++ b/archive/docs/zh-tw/3.4.0/guide/platforms/win8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.4.0/guide/platforms/win8/upgrading.html
+++ b/archive/docs/zh-tw/3.4.0/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.4.0/guide/platforms/wp7/index.html
+++ b/archive/docs/zh-tw/3.4.0/guide/platforms/wp7/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.4.0/guide/platforms/wp8/index.html
+++ b/archive/docs/zh-tw/3.4.0/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.4.0/guide/platforms/wp8/plugin.html
+++ b/archive/docs/zh-tw/3.4.0/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.4.0/guide/platforms/wp8/tools.html
+++ b/archive/docs/zh-tw/3.4.0/guide/platforms/wp8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.4.0/guide/platforms/wp8/upgrading.html
+++ b/archive/docs/zh-tw/3.4.0/guide/platforms/wp8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.4.0/guide/support/index.html
+++ b/archive/docs/zh-tw/3.4.0/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.4.0/index.html
+++ b/archive/docs/zh-tw/3.4.0/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.4.0/plugin_ref/plugman.html
+++ b/archive/docs/zh-tw/3.4.0/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.5.0/config_ref/images.html
+++ b/archive/docs/zh-tw/3.5.0/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.5.0/config_ref/index.html
+++ b/archive/docs/zh-tw/3.5.0/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.5.0/cordova/events/events.backbutton.html
+++ b/archive/docs/zh-tw/3.5.0/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.5.0/cordova/events/events.deviceready.html
+++ b/archive/docs/zh-tw/3.5.0/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.5.0/cordova/events/events.endcallbutton.html
+++ b/archive/docs/zh-tw/3.5.0/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.5.0/cordova/events/events.html
+++ b/archive/docs/zh-tw/3.5.0/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.5.0/cordova/events/events.menubutton.html
+++ b/archive/docs/zh-tw/3.5.0/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.5.0/cordova/events/events.pause.html
+++ b/archive/docs/zh-tw/3.5.0/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.5.0/cordova/events/events.resume.html
+++ b/archive/docs/zh-tw/3.5.0/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.5.0/cordova/events/events.searchbutton.html
+++ b/archive/docs/zh-tw/3.5.0/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.5.0/cordova/events/events.startcallbutton.html
+++ b/archive/docs/zh-tw/3.5.0/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.5.0/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/zh-tw/3.5.0/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.5.0/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/zh-tw/3.5.0/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.5.0/cordova/plugins/pluginapis.html
+++ b/archive/docs/zh-tw/3.5.0/cordova/plugins/pluginapis.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.5.0/cordova/storage/storage.html
+++ b/archive/docs/zh-tw/3.5.0/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.5.0/guide/appdev/privacy/index.html
+++ b/archive/docs/zh-tw/3.5.0/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.5.0/guide/appdev/whitelist/index.html
+++ b/archive/docs/zh-tw/3.5.0/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.5.0/guide/cli/index.html
+++ b/archive/docs/zh-tw/3.5.0/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.5.0/guide/hybrid/plugins/index.html
+++ b/archive/docs/zh-tw/3.5.0/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.5.0/guide/hybrid/webviews/index.html
+++ b/archive/docs/zh-tw/3.5.0/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.5.0/guide/overview/index.html
+++ b/archive/docs/zh-tw/3.5.0/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.5.0/guide/platforms/amazonfireos/config.html
+++ b/archive/docs/zh-tw/3.5.0/guide/platforms/amazonfireos/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.5.0/guide/platforms/amazonfireos/index.html
+++ b/archive/docs/zh-tw/3.5.0/guide/platforms/amazonfireos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.5.0/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/zh-tw/3.5.0/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.5.0/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/zh-tw/3.5.0/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.5.0/guide/platforms/android/config.html
+++ b/archive/docs/zh-tw/3.5.0/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.5.0/guide/platforms/android/index.html
+++ b/archive/docs/zh-tw/3.5.0/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.5.0/guide/platforms/android/plugin.html
+++ b/archive/docs/zh-tw/3.5.0/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.5.0/guide/platforms/android/tools.html
+++ b/archive/docs/zh-tw/3.5.0/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.5.0/guide/platforms/android/upgrading.html
+++ b/archive/docs/zh-tw/3.5.0/guide/platforms/android/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.5.0/guide/platforms/android/webview.html
+++ b/archive/docs/zh-tw/3.5.0/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.5.0/guide/platforms/blackberry10/config.html
+++ b/archive/docs/zh-tw/3.5.0/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.5.0/guide/platforms/blackberry10/index.html
+++ b/archive/docs/zh-tw/3.5.0/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.5.0/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/zh-tw/3.5.0/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.5.0/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/zh-tw/3.5.0/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.5.0/guide/platforms/blackberry10/upgrading.html
+++ b/archive/docs/zh-tw/3.5.0/guide/platforms/blackberry10/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.5.0/guide/platforms/index.html
+++ b/archive/docs/zh-tw/3.5.0/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.5.0/guide/platforms/ios/config.html
+++ b/archive/docs/zh-tw/3.5.0/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.5.0/guide/platforms/ios/index.html
+++ b/archive/docs/zh-tw/3.5.0/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.5.0/guide/platforms/ios/plugin.html
+++ b/archive/docs/zh-tw/3.5.0/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.5.0/guide/platforms/ios/tools.html
+++ b/archive/docs/zh-tw/3.5.0/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.5.0/guide/platforms/ios/upgrading.html
+++ b/archive/docs/zh-tw/3.5.0/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.5.0/guide/platforms/ios/webview.html
+++ b/archive/docs/zh-tw/3.5.0/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.5.0/guide/platforms/tizen/index.html
+++ b/archive/docs/zh-tw/3.5.0/guide/platforms/tizen/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.5.0/guide/platforms/ubuntu/index.html
+++ b/archive/docs/zh-tw/3.5.0/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.5.0/guide/platforms/win8/index.html
+++ b/archive/docs/zh-tw/3.5.0/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.5.0/guide/platforms/win8/tools.html
+++ b/archive/docs/zh-tw/3.5.0/guide/platforms/win8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.5.0/guide/platforms/win8/upgrading.html
+++ b/archive/docs/zh-tw/3.5.0/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.5.0/guide/platforms/wp7/index.html
+++ b/archive/docs/zh-tw/3.5.0/guide/platforms/wp7/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.5.0/guide/platforms/wp8/index.html
+++ b/archive/docs/zh-tw/3.5.0/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.5.0/guide/platforms/wp8/plugin.html
+++ b/archive/docs/zh-tw/3.5.0/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.5.0/guide/platforms/wp8/tools.html
+++ b/archive/docs/zh-tw/3.5.0/guide/platforms/wp8/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.5.0/guide/platforms/wp8/upgrading.html
+++ b/archive/docs/zh-tw/3.5.0/guide/platforms/wp8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.5.0/guide/support/index.html
+++ b/archive/docs/zh-tw/3.5.0/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.5.0/index.html
+++ b/archive/docs/zh-tw/3.5.0/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/3.5.0/plugin_ref/plugman.html
+++ b/archive/docs/zh-tw/3.5.0/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/config_ref/images.html
+++ b/archive/docs/zh-tw/5.4.0/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/config_ref/index.html
+++ b/archive/docs/zh-tw/5.4.0/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/cordova/events/events.backbutton.html
+++ b/archive/docs/zh-tw/5.4.0/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/cordova/events/events.deviceready.html
+++ b/archive/docs/zh-tw/5.4.0/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/cordova/events/events.endcallbutton.html
+++ b/archive/docs/zh-tw/5.4.0/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/cordova/events/events.html
+++ b/archive/docs/zh-tw/5.4.0/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/cordova/events/events.menubutton.html
+++ b/archive/docs/zh-tw/5.4.0/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/cordova/events/events.pause.html
+++ b/archive/docs/zh-tw/5.4.0/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/cordova/events/events.resume.html
+++ b/archive/docs/zh-tw/5.4.0/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/cordova/events/events.searchbutton.html
+++ b/archive/docs/zh-tw/5.4.0/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/cordova/events/events.startcallbutton.html
+++ b/archive/docs/zh-tw/5.4.0/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/zh-tw/5.4.0/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/zh-tw/5.4.0/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/cordova/plugins/pluginapis.html
+++ b/archive/docs/zh-tw/5.4.0/cordova/plugins/pluginapis.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/zh-tw/5.4.0/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/cordova/storage/storage.html
+++ b/archive/docs/zh-tw/5.4.0/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/guide/appdev/privacy/index.html
+++ b/archive/docs/zh-tw/5.4.0/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/guide/appdev/security/index.html
+++ b/archive/docs/zh-tw/5.4.0/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/guide/appdev/whitelist/index.html
+++ b/archive/docs/zh-tw/5.4.0/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/guide/cli/index.html
+++ b/archive/docs/zh-tw/5.4.0/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/guide/hybrid/plugins/index.html
+++ b/archive/docs/zh-tw/5.4.0/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/guide/hybrid/webviews/index.html
+++ b/archive/docs/zh-tw/5.4.0/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/guide/overview/index.html
+++ b/archive/docs/zh-tw/5.4.0/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/guide/platforms/amazonfireos/config.html
+++ b/archive/docs/zh-tw/5.4.0/guide/platforms/amazonfireos/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/guide/platforms/amazonfireos/index.html
+++ b/archive/docs/zh-tw/5.4.0/guide/platforms/amazonfireos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/zh-tw/5.4.0/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/zh-tw/5.4.0/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/guide/platforms/android/config.html
+++ b/archive/docs/zh-tw/5.4.0/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/guide/platforms/android/index.html
+++ b/archive/docs/zh-tw/5.4.0/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/guide/platforms/android/plugin.html
+++ b/archive/docs/zh-tw/5.4.0/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/guide/platforms/android/tools.html
+++ b/archive/docs/zh-tw/5.4.0/guide/platforms/android/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/guide/platforms/android/upgrading.html
+++ b/archive/docs/zh-tw/5.4.0/guide/platforms/android/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/guide/platforms/android/webview.html
+++ b/archive/docs/zh-tw/5.4.0/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/guide/platforms/blackberry10/config.html
+++ b/archive/docs/zh-tw/5.4.0/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/guide/platforms/blackberry10/index.html
+++ b/archive/docs/zh-tw/5.4.0/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/zh-tw/5.4.0/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/zh-tw/5.4.0/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/guide/platforms/blackberry10/upgrading.html
+++ b/archive/docs/zh-tw/5.4.0/guide/platforms/blackberry10/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/guide/platforms/firefoxos/index.html
+++ b/archive/docs/zh-tw/5.4.0/guide/platforms/firefoxos/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/guide/platforms/index.html
+++ b/archive/docs/zh-tw/5.4.0/guide/platforms/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/guide/platforms/ios/config.html
+++ b/archive/docs/zh-tw/5.4.0/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/guide/platforms/ios/index.html
+++ b/archive/docs/zh-tw/5.4.0/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/guide/platforms/ios/plugin.html
+++ b/archive/docs/zh-tw/5.4.0/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/guide/platforms/ios/tools.html
+++ b/archive/docs/zh-tw/5.4.0/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/guide/platforms/ios/upgrading.html
+++ b/archive/docs/zh-tw/5.4.0/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/guide/platforms/ios/webview.html
+++ b/archive/docs/zh-tw/5.4.0/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/guide/platforms/tizen/index.html
+++ b/archive/docs/zh-tw/5.4.0/guide/platforms/tizen/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/guide/platforms/ubuntu/index.html
+++ b/archive/docs/zh-tw/5.4.0/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/guide/platforms/win8/index.html
+++ b/archive/docs/zh-tw/5.4.0/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/guide/platforms/win8/packaging.html
+++ b/archive/docs/zh-tw/5.4.0/guide/platforms/win8/packaging.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/guide/platforms/win8/plugin.html
+++ b/archive/docs/zh-tw/5.4.0/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/guide/platforms/win8/upgrading.html
+++ b/archive/docs/zh-tw/5.4.0/guide/platforms/win8/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/guide/platforms/wp8/index.html
+++ b/archive/docs/zh-tw/5.4.0/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/guide/platforms/wp8/plugin.html
+++ b/archive/docs/zh-tw/5.4.0/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/zh-tw/5.4.0/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/guide/platforms/wp8/webview.html
+++ b/archive/docs/zh-tw/5.4.0/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/guide/support/index.html
+++ b/archive/docs/zh-tw/5.4.0/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/index.html
+++ b/archive/docs/zh-tw/5.4.0/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/zh-tw/5.4.0/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/plugin_ref/plugman.html
+++ b/archive/docs/zh-tw/5.4.0/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/5.4.0/plugin_ref/spec.html
+++ b/archive/docs/zh-tw/5.4.0/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/6.x/config_ref/images.html
+++ b/archive/docs/zh-tw/6.x/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/6.x/config_ref/index.html
+++ b/archive/docs/zh-tw/6.x/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/6.x/cordova/events/events.backbutton.html
+++ b/archive/docs/zh-tw/6.x/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/6.x/cordova/events/events.deviceready.html
+++ b/archive/docs/zh-tw/6.x/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/6.x/cordova/events/events.endcallbutton.html
+++ b/archive/docs/zh-tw/6.x/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/6.x/cordova/events/events.html
+++ b/archive/docs/zh-tw/6.x/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/6.x/cordova/events/events.menubutton.html
+++ b/archive/docs/zh-tw/6.x/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/6.x/cordova/events/events.pause.html
+++ b/archive/docs/zh-tw/6.x/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/6.x/cordova/events/events.resume.html
+++ b/archive/docs/zh-tw/6.x/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/6.x/cordova/events/events.searchbutton.html
+++ b/archive/docs/zh-tw/6.x/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/6.x/cordova/events/events.startcallbutton.html
+++ b/archive/docs/zh-tw/6.x/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/6.x/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/zh-tw/6.x/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/6.x/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/zh-tw/6.x/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/6.x/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/zh-tw/6.x/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/6.x/cordova/storage/storage.html
+++ b/archive/docs/zh-tw/6.x/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/6.x/guide/appdev/hooks/index.html
+++ b/archive/docs/zh-tw/6.x/guide/appdev/hooks/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/6.x/guide/appdev/privacy/index.html
+++ b/archive/docs/zh-tw/6.x/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/6.x/guide/appdev/security/index.html
+++ b/archive/docs/zh-tw/6.x/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/6.x/guide/appdev/whitelist/index.html
+++ b/archive/docs/zh-tw/6.x/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/6.x/guide/cli/index.html
+++ b/archive/docs/zh-tw/6.x/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/6.x/guide/hybrid/plugins/index.html
+++ b/archive/docs/zh-tw/6.x/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/6.x/guide/hybrid/webviews/index.html
+++ b/archive/docs/zh-tw/6.x/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/6.x/guide/next/index.html
+++ b/archive/docs/zh-tw/6.x/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/6.x/guide/overview/index.html
+++ b/archive/docs/zh-tw/6.x/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/6.x/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/zh-tw/6.x/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/6.x/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/zh-tw/6.x/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/6.x/guide/platforms/android/config.html
+++ b/archive/docs/zh-tw/6.x/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/6.x/guide/platforms/android/index.html
+++ b/archive/docs/zh-tw/6.x/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/6.x/guide/platforms/android/plugin.html
+++ b/archive/docs/zh-tw/6.x/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/6.x/guide/platforms/android/webview.html
+++ b/archive/docs/zh-tw/6.x/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/6.x/guide/platforms/blackberry10/config.html
+++ b/archive/docs/zh-tw/6.x/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/6.x/guide/platforms/blackberry10/home.html
+++ b/archive/docs/zh-tw/6.x/guide/platforms/blackberry10/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/6.x/guide/platforms/blackberry10/index.html
+++ b/archive/docs/zh-tw/6.x/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/6.x/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/zh-tw/6.x/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/6.x/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/zh-tw/6.x/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/6.x/guide/platforms/blackberry10/upgrade.html
+++ b/archive/docs/zh-tw/6.x/guide/platforms/blackberry10/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/6.x/guide/platforms/ios/config.html
+++ b/archive/docs/zh-tw/6.x/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/6.x/guide/platforms/ios/index.html
+++ b/archive/docs/zh-tw/6.x/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/6.x/guide/platforms/ios/plugin.html
+++ b/archive/docs/zh-tw/6.x/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/6.x/guide/platforms/ios/tools.html
+++ b/archive/docs/zh-tw/6.x/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/6.x/guide/platforms/ios/upgrading.html
+++ b/archive/docs/zh-tw/6.x/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/6.x/guide/platforms/ios/webview.html
+++ b/archive/docs/zh-tw/6.x/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/6.x/guide/platforms/ubuntu/index.html
+++ b/archive/docs/zh-tw/6.x/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/6.x/guide/platforms/win8/index.html
+++ b/archive/docs/zh-tw/6.x/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/6.x/guide/platforms/win8/plugin.html
+++ b/archive/docs/zh-tw/6.x/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/6.x/guide/platforms/wp8/home.html
+++ b/archive/docs/zh-tw/6.x/guide/platforms/wp8/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/6.x/guide/platforms/wp8/index.html
+++ b/archive/docs/zh-tw/6.x/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/6.x/guide/platforms/wp8/plugin.html
+++ b/archive/docs/zh-tw/6.x/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/6.x/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/zh-tw/6.x/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/6.x/guide/platforms/wp8/webview.html
+++ b/archive/docs/zh-tw/6.x/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/6.x/guide/support/index.html
+++ b/archive/docs/zh-tw/6.x/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/6.x/index.html
+++ b/archive/docs/zh-tw/6.x/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/6.x/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/zh-tw/6.x/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/6.x/plugin_ref/plugman.html
+++ b/archive/docs/zh-tw/6.x/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/6.x/plugin_ref/spec.html
+++ b/archive/docs/zh-tw/6.x/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/7.x/config_ref/images.html
+++ b/archive/docs/zh-tw/7.x/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/7.x/config_ref/index.html
+++ b/archive/docs/zh-tw/7.x/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/7.x/cordova/events/events.backbutton.html
+++ b/archive/docs/zh-tw/7.x/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/7.x/cordova/events/events.deviceready.html
+++ b/archive/docs/zh-tw/7.x/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/7.x/cordova/events/events.endcallbutton.html
+++ b/archive/docs/zh-tw/7.x/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/7.x/cordova/events/events.html
+++ b/archive/docs/zh-tw/7.x/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/7.x/cordova/events/events.menubutton.html
+++ b/archive/docs/zh-tw/7.x/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/7.x/cordova/events/events.pause.html
+++ b/archive/docs/zh-tw/7.x/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/7.x/cordova/events/events.resume.html
+++ b/archive/docs/zh-tw/7.x/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/7.x/cordova/events/events.searchbutton.html
+++ b/archive/docs/zh-tw/7.x/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/7.x/cordova/events/events.startcallbutton.html
+++ b/archive/docs/zh-tw/7.x/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/7.x/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/zh-tw/7.x/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/7.x/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/zh-tw/7.x/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/7.x/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/zh-tw/7.x/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/7.x/cordova/storage/storage.html
+++ b/archive/docs/zh-tw/7.x/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/7.x/guide/appdev/hooks/index.html
+++ b/archive/docs/zh-tw/7.x/guide/appdev/hooks/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/7.x/guide/appdev/privacy/index.html
+++ b/archive/docs/zh-tw/7.x/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/7.x/guide/appdev/security/index.html
+++ b/archive/docs/zh-tw/7.x/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/7.x/guide/appdev/whitelist/index.html
+++ b/archive/docs/zh-tw/7.x/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/7.x/guide/cli/index.html
+++ b/archive/docs/zh-tw/7.x/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/7.x/guide/hybrid/plugins/index.html
+++ b/archive/docs/zh-tw/7.x/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/7.x/guide/hybrid/webviews/index.html
+++ b/archive/docs/zh-tw/7.x/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/7.x/guide/next/index.html
+++ b/archive/docs/zh-tw/7.x/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/7.x/guide/overview/index.html
+++ b/archive/docs/zh-tw/7.x/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/7.x/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/zh-tw/7.x/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/7.x/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/zh-tw/7.x/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/7.x/guide/platforms/android/config.html
+++ b/archive/docs/zh-tw/7.x/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/7.x/guide/platforms/android/index.html
+++ b/archive/docs/zh-tw/7.x/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/7.x/guide/platforms/android/plugin.html
+++ b/archive/docs/zh-tw/7.x/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/7.x/guide/platforms/android/webview.html
+++ b/archive/docs/zh-tw/7.x/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/7.x/guide/platforms/blackberry10/config.html
+++ b/archive/docs/zh-tw/7.x/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/7.x/guide/platforms/blackberry10/home.html
+++ b/archive/docs/zh-tw/7.x/guide/platforms/blackberry10/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/7.x/guide/platforms/blackberry10/index.html
+++ b/archive/docs/zh-tw/7.x/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/7.x/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/zh-tw/7.x/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/7.x/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/zh-tw/7.x/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/7.x/guide/platforms/blackberry10/upgrade.html
+++ b/archive/docs/zh-tw/7.x/guide/platforms/blackberry10/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/7.x/guide/platforms/ios/config.html
+++ b/archive/docs/zh-tw/7.x/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/7.x/guide/platforms/ios/index.html
+++ b/archive/docs/zh-tw/7.x/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/7.x/guide/platforms/ios/plugin.html
+++ b/archive/docs/zh-tw/7.x/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/7.x/guide/platforms/ios/tools.html
+++ b/archive/docs/zh-tw/7.x/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/7.x/guide/platforms/ios/upgrading.html
+++ b/archive/docs/zh-tw/7.x/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/7.x/guide/platforms/ios/webview.html
+++ b/archive/docs/zh-tw/7.x/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/7.x/guide/platforms/ubuntu/index.html
+++ b/archive/docs/zh-tw/7.x/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/7.x/guide/platforms/win8/index.html
+++ b/archive/docs/zh-tw/7.x/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/7.x/guide/platforms/win8/plugin.html
+++ b/archive/docs/zh-tw/7.x/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/7.x/guide/platforms/wp8/home.html
+++ b/archive/docs/zh-tw/7.x/guide/platforms/wp8/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/7.x/guide/platforms/wp8/index.html
+++ b/archive/docs/zh-tw/7.x/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/7.x/guide/platforms/wp8/plugin.html
+++ b/archive/docs/zh-tw/7.x/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/7.x/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/zh-tw/7.x/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/7.x/guide/platforms/wp8/webview.html
+++ b/archive/docs/zh-tw/7.x/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/7.x/guide/support/index.html
+++ b/archive/docs/zh-tw/7.x/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/7.x/index.html
+++ b/archive/docs/zh-tw/7.x/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/7.x/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/zh-tw/7.x/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/7.x/plugin_ref/plugman.html
+++ b/archive/docs/zh-tw/7.x/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/7.x/plugin_ref/spec.html
+++ b/archive/docs/zh-tw/7.x/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/8.x/config_ref/images.html
+++ b/archive/docs/zh-tw/8.x/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/8.x/config_ref/index.html
+++ b/archive/docs/zh-tw/8.x/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/8.x/cordova/events/events.backbutton.html
+++ b/archive/docs/zh-tw/8.x/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/8.x/cordova/events/events.deviceready.html
+++ b/archive/docs/zh-tw/8.x/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/8.x/cordova/events/events.endcallbutton.html
+++ b/archive/docs/zh-tw/8.x/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/8.x/cordova/events/events.html
+++ b/archive/docs/zh-tw/8.x/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/8.x/cordova/events/events.menubutton.html
+++ b/archive/docs/zh-tw/8.x/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/8.x/cordova/events/events.pause.html
+++ b/archive/docs/zh-tw/8.x/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/8.x/cordova/events/events.resume.html
+++ b/archive/docs/zh-tw/8.x/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/8.x/cordova/events/events.searchbutton.html
+++ b/archive/docs/zh-tw/8.x/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/8.x/cordova/events/events.startcallbutton.html
+++ b/archive/docs/zh-tw/8.x/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/8.x/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/zh-tw/8.x/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/8.x/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/zh-tw/8.x/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/8.x/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/zh-tw/8.x/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/8.x/cordova/storage/storage.html
+++ b/archive/docs/zh-tw/8.x/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/8.x/guide/appdev/hooks/index.html
+++ b/archive/docs/zh-tw/8.x/guide/appdev/hooks/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/8.x/guide/appdev/privacy/index.html
+++ b/archive/docs/zh-tw/8.x/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/8.x/guide/appdev/security/index.html
+++ b/archive/docs/zh-tw/8.x/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/8.x/guide/appdev/whitelist/index.html
+++ b/archive/docs/zh-tw/8.x/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/8.x/guide/cli/index.html
+++ b/archive/docs/zh-tw/8.x/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/8.x/guide/hybrid/plugins/index.html
+++ b/archive/docs/zh-tw/8.x/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/8.x/guide/hybrid/webviews/index.html
+++ b/archive/docs/zh-tw/8.x/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/8.x/guide/next/index.html
+++ b/archive/docs/zh-tw/8.x/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/8.x/guide/overview/index.html
+++ b/archive/docs/zh-tw/8.x/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/8.x/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/zh-tw/8.x/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/8.x/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/zh-tw/8.x/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/8.x/guide/platforms/android/config.html
+++ b/archive/docs/zh-tw/8.x/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/8.x/guide/platforms/android/index.html
+++ b/archive/docs/zh-tw/8.x/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/8.x/guide/platforms/android/plugin.html
+++ b/archive/docs/zh-tw/8.x/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/8.x/guide/platforms/android/webview.html
+++ b/archive/docs/zh-tw/8.x/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/8.x/guide/platforms/blackberry10/config.html
+++ b/archive/docs/zh-tw/8.x/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/8.x/guide/platforms/blackberry10/home.html
+++ b/archive/docs/zh-tw/8.x/guide/platforms/blackberry10/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/8.x/guide/platforms/blackberry10/index.html
+++ b/archive/docs/zh-tw/8.x/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/8.x/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/zh-tw/8.x/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/8.x/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/zh-tw/8.x/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/8.x/guide/platforms/blackberry10/upgrade.html
+++ b/archive/docs/zh-tw/8.x/guide/platforms/blackberry10/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/8.x/guide/platforms/ios/config.html
+++ b/archive/docs/zh-tw/8.x/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/8.x/guide/platforms/ios/index.html
+++ b/archive/docs/zh-tw/8.x/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/8.x/guide/platforms/ios/plugin.html
+++ b/archive/docs/zh-tw/8.x/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/8.x/guide/platforms/ios/tools.html
+++ b/archive/docs/zh-tw/8.x/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/8.x/guide/platforms/ios/upgrading.html
+++ b/archive/docs/zh-tw/8.x/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/8.x/guide/platforms/ios/webview.html
+++ b/archive/docs/zh-tw/8.x/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/8.x/guide/platforms/ubuntu/index.html
+++ b/archive/docs/zh-tw/8.x/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/8.x/guide/platforms/win8/index.html
+++ b/archive/docs/zh-tw/8.x/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/8.x/guide/platforms/win8/plugin.html
+++ b/archive/docs/zh-tw/8.x/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/8.x/guide/platforms/wp8/home.html
+++ b/archive/docs/zh-tw/8.x/guide/platforms/wp8/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/8.x/guide/platforms/wp8/index.html
+++ b/archive/docs/zh-tw/8.x/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/8.x/guide/platforms/wp8/plugin.html
+++ b/archive/docs/zh-tw/8.x/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/8.x/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/zh-tw/8.x/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/8.x/guide/platforms/wp8/webview.html
+++ b/archive/docs/zh-tw/8.x/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/8.x/guide/support/index.html
+++ b/archive/docs/zh-tw/8.x/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/8.x/index.html
+++ b/archive/docs/zh-tw/8.x/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/8.x/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/zh-tw/8.x/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/8.x/plugin_ref/plugman.html
+++ b/archive/docs/zh-tw/8.x/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/8.x/plugin_ref/spec.html
+++ b/archive/docs/zh-tw/8.x/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/9.x/config_ref/images.html
+++ b/archive/docs/zh-tw/9.x/config_ref/images.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/9.x/config_ref/index.html
+++ b/archive/docs/zh-tw/9.x/config_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/9.x/cordova/events/events.backbutton.html
+++ b/archive/docs/zh-tw/9.x/cordova/events/events.backbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/9.x/cordova/events/events.deviceready.html
+++ b/archive/docs/zh-tw/9.x/cordova/events/events.deviceready.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/9.x/cordova/events/events.endcallbutton.html
+++ b/archive/docs/zh-tw/9.x/cordova/events/events.endcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/9.x/cordova/events/events.html
+++ b/archive/docs/zh-tw/9.x/cordova/events/events.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/9.x/cordova/events/events.menubutton.html
+++ b/archive/docs/zh-tw/9.x/cordova/events/events.menubutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/9.x/cordova/events/events.pause.html
+++ b/archive/docs/zh-tw/9.x/cordova/events/events.pause.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/9.x/cordova/events/events.resume.html
+++ b/archive/docs/zh-tw/9.x/cordova/events/events.resume.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/9.x/cordova/events/events.searchbutton.html
+++ b/archive/docs/zh-tw/9.x/cordova/events/events.searchbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/9.x/cordova/events/events.startcallbutton.html
+++ b/archive/docs/zh-tw/9.x/cordova/events/events.startcallbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/9.x/cordova/events/events.volumedownbutton.html
+++ b/archive/docs/zh-tw/9.x/cordova/events/events.volumedownbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/9.x/cordova/events/events.volumeupbutton.html
+++ b/archive/docs/zh-tw/9.x/cordova/events/events.volumeupbutton.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/9.x/cordova/storage/localstorage/localstorage.html
+++ b/archive/docs/zh-tw/9.x/cordova/storage/localstorage/localstorage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/9.x/cordova/storage/storage.html
+++ b/archive/docs/zh-tw/9.x/cordova/storage/storage.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/9.x/guide/appdev/hooks/index.html
+++ b/archive/docs/zh-tw/9.x/guide/appdev/hooks/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/9.x/guide/appdev/privacy/index.html
+++ b/archive/docs/zh-tw/9.x/guide/appdev/privacy/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/9.x/guide/appdev/security/index.html
+++ b/archive/docs/zh-tw/9.x/guide/appdev/security/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/9.x/guide/appdev/whitelist/index.html
+++ b/archive/docs/zh-tw/9.x/guide/appdev/whitelist/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/9.x/guide/cli/index.html
+++ b/archive/docs/zh-tw/9.x/guide/cli/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/9.x/guide/hybrid/plugins/index.html
+++ b/archive/docs/zh-tw/9.x/guide/hybrid/plugins/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/9.x/guide/hybrid/webviews/index.html
+++ b/archive/docs/zh-tw/9.x/guide/hybrid/webviews/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/9.x/guide/next/index.html
+++ b/archive/docs/zh-tw/9.x/guide/next/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/9.x/guide/overview/index.html
+++ b/archive/docs/zh-tw/9.x/guide/overview/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/9.x/guide/platforms/amazonfireos/plugin.html
+++ b/archive/docs/zh-tw/9.x/guide/platforms/amazonfireos/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/9.x/guide/platforms/amazonfireos/webview.html
+++ b/archive/docs/zh-tw/9.x/guide/platforms/amazonfireos/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/9.x/guide/platforms/android/config.html
+++ b/archive/docs/zh-tw/9.x/guide/platforms/android/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/9.x/guide/platforms/android/index.html
+++ b/archive/docs/zh-tw/9.x/guide/platforms/android/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/9.x/guide/platforms/android/plugin.html
+++ b/archive/docs/zh-tw/9.x/guide/platforms/android/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/9.x/guide/platforms/android/webview.html
+++ b/archive/docs/zh-tw/9.x/guide/platforms/android/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/9.x/guide/platforms/blackberry10/config.html
+++ b/archive/docs/zh-tw/9.x/guide/platforms/blackberry10/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/9.x/guide/platforms/blackberry10/home.html
+++ b/archive/docs/zh-tw/9.x/guide/platforms/blackberry10/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/9.x/guide/platforms/blackberry10/index.html
+++ b/archive/docs/zh-tw/9.x/guide/platforms/blackberry10/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/9.x/guide/platforms/blackberry10/plugin.html
+++ b/archive/docs/zh-tw/9.x/guide/platforms/blackberry10/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/9.x/guide/platforms/blackberry10/tools.html
+++ b/archive/docs/zh-tw/9.x/guide/platforms/blackberry10/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/9.x/guide/platforms/blackberry10/upgrade.html
+++ b/archive/docs/zh-tw/9.x/guide/platforms/blackberry10/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/9.x/guide/platforms/ios/config.html
+++ b/archive/docs/zh-tw/9.x/guide/platforms/ios/config.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/9.x/guide/platforms/ios/index.html
+++ b/archive/docs/zh-tw/9.x/guide/platforms/ios/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/9.x/guide/platforms/ios/plugin.html
+++ b/archive/docs/zh-tw/9.x/guide/platforms/ios/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/9.x/guide/platforms/ios/tools.html
+++ b/archive/docs/zh-tw/9.x/guide/platforms/ios/tools.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/9.x/guide/platforms/ios/upgrading.html
+++ b/archive/docs/zh-tw/9.x/guide/platforms/ios/upgrading.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/9.x/guide/platforms/ios/webview.html
+++ b/archive/docs/zh-tw/9.x/guide/platforms/ios/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/9.x/guide/platforms/ubuntu/index.html
+++ b/archive/docs/zh-tw/9.x/guide/platforms/ubuntu/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/9.x/guide/platforms/win8/index.html
+++ b/archive/docs/zh-tw/9.x/guide/platforms/win8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/9.x/guide/platforms/win8/plugin.html
+++ b/archive/docs/zh-tw/9.x/guide/platforms/win8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/9.x/guide/platforms/wp8/home.html
+++ b/archive/docs/zh-tw/9.x/guide/platforms/wp8/home.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/9.x/guide/platforms/wp8/index.html
+++ b/archive/docs/zh-tw/9.x/guide/platforms/wp8/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/9.x/guide/platforms/wp8/plugin.html
+++ b/archive/docs/zh-tw/9.x/guide/platforms/wp8/plugin.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/9.x/guide/platforms/wp8/upgrade.html
+++ b/archive/docs/zh-tw/9.x/guide/platforms/wp8/upgrade.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/9.x/guide/platforms/wp8/webview.html
+++ b/archive/docs/zh-tw/9.x/guide/platforms/wp8/webview.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/9.x/guide/support/index.html
+++ b/archive/docs/zh-tw/9.x/guide/support/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/9.x/index.html
+++ b/archive/docs/zh-tw/9.x/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/9.x/platform_plugin_versioning_ref/index.html
+++ b/archive/docs/zh-tw/9.x/platform_plugin_versioning_ref/index.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/9.x/plugin_ref/plugman.html
+++ b/archive/docs/zh-tw/9.x/plugin_ref/plugman.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>

--- a/archive/docs/zh-tw/9.x/plugin_ref/spec.html
+++ b/archive/docs/zh-tw/9.x/plugin_ref/spec.html
@@ -47,16 +47,6 @@
     <!-- JS -->
     <script defer type="text/javascript" src="../../../../static/js/lib/jquery-2.1.1.min.js"></script>
     <script defer type="text/javascript" src="../../../../static/js/lib/bootstrap.min.js"></script>
-
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-64283057-1', 'auto');
-    ga('send', 'pageview');
-</script>
-
 </head>
 
 <body>


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Resolves #1396


### Description
<!-- Describe your changes in detail -->
Automated removal (with no replacement) of Google Analytics code in archived docs.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Spot checks in files, but not thorough testing.


### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
