### PR TITLE
ios(guide): add instructions for building for App Store Upload

### DIFF
--- a/www/docs/en/latest/guide/platforms/ios/index.md
+++ b/www/docs/en/latest/guide/platforms/ios/index.md
@@ -286,6 +286,20 @@ For manual signing, specifying the provisioning profiles by UUID:
 
 There is also support to mix and match command line arguments and parameters in `build.json`. Values from the command line arguments will get precedence.
 
+### Building for App Store Upload
+
+When creating an `.ipa` intended for App Store upload, make sure the build targets a **device** build.
+
+Use:
+
+```zsh
+cordova build ios --release --device
+```
+
+Without `--device`, Cordova may build for the simulator depending on context, which does not follow the same archive/export flow used for App Store distribution.
+
+If `packageType` is already set in your `build.json` release configuration (for example, `"packageType": "app-store"`), you do not need to pass `--packageType` on the command line unless you want to override it.
+
 ## Xcode Build Flags
 
 If you have a custom situation where you need to pass additional build flags to Xcode you would use one or more `--buildFlag` options to pass these flags to `xcodebuild`. If you use an `xcodebuild` built-in flag, it will show a warning.


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

https://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

- iOS

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

- Add section `Building for App Store Upload`, showing an example how to create an IPA for the App Store upload. 
- Note, that `--device` has to be added to `cordova build ios --release` to create an IPA.
- Note, that packageType can be set by build.json and must not be set extra
- Generated-By: GPT-5.3-Codex

### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
