### PR TITLE
doc(android): refactor embedding webview

### DIFF
--- a/www/docs/en/dev/guide/platforms/android/webview.md
+++ b/www/docs/en/dev/guide/platforms/android/webview.md
@@ -57,7 +57,7 @@ legacy `CordovaActivity` component that pre-dates the 1.9 release.
                 android:layout_height="match_parent" />
 </LinearLayout
 ```
-1. Modify your activity so that the class extends CordovaActivity (found at app/main/java/org/apache/cordova/CordovaActivity.java)
+1. Modify your activity so that the class extends `CordovaActivity` (found at `app/main/java/org/apache/cordova/CordovaActivity.java`)
 ```
 public class TestActivity extends CordovaActivity {
     

--- a/www/docs/en/dev/guide/platforms/android/webview.md
+++ b/www/docs/en/dev/guide/platforms/android/webview.md
@@ -69,7 +69,7 @@ public class TestActivity extends CordovaActivity {
 @Override
 public void onCreate(Bundle savedInstanceState) {
      super.onCreate(savedInstanceState);
-     setContentView(R.layout.activity_test); //this is the layout file for your activity
+     setContentView(R.layout.activity_test); // layout file for your activity
      super.init();
      loadUrl(launchUrl);
 }

--- a/www/docs/en/dev/guide/platforms/android/webview.md
+++ b/www/docs/en/dev/guide/platforms/android/webview.md
@@ -38,53 +38,57 @@ legacy `CordovaActivity` component that pre-dates the 1.9 release.
    [cordova.apache.org](https://cordova.apache.org) and unzip its
    Android package.
 
-2. Follow the instructions here to build your first cordova app [CreateYourFirstApp](https://cordova.apache.org/docs/en/8.x/guide/cli/index.html)
+1. Follow the instructions here to build your first cordova app [CreateYourFirstApp](https://cordova.apache.org/docs/en/8.x/guide/cli/index.html)
 
-3. Copy Cordova framework files **from platforms/android/CordovaLib/src/** to your android application directory at **/app/main/java**. Also copy additional Cordova framework files **from platforms/android/src/** to your android application directory at **/app/main/java**.
-
-4. Modify the layout file of the activity that shall host the Cordova view e.g.
+1. Copy Cordova framework files
 ```
- <LinearLayout android:layout_width="fill_parent"
+platforms/android/CordovaLib/src/.* to <AndroidAppRoot>/app/main/java
+platforms/android/src/** to <AndroidAppRoot>/app/main/java
+```
+
+1. Modify the layout file of the activity that shall host the Cordova view e.g.
+```
+<LinearLayout android:layout_width="fill_parent"
               android:layout_height="fill_parent"
               android:orientation="vertical"
               xmlns:android="http://schemas.android.com/apk/res/android">
-   <org.apache.cordova.engine.SystemWebView
-            android:id="@+id/cordovaWebView"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent" />
-   </LinearLayout
+    <org.apache.cordova.engine.SystemWebView
+                android:id="@+id/cordovaWebView"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent" />
+</LinearLayout
 ```
-5. Modify your activity so that the class extends CordovaActivity (found at app/main/java/org/apache/....CordovaActivity.java)
+1. Modify your activity so that the class extends CordovaActivity (found at app/main/java/org/apache/....CordovaActivity.java)
 ```
-   public class TestActivity extends CordovaActivity {
+public class TestActivity extends CordovaActivity {
     
-   }
+}
 ```
    
-6. Override onCreate, makeWebView and createViews to use your defined layout
+1. Override onCreate, makeWebView and createViews to use your defined layout
 ```
-   @Override
-   public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_test); //this is the layout file for your activity
-        super.init();
-        loadUrl(launchUrl);
-    }
+@Override
+public void onCreate(Bundle savedInstanceState) {
+     super.onCreate(savedInstanceState);
+     setContentView(R.layout.activity_test); //this is the layout file for your activity
+     super.init();
+     loadUrl(launchUrl);
+}
 
-    @Override
-    protected CordovaWebView makeWebView() {
-        SystemWebView appView = (SystemWebView) findViewById(R.id.cordovaWebView);  //this is the id for the SystemWebView in step 4
-        return new CordovaWebViewImpl(new SystemWebViewEngine(appView));
-    }
+@Override
+protected CordovaWebView makeWebView() {
+    SystemWebView appView = (SystemWebView) findViewById(R.id.cordovaWebView);  //this is the id for the SystemWebView in step 4
+    return new CordovaWebViewImpl(new SystemWebViewEngine(appView));
+}
 
-    @Override
-    protected void createViews() {
-        // leave empty so the layout is used
-    }
+@Override
+protected void createViews() {
+    // leave empty so the layout is used
+}
 ```
 
-7. Copy the application's HTML and JavaScript files to the Android
+1. Copy the application's HTML and JavaScript files to the Android
    project's `/assets/www` directory.
 
-8. Copy the `config.xml` file from `/res/xml` to the
+1. Copy the `config.xml` file from `/res/xml` to the
    project's `/res/xml` directory.

--- a/www/docs/en/dev/guide/platforms/android/webview.md
+++ b/www/docs/en/dev/guide/platforms/android/webview.md
@@ -41,10 +41,9 @@ legacy `CordovaActivity` component that pre-dates the 1.9 release.
 1. Follow the instructions here to build your first cordova app [CreateYourFirstApp](https://cordova.apache.org/docs/en/8.x/guide/cli/index.html)
 
 1. Copy Cordova framework files
-```
-platforms/android/CordovaLib/src/.* to <AndroidAppRoot>/app/main/java
-platforms/android/src/** to <AndroidAppRoot>/app/main/java
-```
+
+* `platforms/android/CordovaLib/src/.*` to `<AndroidAppRoot>/app/main/java/`
+* `platforms/android/src/*` to `<AndroidAppRoot>/app/main/java/`
 
 1. Modify the layout file of the activity that shall host the Cordova view e.g.
 ```
@@ -58,14 +57,14 @@ platforms/android/src/** to <AndroidAppRoot>/app/main/java
                 android:layout_height="match_parent" />
 </LinearLayout
 ```
-1. Modify your activity so that the class extends CordovaActivity (found at app/main/java/org/apache/....CordovaActivity.java)
+1. Modify your activity so that the class extends CordovaActivity (found at app/main/java/org/apache/cordova/CordovaActivity.java)
 ```
 public class TestActivity extends CordovaActivity {
     
 }
 ```
    
-1. Override onCreate, makeWebView and createViews to use your defined layout
+1. Override `onCreate`, `makeWebView` and `createViews` to use your defined layout
 ```
 @Override
 public void onCreate(Bundle savedInstanceState) {

--- a/www/docs/en/dev/guide/platforms/android/webview.md
+++ b/www/docs/en/dev/guide/platforms/android/webview.md
@@ -33,61 +33,203 @@ of embedding a WebView.  Starting with Cordova 1.9, the Android
 platform relies on a `CordovaWebView` component, which builds on a
 legacy `CordovaActivity` component that pre-dates the 1.9 release.
 
-1. To follow these instructions, make sure you have the latest Cordova
-   distribution. Download it from
-   [cordova.apache.org](https://cordova.apache.org) and unzip its
-   Android package.
+1. Create a new or open an exisiting native application.
 
-1. Follow [these instructions](https://cordova.apache.org/docs/en/latest/guide/cli/index.html) to build your first Cordova app
+2. Add the Cordova-Android framework dependency to your app module's build configuration.
 
-1. Copy Cordova framework files
+    If your build configuration uses Groovy DSL, update `app/build.gradle` with the following:
 
-* `platforms/android/CordovaLib/src/.*` to `<AndroidAppRoot>/app/main/java/`
-* `platforms/android/src/*` to `<AndroidAppRoot>/app/main/java/`
+    ```groovy
+    dependencies {
+        implementation 'org.apache.cordova:framework:14.0.1'
+    }
+    ```
 
-1. Modify the layout file of the activity that shall host the Cordova view e.g.
-```
-<LinearLayout android:layout_width="fill_parent"
-              android:layout_height="fill_parent"
-              android:orientation="vertical"
-              xmlns:android="http://schemas.android.com/apk/res/android">
-    <org.apache.cordova.engine.SystemWebView
-                android:id="@+id/cordovaWebView"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent" />
-</LinearLayout
-```
-1. Modify your activity so that the class extends `CordovaActivity` (found at `app/main/java/org/apache/cordova/CordovaActivity.java`)
-```
-public class TestActivity extends CordovaActivity {
-    
+    If your build configuration uses Kotlin DSL, update `app/build.gradle.kts` with the following:
+
+    ```kotlin
+    dependencies {
+        implementation("org.apache.cordova:framework:14.0.1")
+    }
+    ```
+
+    After making any changes to your build configuration file, make sure to "**Sync Project with Gradle Files**" so it will checkout the framework.
+
+    **Note:** Your build configuration may already includes a `dependencies` block, so simply add the `implementation` line within the existing block.
+
+    **Note:** You can find a list of available versions of released Cordova-Android framework on [Sonatype Maven Central Repository](https://central.sonatype.com/artifact/org.apache.cordova/framework/versions) or any other mirror of the Maven Central Repository.
+
+ 3. Modify the layout file of the activity that shall host the Cordova view e.g.
+
+    ```xml
+    <?xml version="1.0" encoding="utf-8"?>
+    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        android:orientation="vertical"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <org.apache.cordova.engine.SystemWebView
+            android:id="@+id/cordovaWebView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+    </LinearLayout>
+    ```
+
+ 4. Modify your activity to extend `CordovaActivity` and override the `onCreate`, `makeWebView` and `createViews` to use your defined layout:
+
+    **Kotlin Example:**
+
+    ```kotlin
+    package org.apache.cordova.testapp
+
+    import android.os.Bundle
+    import android.view.View
+    import androidx.activity.enableEdgeToEdge
+    import org.apache.cordova.CordovaActivity
+    import org.apache.cordova.CordovaWebView
+    import org.apache.cordova.CordovaWebViewImpl
+    import org.apache.cordova.engine.SystemWebView
+    import org.apache.cordova.engine.SystemWebViewEngine
+
+    class TestActivity : CordovaActivity() {
+        override fun onCreate(savedInstanceState: Bundle?) {
+            super.onCreate(savedInstanceState)
+            enableEdgeToEdge()
+            setContentView(R.layout.activity_test)
+        }
+
+        override fun makeWebView(): CordovaWebView {
+            val appView = findViewById<View>(R.id.cordovaWebView) as SystemWebView
+            return CordovaWebViewImpl(SystemWebViewEngine(appView))
+        }
+
+        override fun createViews() {
+            // leave empty so the layout is used
+        }
+    }
+    ```
+
+    **Java Example:**
+
+    ```java
+    package org.apache.cordova.testapp;
+
+    import android.os.Bundle;
+    import android.view.View;
+    import androidx.activity.enableEdgeToEdge;
+    import org.apache.cordova.CordovaActivity;
+    import org.apache.cordova.CordovaWebView;
+    import org.apache.cordova.CordovaWebViewImpl;
+    import org.apache.cordova.engine.SystemWebView;
+    import org.apache.cordova.engine.SystemWebViewEngine;
+
+    public class TestActivity extends CordovaActivity {
+        @Override
+        public void onCreate(Bundle savedInstanceState) {
+            super.onCreate(savedInstanceState);
+            setContentView(R.layout.activity_test); // layout file for your activity
+            super.init();
+            loadUrl(launchUrl);
+        }
+
+        @Override
+        protected CordovaWebView makeWebView() {
+            SystemWebView appView = (SystemWebView) findViewById(R.id.cordovaWebView);  // id for the SystemWebView in previous step
+            return new CordovaWebViewImpl(new SystemWebViewEngine(appView));
+        }
+
+        @Override
+        protected void createViews() {
+            // leave empty so the layout is used
+        }
+    }
+    ```
+
+3. Setup up the theming for your activity to comply with Cordova.
+
+    As Cordova-Android framework displays a SplashScreen, we will need to update the native app's `themes.xml` to include a SplashScreen theme and `postSplashScreenTheme` for our Cordova activity.
+
+    **Note:** Since `CordovaActivity` extends `AppCompatActivity`, the `postSplashScreenTheme` that the activity will transition to must inherit from a `Theme.AppCompat.*` style. For example, you can use `Theme.AppCompat.DayNight.NoActionBar` or a custom theme based on it.
+
+    Below is an example and the theme names can be changed to your perfered naming.
+
+    ```xml
+    <?xml version="1.0" encoding="utf-8"?>
+    <resources xmlns:tools="http://schemas.android.com/tools">
+        <!-- The theme that will be used for the activity that displays Cordova -->
+        <style name="Theme.MyCordovaAppSplashScreen" parent="Theme.SplashScreen.IconBackground">
+            <item name="windowSplashScreenBackground">@color/black</item>
+            <item name="windowSplashScreenAnimatedIcon">@drawable/ic_launcher_foreground</item>
+            <item name="windowSplashScreenAnimationDuration">200</item>
+            <item name="postSplashScreenTheme">@style/Theme.MyCordovaApp</item>
+        </style>
+
+        <!-- The Post SplashScreen Theme -->
+        <style name="Theme.MyCordovaApp" parent="Theme.AppCompat.DayNight.NoActionBar" />
+    </resources>
+    ```
+    Next, update the `android:theme` attribute for your Cordova `<activity>` to `@style/Theme.MyCordovaAppSplashScreen` .
+
+4. Copy your application's web assets (HTML, CSS, JavaScript) to the Android project's `<app-root-directory>/app/src/main/assets/www/` directory.
+
+5. Copy your `config.xml` file to your Android project's `<app-root-directory>/app/src/main/res/xml/` directory.
+
+## Bonus: Jetpack Compose
+
+If your native Android application uses Jetpack Compose instead of XML layouts, you can still integrate the Cordova WebView by writing your Activity like this:
+
+```kotlin
+package org.apache.cordova.testapp
+
+import android.os.Bundle
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.viewinterop.AndroidView
+import org.apache.cordova.testapp.ui.theme.TestAppTheme
+import org.apache.cordova.CordovaActivity
+import org.apache.cordova.CordovaWebView
+import org.apache.cordova.CordovaWebViewImpl
+import org.apache.cordova.engine.SystemWebView
+import org.apache.cordova.engine.SystemWebViewEngine
+
+class TestActivity : CordovaActivity() {
+    private lateinit var cordovaWebView: CordovaWebView
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+
+        // Set up the Cordova WebView manually
+        val systemWebView = SystemWebView(this)
+        cordovaWebView = CordovaWebViewImpl(SystemWebViewEngine(systemWebView))
+
+        setContent {
+            // Make sure to change "TestAppTheme" with your app's custom Jetpack Compose theme function.
+            TestAppTheme {
+                CordovaWebViewContainer(systemWebView = systemWebView)
+            }
+        }
+
+        loadUrl(launchUrl)
+    }
+
+    override fun makeWebView(): CordovaWebView {
+        return cordovaWebView
+    }
+
+    override fun createViews() {
+        // leave empty so the layout is used
+    }
+}
+
+@Composable
+fun CordovaWebViewContainer(systemWebView: SystemWebView) {
+    AndroidView(
+        factory = { systemWebView },
+        modifier = Modifier.fillMaxSize()
+    )
 }
 ```
-   
-1. Override `onCreate`, `makeWebView` and `createViews` to use your defined layout
-```
-@Override
-public void onCreate(Bundle savedInstanceState) {
-     super.onCreate(savedInstanceState);
-     setContentView(R.layout.activity_test); // layout file for your activity
-     super.init();
-     loadUrl(launchUrl);
-}
-
-@Override
-protected CordovaWebView makeWebView() {
-    SystemWebView appView = (SystemWebView) findViewById(R.id.cordovaWebView);  // id for the SystemWebView in previous step
-    return new CordovaWebViewImpl(new SystemWebViewEngine(appView));
-}
-
-@Override
-protected void createViews() {
-    // leave empty so the layout is used
-}
-```
-
-1. Copy the application's HTML and JavaScript files to the Android
-   project's `/assets/www` directory.
-
-1. Copy the `config.xml` file from `/res/xml` to the
-   project's `/res/xml` directory.

--- a/www/docs/en/dev/guide/platforms/android/webview.md
+++ b/www/docs/en/dev/guide/platforms/android/webview.md
@@ -76,7 +76,7 @@ public void onCreate(Bundle savedInstanceState) {
 
 @Override
 protected CordovaWebView makeWebView() {
-    SystemWebView appView = (SystemWebView) findViewById(R.id.cordovaWebView);  //this is the id for the SystemWebView in step 4
+    SystemWebView appView = (SystemWebView) findViewById(R.id.cordovaWebView);  // id for the SystemWebView in previous step
     return new CordovaWebViewImpl(new SystemWebViewEngine(appView));
 }
 

--- a/www/docs/en/dev/guide/platforms/android/webview.md
+++ b/www/docs/en/dev/guide/platforms/android/webview.md
@@ -38,7 +38,7 @@ legacy `CordovaActivity` component that pre-dates the 1.9 release.
    [cordova.apache.org](https://cordova.apache.org) and unzip its
    Android package.
 
-1. Follow the instructions here to build your first cordova app [CreateYourFirstApp](https://cordova.apache.org/docs/en/8.x/guide/cli/index.html)
+1. Follow [these instructions](https://cordova.apache.org/docs/en/latest/guide/cli/index.html) to build your first Cordova app
 
 1. Copy Cordova framework files
 

--- a/www/docs/en/dev/guide/platforms/android/webview.md
+++ b/www/docs/en/dev/guide/platforms/android/webview.md
@@ -38,97 +38,53 @@ legacy `CordovaActivity` component that pre-dates the 1.9 release.
    [cordova.apache.org](https://cordova.apache.org) and unzip its
    Android package.
 
-1. Navigate to the Android package's `/framework` directory and run
-   `ant jar`. It creates the Cordova `.jar` file, formed as
-   `/framework/cordova-x.x.x.jar`.
+2. Follow the instructions here to build your first cordova app [CreateYourFirstApp](https://cordova.apache.org/docs/en/8.x/guide/cli/index.html)
 
-1. Copy the `.jar` file into the Android project's `/libs` directory.
+3. Copy Cordova framework files **from platforms/android/CordovaLib/src/** to your android application directory at **/app/main/java**. Also copy additional Cordova framework files **from platforms/android/src/** to your android application directory at **/app/main/java**.
 
-1. Add the following to the application's `/res/xml/main.xml` file,
-   with the `layout_height`, `layout_width` and `id` modified to suit
-   the application:
-
-        <org.apache.cordova.CordovaWebView
-            android:id="@+id/tutorialView"
+4. Modify the layout file of the activity that shall host the Cordova view e.g.
+```
+ <LinearLayout android:layout_width="fill_parent"
+              android:layout_height="fill_parent"
+              android:orientation="vertical"
+              xmlns:android="http://schemas.android.com/apk/res/android">
+   <org.apache.cordova.engine.SystemWebView
+            android:id="@+id/cordovaWebView"
             android:layout_width="match_parent"
             android:layout_height="match_parent" />
+   </LinearLayout
+```
+5. Modify your activity so that the class extends CordovaActivity (found at app/main/java/org/apache/....CordovaActivity.java)
+```
+   public class TestActivity extends CordovaActivity {
+    
+   }
+```
+   
+6. Override onCreate, makeWebView and createViews to use your defined layout
+```
+   @Override
+   public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_test); //this is the layout file for your activity
+        super.init();
+        loadUrl(launchUrl);
+    }
 
-1. Modify the activity so that it implements the `CordovaInterface`.
-   It should implement the included methods.  You may wish to copy
-   them from `/framework/src/org/apache/cordova/CordovaActivity.java`,
-   or else implement them on your own.  The following code fragment
-   shows a basic application that relies on the interface. Note how
-   the referenced view id matches the `id` attribute specified in the
-   XML fragment shown above:
+    @Override
+    protected CordovaWebView makeWebView() {
+        SystemWebView appView = (SystemWebView) findViewById(R.id.cordovaWebView);  //this is the id for the SystemWebView in step 4
+        return new CordovaWebViewImpl(new SystemWebViewEngine(appView));
+    }
 
-        public class CordovaViewTestActivity extends Activity implements CordovaInterface {
-            CordovaWebView cwv;
-            /* Called when the activity is first created. */
-            @Override
-            public void onCreate(Bundle savedInstanceState) {
-                super.onCreate(savedInstanceState);
-                setContentView(R.layout.main);
-                cwv = (CordovaWebView) findViewById(R.id.tutorialView);
-                Config.init(this);
-                cwv.loadUrl(Config.getStartUrl());
-            }
+    @Override
+    protected void createViews() {
+        // leave empty so the layout is used
+    }
+```
 
-1. If the application needs to use the camera, implement the
-   following:
-
-        @Override
-        public void setActivityResultCallback(CordovaPlugin plugin) {
-            this.activityResultCallback = plugin;
-        }
-        /**
-         * Launch an activity for which you would like a result when it finished. When this activity exits,
-         * your onActivityResult() method is called.
-         *
-         * @param command           The command object
-         * @param intent            The intent to start
-         * @param requestCode       The request code that is passed to callback to identify the activity
-         */
-        public void startActivityForResult(CordovaPlugin command, Intent intent, int requestCode) {
-            this.activityResultCallback = command;
-            this.activityResultKeepRunning = this.keepRunning;
-
-            // If multitasking turned on, then disable it for activities that return results
-            if (command != null) {
-                this.keepRunning = false;
-            }
-
-            // Start activity
-            super.startActivityForResult(intent, requestCode);
-        }
-
-        @Override
-        /**
-         * Called when an activity you launched exits, giving you the requestCode you started it with,
-         * the resultCode it returned, and any additional data from it.
-         *
-         * @param requestCode       The request code originally supplied to startActivityForResult(),
-         *                          allowing you to identify who this result came from.
-         * @param resultCode        The integer result code returned by the child activity through its setResult().
-         * @param data              An Intent, which can return result data to the caller (various data can be attached to Intent "extras").
-         */
-        protected void onActivityResult(int requestCode, int resultCode, Intent intent) {
-            super.onActivityResult(requestCode, resultCode, intent);
-            CordovaPlugin callback = this.activityResultCallback;
-            if (callback != null) {
-                callback.onActivityResult(requestCode, resultCode, intent);
-            }
-        }
-
-1. Finally, remember to add the thread pool, otherwise plugins
-   have no threads on which to run:
-
-        @Override
-        public ExecutorService getThreadPool() {
-            return threadPool;
-        }
-
-1. Copy the application's HTML and JavaScript files to the Android
+7. Copy the application's HTML and JavaScript files to the Android
    project's `/assets/www` directory.
 
-1. Copy the `config.xml` file from `/framework/res/xml` to the
+8. Copy the `config.xml` file from `/res/xml` to the
    project's `/res/xml` directory.


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

https://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Closes #904
Resolves #884
Resolves #875

While Cordova primarily focuses on apps created through the CLI rather than platform-centric workflows, I wanted to modernize this guide to serve as a more up-to-date starting point for those looking to embed Cordova manually.

### Description
<!-- Describe your changes in detail -->

1. Removed the distribution download step. Not needed in this guide.
2. Removed the follow first Cordova app step. Not related to embedding.
3. Removed the "Copy Cordova framework files" step. Not needed in this guide.
4. Removed `ant` related content. Outdated content
5. Added the step in how to how Cordova-Android framework with `build.gradle`
    - Covers Groovy DSL & Kotlin DSL syntax
6. Added Kotlin & Java example for `TestActivity`
7. Talked about theming requirement. 
    - E.g. Since SplashScreen API was baked in the `CordovaActivity`, the Activity should point to the SplashScreen theme
    - Also `postSplashScreenTheme` should inherit from a `Theme.AppCompat.*` style/
8. Added Jetpack Compose Example (Kotlin only) 

### Testing
<!-- Please describe in detail how you tested your changes. -->

Tried to build an app following the steps.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
