### PR TITLE
doc(android): Improve documentation of onRequestPermissionResult

### DIFF
--- a/www/docs/en/11.x/guide/platforms/android/plugin.md
+++ b/www/docs/en/11.x/guide/platforms/android/plugin.md
@@ -344,21 +344,35 @@ protected void getReadPermission(int requestCode)
 }
 ```
 
-This will call the activity and cause a prompt to appear, asking for the permission.  Once the user has the permission, the result must be handled with the `onRequestPermissionResult` method, which
-every plugin should override.  An example of this can be found below:
+This will call the activity and cause a prompt to appear, asking for the permission. Once the user has the permission, the result must be handled with the `onRequestPermissionResult` method, a forwarded [Android method](https://developer.android.com/reference/android/app/Activity#onRequestPermissionsResult(int,%20java.lang.String[],%20int[])), which every plugin should override.  An example of this can be found below:
 
 ```java
-public void onRequestPermissionResult(int requestCode, String[] permissions,
-                                         int[] grantResults) throws JSONException
+@Override
+public void onRequestPermissionResult(int requestCode, String[] permissions, int[] grantResults) throws JSONException
 {
-    for(int r:grantResults)
+    // It is possible that the permissions request interaction with the user is interrupted.
+    // In this case you will receive an empty permissions and grantResults array, which should be
+    // treated as a cancellation.
+    boolean granted = grantResults.length != 0;
+
+    // Check if a permission is denied by user
+    for(int grantResult : grantResults)
     {
-        if(r == PackageManager.PERMISSION_DENIED)
+        if(grantResult == PackageManager.PERMISSION_DENIED)
         {
-            this.callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.ERROR, PERMISSION_DENIED_ERROR));
-            return;
+            granted = false;
+            break;
         }
     }
+
+    // User denied a permission
+    if(!granted)
+    {
+        this.callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.ERROR, PERMISSION_DENIED_ERROR));
+        return;
+    }
+    
+    // Handle the request with the granted permission
     switch(requestCode)
     {
         case SEARCH_REQ_CODE:


### PR DESCRIPTION
### Platforms affected
Android

### Motivation and Context
It was not documented, that `grantResults` can be empty when the permissions request interaction with the user was interrupted and that `onRequestPermissionResult` is a method from Android.

- Mention that it is a forwarded Android method
- Add Android documentation link for `onRequestPermissionsResult`
- Handle and document `grandResult.length == 0`, which can occur, if the request interaction was interrupted
- Document code in `onRequestPermissionResult` and small refactoring

I changed this in `dev`, `12.x-2025.01`, `12.x`, `11.x`

### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
