### PR TITLE
chore: ignore asdf `.tool-version` and Visual Studio Code workspace files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,8 @@ ruby_modules
 Gemfile.lock
 
 .*.swp
+
+# asdf tool-version pinning for e.g. ruby
+.tool-versions
+# Workspace files for VS Code
+*.code-workspace


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

https://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

- All

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

- .tool-versions can be created for asdf to select for e.g. a specific ruby version
-  *.code-workspace files can be created by Visual Studio Code, when the project is used in a workspace

### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
