### PR TITLE
doc(third-party-tools): remove instabug

### DIFF
--- a/www/_data/tools.yml
+++ b/www/_data/tools.yml
@@ -65,15 +65,6 @@
         Framework agnostic, use it with plain Javascript,
         jQuery, Angular, React or Knockout.
 
--   name: Instabug
-    image: instabug.png
-    url: https://instabug.com/platforms/cordova
-    description: >
-        Instabug provides Cordova developers with a bug reporting and in-app
-        feedback solution. With a one minute install guide,
-         it enables users to seamlessly report bugs while automatically attaching
-        details such as network logs, repro-steps, etc.
-
 -   name: Quasar
     image: quasar-logo.svg
     url: https://quasar.dev


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

https://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

n/a

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Remove third-party tools that appears to no longer support Cordova

### Description
<!-- Describe your changes in detail -->

Instabug has been rebranded to Luciq. 

It appears the Luciq website does reference any support or integration guides for Cordova.

Only [one page in the docs](https://docs.luciq.ai/reference/extended-bug-report-mode) says `Cordova` but the link takes you to a "Page Not Found".

Additionally, the [instabug-cordova ](https://www.npmjs.com/package/instabug-cordova) npm package also mentioned the following:

> Support for Cordova will officially end on June 30, 2025.

### Testing
<!-- Please describe in detail how you tested your changes. -->

n/a

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
