### PR TITLE
Plugin Guide: Notes for --link option

### DIFF
--- a/www/docs/en/12.x-2025.01/guide/hybrid/plugins/index.md
+++ b/www/docs/en/12.x-2025.01/guide/hybrid/plugins/index.md
@@ -194,7 +194,7 @@ cordova plugin add ../path/to/my/plugin/relative/to/project --link
 ```
 
 This creates a symbolic link instead of copying the plugin files, which enables you
-to work on your plugin and then simply rebuild the app to use your changes.
+to work on your plugin and then simply rebuild the app to use your changes. You have to add the plugin after you added the platform, otherwise the link will not work. The link will also be lost, if you re-add a platform. If you do this you have to re-add the plugin.
 
 ## Validating a Plugin using Plugman
 


### PR DESCRIPTION
Added notice, that the linking only works, when the plugin is added after a platform was added and that the linking will be lost if a platform is re-added

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

https://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->



### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
