### PR TITLE
fix: remove redundant `http:` from GitHub issues link for `2026-06-07-inappbrowser-release-6.0.1.md`

### DIFF
--- a/www/_posts/2026-06-07-inappbrowser-release-6.0.1.md
+++ b/www/_posts/2026-06-07-inappbrowser-release-6.0.1.md
@@ -41,7 +41,7 @@ References:
 
 https://www.cve.org/CVERecord?id=CVE-2026-47430
 
-Please report any issues you find on [GitHub](http://https://github.com/apache/cordova-plugin-inappbrowser/issues)!
+Please report any issues you find on [GitHub](https://github.com/apache/cordova-plugin-inappbrowser/issues)!
 
 <!--more-->
 # Changes include:


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

https://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

- The link is not functional on cordova.apache.org. Blog post: https://cordova.apache.org/announcements/2026/06/07/inappbrowser-release-6.0.1.html

### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
