### PR TITLE
doc(ios): install cocoapods with homebrew

### DIFF
--- a/www/docs/en/12.x-2025.01/guide/platforms/ios/index.md
+++ b/www/docs/en/12.x-2025.01/guide/platforms/ios/index.md
@@ -124,7 +124,7 @@ The [CocoaPods](https://cocoapods.org/#install) tools are needed to build iOS ap
 To install CocoaPods, run the following from command-line terminal:
 
 ```bash
-$ sudo gem install cocoapods
+$ brew install cocoapods
 ```
 
 ## Project Configuration

--- a/www/docs/en/12.x/guide/platforms/ios/index.md
+++ b/www/docs/en/12.x/guide/platforms/ios/index.md
@@ -124,7 +124,7 @@ The [CocoaPods](https://cocoapods.org/#install) tools are needed to build iOS ap
 To install CocoaPods, run the following from command-line terminal:
 
 ```bash
-$ sudo gem install cocoapods
+$ brew install cocoapods
 ```
 
 ## Project Configuration

--- a/www/docs/en/dev/guide/platforms/ios/index.md
+++ b/www/docs/en/dev/guide/platforms/ios/index.md
@@ -124,7 +124,7 @@ The [CocoaPods](https://cocoapods.org/#install) tools are needed to build iOS ap
 To install CocoaPods, run the following from command-line terminal:
 
 ```bash
-$ sudo gem install cocoapods
+$ brew install cocoapods
 ```
 
 ## Project Configuration


### PR DESCRIPTION
- cocoapods are not installable with the current system ruby version on macOS. When trying to install with `sudo gem install cocoapods`, the error message will appear: `securerandom requires Ruby version >= 3.1.0. The current ruby version is 2.6.10.210`.
- On stackoverflow it is suggested to install it instead with homebrew: https://stackoverflow.com/questions/77339560/error-installing-cocoapodsdrb-requires-ruby-version-2-7-0-the-current-ruby

### Platforms affected
macOS

### Motivation and Context
I tried to setup my machine and got an error when installing cocoa pods

### Description


### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
