### PR TITLE
doc(plugin): notes for --link when the linking is lost

### DIFF
--- a/www/docs/en/12.x-2025.01/guide/hybrid/plugins/index.md
+++ b/www/docs/en/12.x-2025.01/guide/hybrid/plugins/index.md
@@ -193,8 +193,7 @@ Cordova app as usual and add the plugin with the `--link` option:
 cordova plugin add ../path/to/my/plugin/relative/to/project --link
 ```
 
-This creates a symbolic link instead of copying the plugin files, which enables you
-to work on your plugin and then simply rebuild the app to use your changes.
+This creates a symbolic link instead of copying the plugin files, which enables you to work on your plugin and then simply rebuild the app to use your changes. The plugin should be added after the platform, or the link will not work. The link will also be lost if you re-add the platform or [restore the project](../../../platform_plugin_versioning_ref/index.md) with `cordova prepare`. In that case, you'll need to re-add the plugin to restore the link.
 
 ## Validating a Plugin using Plugman
 

--- a/www/docs/en/dev/guide/hybrid/plugins/index.md
+++ b/www/docs/en/dev/guide/hybrid/plugins/index.md
@@ -193,8 +193,7 @@ Cordova app as usual and add the plugin with the `--link` option:
 cordova plugin add ../path/to/my/plugin/relative/to/project --link
 ```
 
-This creates a symbolic link instead of copying the plugin files, which enables you
-to work on your plugin and then simply rebuild the app to use your changes.
+This creates a symbolic link instead of copying the plugin files, which enables you to work on your plugin and then simply rebuild the app to use your changes. The plugin should be added after the platform, or the link will not work. The link will also be lost if you re-add the platform or [restore the project](../../../platform_plugin_versioning_ref/index.md) with `cordova prepare`. In that case, you'll need to re-add the plugin to restore the link.
 
 ## Validating a Plugin using Plugman
 


### PR DESCRIPTION
- Added notice, that the linking only works, when the plugin is added after a platform was added and that the linking will be lost if a platform is re-added or a project is restored
- Added link to "Version management" to explain what restoring a project means and add `cordova prepare` to give an example also

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

https://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
All

### Motivation and Context
It was not clear, that the plugin linking will be lost, if a platform is re-added or a project is restored



### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
