### PR TITLE
fix(RewriteRule): do not redirect for archive or English docs

### DIFF
--- a/www/.htaccess
+++ b/www/.htaccess
@@ -116,7 +116,7 @@ RewriteRule ^.*docs/(\w\w(?:-\w\w)?)/latest$ {{site.baseurl}}/docs/$1/latest/ [R
 RewriteRule ^.*docs/(\w\w(?:-\w\w)?)/latest/(.*)$ {{site.baseurl}}/docs/$1/{{site.latest_docs_version}}/$2 [L]
 
 # Redirect http to https
-# From Cordova PMC Member raphinesse 
+# From Cordova PMC Member raphinesse
 # https://s.apache.org/An8s
 
 # If we receive a forwarded http request from a proxy...
@@ -129,6 +129,19 @@ RewriteCond %{HTTPS} !=on
 # Redirect to https version
 RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
 
-# Redirect all docs translations to their English version
-RewriteCond $1 !=en
-RewriteRule ^.*docs/(\w\w(?:-\w\w)?)/(.*)$ {{site.baseurl}}/docs/en/$2 [R=302,L]
+# Prevent redirecting away from archive URLs
+RewriteCond %{REQUEST_URI} ^/archive/ [NC]
+RewriteRule .* - [L]
+
+# Prevent redirecting away from English docs
+RewriteCond %{REQUEST_URI} ^/docs/en/ [NC]
+RewriteRule .* - [L]
+
+# Redirect all non-English documentation to the English version.
+# If the English counterpart is missing, a 404 page will be displayed.
+# Over time, the non-English documentation has fallen out of sync with the English version.
+# For example, some pages may have been removed from the English documentation because they were no longer
+# relevant or were merged into other pages, while the translated versions were not updated accordingly.
+RewriteCond %{REQUEST_URI} ^/docs/(\w\w(?:-\w\w)?) [NC]
+RewriteCond %1 !=en
+RewriteRule ^docs/(\w\w(?:-\w\w)?)/(.*)$ /docs/en/$2 [R=302,L]


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

https://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Fix redirect for archived docs

### Description
<!-- Describe your changes in detail -->

Updated the `RewriteRules` to follow these steps, in order:

1. Stop rewrite when URL starts with `/archive/`.
2. Stop rewrite when URL starts with  `/docs/en/`.
3. Forward non-English docs to English docs.

Additional Notes:

- Step three has always been designed to redirect old language documentation to the English version.
  - However, it is possible to change this behavior to redirect them to the archived language documentation instead, **if preferred**. (Would be in a separate PR)
  - However, since this redirection behavior has been in place for several years, changing it now may no longer be necessary.
- If old versions of the English documentation are to be archived, the `RewriteRule` should be placed above step two. In this case, it would redirect to archive.

### Testing
<!-- Please describe in detail how you tested your changes. -->

Ran a httpd server to test the RewriteRules.

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
