### PR TITLE
Add "jekyll" label to .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -29,6 +29,7 @@ github:
     - javascript
     - nodejs
     - hacktoberfest
+    - jekyll
 
   features:
     wiki: false


### PR DESCRIPTION

### Platforms affected
N/A

### Motivation and Context
Adding the **_jekyll_** label so that its easier to find ASF projects using [Jekyll](https://jekyllrb.com/)

(I've created an [Infra PR](https://github.com/apache/infrastructure-website/pull/255) to add [this GitHub Query](https://github.com/search?q=topic%3Ajekyll+org%3Aapache&type=Repositories) to the [Infra Project Website page](https://infra.apache.org/project-site.html#sitemanagement))

### Description
Add "jekyll" label to .asf.yaml

### Testing
N/A

### Checklist

- [ N/A] I've run the tests to see all new and existing tests pass
- [ N/A] I added automated test coverage as appropriate for this change
- [ N/A] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ N/A] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [X] I've updated the documentation if necessary
