### PR TITLE
doc: correct version redirects where possible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7

--- a/tools/bin/gen_pages_dict.js
+++ b/tools/bin/gen_pages_dict.js
@@ -40,7 +40,7 @@ const LATEST_ALIAS_URI = '/latest/';
 function pathToURI (filePath, rootPath) {
     return filePath
         .replace(new RegExp('^' + rootPath), '')
-        .replace(/\\.md$/, '.html');
+        .replace(/\.md$/, '.html');
 }
 
 function pagesFromRedirects (redirects, languages) {
@@ -88,7 +88,6 @@ function main () {
     // add entries for all Markdown files in the site root
     const allMarkdownFiles = path.join(siteRootPath, '**/*.md');
     fs.glob(allMarkdownFiles, function (error, filePaths) {
-        console.log(filePaths);
         if (error) throw error;
 
         for (let i = 0; i < filePaths.length; i++) {

--- a/www/_layouts/docs.html
+++ b/www/_layouts/docs.html
@@ -18,6 +18,8 @@ set some constants
 {% assign MY_ENTRY = page.url | replace: VERSION_ROOT,"" %}
 {% assign my_entry_parts = MY_ENTRY | split: "/" %}
 
+{% assign page_url = "/" | append: page.path | replace: ".md", ".html" %}
+
 {% comment %}
 PATH_TO_ROOT: path from here to version root, replacing all parts except the last one with '../'
 NOTE:
@@ -152,7 +154,7 @@ NOTE:
                                     layouts change from version to version
                             {% endcomment %}
                             {% capture other_version_root %}/docs/{{ page.language }}/{{ other_version_string }}/{% endcapture %}
-                            {% assign other_version_url = page.url | replace:VERSION_ROOT,other_version_root %}
+                            {% assign other_version_url = page_url | replace:VERSION_ROOT,other_version_root %}
 
                             {% unless ALL_PAGES contains other_version_url %}
                                 {% assign other_version_url = other_version_root %}
@@ -177,7 +179,7 @@ NOTE:
             Get URL for this page in the latest version
             {% endcomment %}
             {% capture latest_root %}/docs/{{ page.language }}/latest/{% endcapture %}
-            {% assign latest_url = page.url | replace:VERSION_ROOT,latest_root %}
+            {% assign latest_url = page_url | replace:VERSION_ROOT,latest_root %}
 
             {% comment %}
             If this page doesn't exist, just use root


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

https://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Resolves #1278

### Description
<!-- Describe your changes in detail -->

- CI to use NodeJS 22
- Fix regex to replace `.md` to `.html` in `all-pages.yml` generation.
- Remove `console.log` that affected `all-pages.yml` content.
- Get the current page full URL with `page.path` and format it with a prefixed `/` and converted `.md` to `.html`.
- Fixed page detection when checking against `all-pages.yml`.

### Testing
<!-- Please describe in detail how you tested your changes. -->

**Built Docs:**

- `bundle install`
- `npm install`
- `npm run serve`

**Navigated to an old doc:**

- `http://localhost:3000/docs/en/8.x/guide/cli/index.html`

**Observations:**

1. Outdated Version Warning:
   The link for "This version of the documentation is outdated! Click here for the latest released version." points to `http://localhost:3000/docs/en/latest/guide/cli/index.html`.

   **Note**: Clicking on this link will not work because the `latest` redirection is handled by `.htaccess`, and `serve` is not running an Apache Httpd server.

2. 12.x Version Link:
   The link for `12.x` in the version dropdown points to `http://localhost:3000/docs/en/12.x/guide/cli/index.html`. Clicking on this link will perform a redirect to the correct page.

3. 2.8.0 Version Link:
    The link for `2.8.0` is grayed out since this version does not have a mapping for the current page. The link points to `http://localhost:3000/docs/en/2.8.0/`. Clicking on this link will redirect to the root page of version 2.8.0.

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
