### PR TITLE
docs(spec.md): change source-file compiler-flags example

### DIFF
--- a/www/docs/en/dev/plugin_ref/spec.md
+++ b/www/docs/en/dev/plugin_ref/spec.md
@@ -273,8 +273,8 @@ Examples:
 <source-file src="src/android/Foo.java" target-dir="src/com/alunny/foo" />
 <!-- ios -->
 <source-file src="src/ios/CDVFoo.m" />
+<source-file src="src/ios/CDVFoo.m" compiler-flags="-fno-objc-arc" />
 <source-file src="src/ios/someLib.a" framework="true" />
-<source-file src="src/ios/someLib.a" compiler-flags="-fno-objc-arc" />
 ```
 
 ## header-file


### PR DESCRIPTION
`compiler-flags` has no effect on prebuilt libraries such as the `someLib.a` example. Also the `someLib.a` should always include the `framework="true"` as the previous example.

So removed the `<source-file src="src/ios/someLib.a" compiler-flags="-fno-objc-arc" />` as it's invalid and included a new example for adding the compiler flags to a `.m` file