### PR TITLE
Android guide: How to get java home path on mac

### DIFF
--- a/www/docs/en/12.x-2025.01/guide/platforms/android/index.md
+++ b/www/docs/en/12.x-2025.01/guide/platforms/android/index.md
@@ -333,7 +333,7 @@ When you installed the Java Development Kit like described in this guide you can
 
 Set `JAVA_HOME` like you already did it for `ANDROID_HOME`.
 
-### Reaload Terminal
+### Reload Terminal
 
 Reload your terminal to see this change reflected or run the following command:
 

--- a/www/docs/en/12.x-2025.01/guide/platforms/android/index.md
+++ b/www/docs/en/12.x-2025.01/guide/platforms/android/index.md
@@ -297,6 +297,7 @@ _**Note:** The directories above are generally located in the Android SDK ROOT._
 On Linux or macOS versions prior to Catalina, use any text editor to create or modify the `~/.bash_profile` file.
 <br>On macOS Catalina and newer, create or modify the `~/.zprofile` file, as the default shell has changed.
 
+##### ANDROID_HOME
 Add the following line to your shell's profile to set up the `ANDROID_HOME` environment variable.
 
 **Linux:**
@@ -321,6 +322,18 @@ export PATH=$PATH:$ANDROID_HOME/cmdline-tools/latest/bin/
 export PATH=$PATH:$ANDROID_HOME/build-tools/
 export PATH=$PATH:$ANDROID_HOME/emulator/
 ```
+
+#### JAVA_HOME
+
+**macOS:**
+
+When you installed the Java Development Kit like described in this guide you can get the java home path executing
+
+`echo $(/usr/libexec/java_home)`
+
+Set `JAVA_HOME` like you already did it for `ANDROID_HOME`.
+
+### Reaload Terminal
 
 Reload your terminal to see this change reflected or run the following command:
 


### PR DESCRIPTION
- Add a shell command how to get the current java home path
- Add ANDROID_HOME section to separate the guide from the JAVA_HOME guide
- Add "Reload Terminal" section

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

https://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->



### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
